### PR TITLE
fix(scripts): postpack-restore cleans bundled node_modules + move to postpack lifecycle

### DIFF
--- a/packages/codex-mcp/package.json
+++ b/packages/codex-mcp/package.json
@@ -21,7 +21,7 @@
     "test": "vitest run",
     "lint": "biome check src/ && tsc --noEmit",
     "prepack": "node ../../scripts/prepack-bundle.mjs shared",
-    "postpublish": "node ../../scripts/postpack-restore.mjs"
+    "postpack": "node ../../scripts/postpack-restore.mjs shared"
   },
   "keywords": [
     "mcp",

--- a/packages/gemini-mcp/package.json
+++ b/packages/gemini-mcp/package.json
@@ -21,7 +21,7 @@
     "test": "vitest run",
     "lint": "biome check src/ && tsc --noEmit",
     "prepack": "node ../../scripts/prepack-bundle.mjs shared",
-    "postpublish": "node ../../scripts/postpack-restore.mjs"
+    "postpack": "node ../../scripts/postpack-restore.mjs shared"
   },
   "keywords": [
     "mcp",

--- a/packages/llm-mcp/package.json
+++ b/packages/llm-mcp/package.json
@@ -16,7 +16,7 @@
     "test": "vitest run",
     "lint": "biome check src/ && tsc --noEmit",
     "prepack": "node ../../scripts/prepack-bundle.mjs shared gemini-mcp codex-mcp ollama-mcp",
-    "postpublish": "node ../../scripts/postpack-restore.mjs"
+    "postpack": "node ../../scripts/postpack-restore.mjs shared gemini-mcp codex-mcp ollama-mcp"
   },
   "keywords": [
     "mcp",

--- a/packages/ollama-mcp/package.json
+++ b/packages/ollama-mcp/package.json
@@ -21,7 +21,7 @@
     "test": "vitest run",
     "lint": "biome check src/ && tsc --noEmit",
     "prepack": "node ../../scripts/prepack-bundle.mjs shared",
-    "postpublish": "node ../../scripts/postpack-restore.mjs"
+    "postpack": "node ../../scripts/postpack-restore.mjs shared"
   },
   "keywords": [
     "mcp",

--- a/scripts/postpack-restore.mjs
+++ b/scripts/postpack-restore.mjs
@@ -1,17 +1,50 @@
 #!/usr/bin/env node
 /**
- * Restores package.json from package.json.bak after `npm pack` or
- * `npm publish` completes. Companion to prepack-bundle.mjs — see
- * that file and ADR-052 for the full rationale.
+ * Restores package.json from package.json.bak AND removes bundled
+ * node_modules/<dep>/ directories that prepack-bundle.mjs created.
+ * Companion to prepack-bundle.mjs — see that file and ADR-052 for the
+ * full rationale on bundling.
  *
- * Runs via the `postpack` npm script from each MCP package dir.
- * Safe to run when no backup exists (no-op).
+ * Wired to the `postpack` lifecycle (NOT `postpublish`) so it fires
+ * after `npm pack` AND after `npm publish` regardless of whether the
+ * publish itself succeeded — defends against EOTP / network failures
+ * that previously left the workspace in a half-bundled state where
+ * the bundled `node_modules/@ask-llm/shared/` outranked the workspace
+ * symlink in TS module resolution and silently broke local builds.
+ *
+ * Usage (mirrors prepack-bundle.mjs):
+ *   node ../../scripts/postpack-restore.mjs shared
+ *   node ../../scripts/postpack-restore.mjs shared gemini-mcp codex-mcp ollama-mcp
+ *
+ * Safe to run when no backup exists (no-op for the package.json half)
+ * and when node_modules entries don't exist (no-op for the cleanup half).
+ * Workspace-symlink entries are deliberately NOT removed — only real
+ * directories created by the prepack copy are cleaned up.
  */
 import fs from "node:fs";
+import path from "node:path";
 
+// 1. Restore package.json from .bak (the existing behavior).
 if (fs.existsSync("package.json.bak")) {
   fs.renameSync("package.json.bak", "package.json");
   console.log("[postpack-restore] restored package.json from package.json.bak");
 } else {
   console.log("[postpack-restore] no package.json.bak to restore");
+}
+
+// 2. Remove bundled node_modules/<dep>/ directories created by prepack-bundle.
+//    Only delete real directories, never symlinks (which are the workspace
+//    links yarn install created and we want to preserve).
+const depsArg = process.argv.slice(2);
+for (const dep of depsArg) {
+  const destName = dep === "shared" ? "@ask-llm/shared" : `ask-${dep}`;
+  const dest = path.join("node_modules", destName);
+  if (!fs.existsSync(dest)) continue;
+  const stat = fs.lstatSync(dest);
+  if (stat.isSymbolicLink()) {
+    // Workspace symlink — leave it alone.
+    continue;
+  }
+  fs.rmSync(dest, { recursive: true, force: true });
+  console.log(`[postpack-restore] removed bundled ${dest}`);
 }

--- a/scripts/postpack-restore.mjs
+++ b/scripts/postpack-restore.mjs
@@ -39,12 +39,32 @@ const depsArg = process.argv.slice(2);
 for (const dep of depsArg) {
   const destName = dep === "shared" ? "@ask-llm/shared" : `ask-${dep}`;
   const dest = path.join("node_modules", destName);
-  if (!fs.existsSync(dest)) continue;
-  const stat = fs.lstatSync(dest);
+  // Single lstatSync (which never follows symlinks) inside a try/catch
+  // handles both not-exists and broken-symlink cases cleanly. The earlier
+  // existsSync+lstatSync two-step had a subtle gap: existsSync follows
+  // symlinks, so a broken symlink at dest returned false and bypassed the
+  // isSymbolicLink guard entirely.
+  let stat;
+  try {
+    stat = fs.lstatSync(dest);
+  } catch (err) {
+    if (err.code === "ENOENT") continue;
+    throw err;
+  }
   if (stat.isSymbolicLink()) {
     // Workspace symlink — leave it alone.
     continue;
   }
   fs.rmSync(dest, { recursive: true, force: true });
   console.log(`[postpack-restore] removed bundled ${dest}`);
+
+  // After removing a scoped package (e.g. @ask-llm/shared), the scope
+  // directory itself is left empty. Tidy it so we leave zero artefacts.
+  // The scopeDir !== "node_modules" guard prevents removing the whole
+  // node_modules dir if it ever happens to be empty after our removal.
+  const scopeDir = path.dirname(dest);
+  if (scopeDir !== "node_modules" && fs.readdirSync(scopeDir).length === 0) {
+    fs.rmdirSync(scopeDir);
+    console.log(`[postpack-restore] removed empty scope ${scopeDir}`);
+  }
 }


### PR DESCRIPTION
## Summary
Two related fixes for the publish-cycle cruft surfaced during PR #29's EOTP saga (memory note \`project_release_pipeline.md\`):

1. **\`postpack-restore.mjs\` now removes bundled \`node_modules\` entries** created by \`prepack-bundle.mjs\`. Previously it only restored \`package.json\` from \`.bak\`, leaving \`node_modules/@ask-llm/shared/\` (and similar) as real directories that outranked the workspace symlink in TS module resolution.
2. **Lifecycle hook moved from \`postpublish\` → \`postpack\`** so cleanup fires after \`npm pack\` AND after \`npm publish\` regardless of whether the publish step succeeded.

## Why

\`postpublish\` only fires on **successful** publish, so an EOTP / network / 2FA-timeout failure would leave the workspace half-bundled with no cleanup. After my own EOTP failure during PR #29, local \`yarn build\` silently used the stale bundled \`dist\` instead of the live workspace source, producing \"type doesn't have property X\" errors that didn't match what was in \`packages/shared/dist/\`. Took ~15 minutes to diagnose.

\`postpack\` fires after \`npm pack\` (BOTH on plain pack and on the pack-step of publish), regardless of whether a subsequent publish succeeds. That's the right timing for cleanup.

## Implementation
- \`scripts/postpack-restore.mjs\` now accepts dep args (matching \`prepack-bundle.mjs\` signature) and removes each \`node_modules/<dep>/\` entry IF it's a real directory. Workspace symlinks are left alone via \`fs.lstatSync(...).isSymbolicLink()\` check — so yarn install state is preserved.
- All 4 packages (\`gemini-mcp\`, \`codex-mcp\`, \`ollama-mcp\`, \`llm-mcp\`) updated to use \`postpack\` with matching dep args.

## Verification

End-to-end \`npm pack\` test in \`packages/gemini-mcp\`:
- **Before pack**: no \`node_modules/@ask-llm/shared\` locally (yarn 4 hoists workspace symlinks to repo root)
- **After pack**: same state — \`postpack-restore\` cleaned up the prepack-created bundled copy
- **\`package.json\`** unchanged (still has \`workspace:*\`, not the bundled \`*\` rewrite)

Test plan:
- [x] \`yarn test\` — 444 passing across 6 packages (no test changes; this is script-only)
- [x] \`yarn lint\` — clean
- [x] \`yarn build\` — clean
- [x] Live \`npm pack\` cycle verifies the postpack hook fires and cleans up
- [x] No version bump needed (script-only change; \`postpack-restore.mjs\` isn't shipped in any package's tarball — it lives in repo root \`scripts/\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)