### PR TITLE
experiment(codex-pair-poc): scaffold POC plugin for codex-as-background-validator

### DIFF
--- a/experiments/codex-pair-poc/.claude-plugin/plugin.json
+++ b/experiments/codex-pair-poc/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "codex-pair-poc",
+  "version": "0.0.1",
+  "description": "POC: Codex as a continuous background validator that watches every file edit and emits load-bearing concerns to Claude on the next turn. Built to A/B-test the pair-programmer hypothesis vs. Claude alone.",
+  "author": {
+    "name": "Anton Lykhoyda",
+    "url": "https://github.com/Lykhoyda"
+  },
+  "license": "MIT",
+  "keywords": ["codex", "pair-programming", "background-validation", "experiment", "claude-code"]
+}

--- a/experiments/codex-pair-poc/README.md
+++ b/experiments/codex-pair-poc/README.md
@@ -1,0 +1,88 @@
+# codex-pair-poc
+
+**Status:** Experimental proof-of-concept. Not for production use.
+
+A Claude Code plugin that runs Codex as a continuous background validator: after every file edit Claude makes, Codex inspects the result and (if it has a load-bearing concern) emits feedback that Claude reads on the next turn. Designed to A/B-test the hypothesis that having Codex as an "extra pair of eyes during writing" produces measurably better code than Claude alone.
+
+See [`memory/project_codex_pair_programmer_idea.md`](../../) for the full design rationale and why this is structurally different from the existing post-write `/codex-review` and `/codex-verify` skills.
+
+## How it works
+
+```
+Claude edits file X
+        │
+        ▼
+  Claude Code fires PostToolUse hook
+        │
+        ▼
+  hooks/codex-pair-watch.mjs reads stdin (the hook payload)
+        │
+        ▼
+  Reads file X's current content
+        │
+        ▼
+  Sends to `codex exec --json -m gpt-5.5` with a "PASS unless load-bearing" prompt
+        │
+        ├─ Codex says PASS → silent, log to .codex-pair-log.jsonl
+        │
+        └─ Codex raises concern → stderr (Claude reads on next turn) + log
+```
+
+Key design points:
+
+- **High-precision, low-recall by intent.** The prompt enforces "default silent." Most edits produce `PASS`. Codex only speaks when there's a real concern.
+- **Codex stays as engineer, not gemini.** See the memory note on provider choice — fast-mediocre validators get tuned out after false alarms; slow-smart is correct for this role.
+- **Hard timeout (60s default).** Stuck codex calls don't strand Claude. Configurable via `CODEX_PAIR_TIMEOUT_MS`.
+- **Coarse skip filters.** node_modules, dist, lockfiles, binary assets skipped. Files >20 KB skipped to bound POC cost.
+- **Full audit log.** Every fire (including PASS, ERROR, SKIPPED) is appended to `.codex-pair-log.jsonl` for post-hoc benchmark analysis.
+
+## Install
+
+This plugin is not published to npm. Install locally:
+
+1. **From the ask-llm repo root**, the plugin lives at `experiments/codex-pair-poc/`.
+2. Register it in your Claude Code plugin marketplace, OR copy it into `~/.claude/plugins/` manually, OR add the path to your Claude Code `settings.json` `pluginPaths` field. (Refer to Claude Code's plugin loading docs for the exact mechanism on your install — this varies by Claude Code version.)
+3. Verify Codex CLI is installed and authenticated (`codex --version` should print 0.128.0+; auth via `codex auth login` or `OPENAI_API_KEY`).
+
+Once installed, every `Edit` / `Write` / `MultiEdit` tool call in any Claude Code session fires the hook. You can verify by editing any file and looking for `.codex-pair-log.jsonl` to appear in your project root.
+
+## Benchmark methodology
+
+See [`benchmarks/task-todo-app.md`](benchmarks/task-todo-app.md) for the canonical A/B test:
+
+1. **Run A** (Claude only): plugin disabled, give Claude the todo-app task, save outputs.
+2. **Run B** (Claude + Codex): plugin enabled, give Claude the SAME task in a fresh directory, save outputs.
+3. **Compare** correctness, concurrency safety, type safety, error handling, test coverage on a 1–5 rubric. Read the `.codex-pair-log.jsonl` from Run B to see what Codex flagged.
+4. **Repeat** 2–3 times for run-to-run variance control.
+
+A clear ≥1-of-5 quality delta in Run B's favor, with Codex's concerns visibly addressed in the code, is the green light to invest further.
+
+## Toggling the plugin without uninstalling
+
+For A/B benchmarks where you want fast toggling:
+
+- **Disable**: rename `.claude-plugin/plugin.json` to `.claude-plugin/plugin.json.disabled` (Claude Code won't load the plugin without the manifest)
+- **Re-enable**: rename back
+
+Or temporarily neutralize the hook by replacing `hooks/hooks.json` with `{ "hooks": {} }`.
+
+## Cost ceiling
+
+The POC has no automatic budget limit. Each PostToolUse fires one codex call (~5–30s, ~1–3 cents per fire on gpt-5.5 depending on file size). A 50-edit session = ~50 codex calls = ~$0.50–$1.50 + ~5–25 wall-clock minutes of cumulative codex latency added to Claude's session.
+
+For longer sessions or budget concerns, lower `CODEX_PAIR_TIMEOUT_MS` to fail-fast on slow calls, or temporarily disable the plugin entirely (see above).
+
+## Known limitations / explicit non-goals for the POC
+
+1. **No edit-debounce.** Every Edit fires Codex; rapid multi-edit chains (e.g., during a refactor) produce N codex calls instead of one. A v2 could debounce — `setTimeout` after the last edit, only fire once per quiet period.
+2. **No diff-mode.** Codex sees the full post-edit file, not the diff. For large files, this wastes tokens on context. v2 could send `tool_input.old_string` / `new_string` as a diff.
+3. **No state carry-over.** Each codex call is stateless — codex doesn't know what was edited 3 edits ago. Architectural drift across many edits is invisible to it.
+4. **No model fallback.** If gpt-5.5 quota exhausts, codex calls fail and the hook logs an error. No automatic fallback to gpt-5.5-mini (the ask-codex-mcp executor has this; this POC doesn't, to keep the hook simple).
+5. **Single-threaded.** Two parallel Edit tools (unlikely in practice) would queue codex calls serially. Fine for the POC.
+6. **No way for codex to take the keyboard.** This is "background validation," not real pair programming. See the memory note — if the design proves valuable, the next iteration is about *closing the feedback loop more tightly*, not about giving codex write access.
+
+## What to do with the results
+
+- **Strong positive** (≥2-of-5 delta consistently, codex's concerns are real and acted on): graduate the POC into a real plugin in `packages/`, integrate with the ask-llm ecosystem, ship via changesets.
+- **Mixed** (occasional wins, lots of noise): tune the prompt — tighten the "load-bearing" definition. Consider sample-based or significance-gated firing.
+- **Negative** (no delta, or codex's concerns ignored): the pair-programmer-as-background-validator hypothesis didn't pan out. Document why in an ADR-style note, keep the POC frozen for reference, don't ship.

--- a/experiments/codex-pair-poc/benchmarks/task-todo-app.md
+++ b/experiments/codex-pair-poc/benchmarks/task-todo-app.md
@@ -1,0 +1,71 @@
+# Benchmark task: small todo app
+
+This is the canonical task for A/B-testing the codex-pair-poc plugin. It's chosen to be:
+
+- **Multi-file** — exercises the hook many times (server, routes, types, storage, tests)
+- **Bug-prone** — has natural footguns (async file I/O race conditions, type widening, error swallowing) that a good validator should catch
+- **Bounded** — completes in a single Claude Code session, comparable across runs
+- **Type-checkable** — outputs can be objectively validated (does `tsc` pass? does the server start?)
+
+## The prompt to give Claude
+
+Paste this verbatim into a fresh Claude Code session at the start of each run:
+
+> Build a small TypeScript Express server with the following endpoints:
+>
+> - `GET /todos` — returns all todos as JSON
+> - `POST /todos` — accepts `{ "text": string }`, creates a new todo with a UUID, returns 201 with the created todo
+> - `PATCH /todos/:id` — accepts `{ "done": boolean }`, updates the todo, returns the updated todo or 404
+> - `DELETE /todos/:id` — deletes the todo, returns 204 or 404
+>
+> Persist todos to a file `todos.json` in the project root. The server must handle concurrent requests safely (no race conditions on the file). Use Express 5, TypeScript strict mode, and Zod for input validation.
+>
+> Include a small set of vitest tests that exercise the happy path and at least one error case per endpoint.
+>
+> Run `tsc --noEmit` and `vitest run` at the end to verify everything passes.
+
+## What to record per run
+
+Create a directory `runs/<timestamp>/` and capture:
+
+1. **All files Claude created** — copy the working directory after Claude says it's done
+2. **`tsc --noEmit` exit code** — does it type-check?
+3. **`vitest run` exit code** — do the tests pass?
+4. **Wall-clock time** — from prompt submission to "I'm done" message
+5. **`.codex-pair-log.jsonl`** (only present in run-B with plugin enabled) — copy the entire log
+
+## Subjective code-quality rubric
+
+Rate each run 1–5 on:
+
+- **Correctness** — does each endpoint do what was specified? (1 = mostly broken, 5 = all four endpoints work end-to-end)
+- **Concurrency safety** — is the file write actually safe under concurrent requests? Or is it a lurking race?
+- **Type safety** — `unknown`/`any` cast count; `as` cast count; explicit `unknown` handling
+- **Error handling** — are errors returned with appropriate status codes, or do they bubble as 500s?
+- **Test coverage** — does the happy path AND error case test exist per endpoint?
+
+Aggregate the two runs' scores and compute the delta.
+
+## Recommended run protocol
+
+1. **Run A (Claude only).** Disable the plugin (remove or rename `experiments/codex-pair-poc/.claude-plugin/`). Start a fresh Claude Code session in a clean directory. Paste the prompt. Let Claude work end-to-end. Save outputs to `runs/<timestamp>-A/`.
+
+2. **Run B (Claude + Codex).** Re-enable the plugin. Start a fresh Claude Code session in a different clean directory. Paste the SAME prompt verbatim. Let Claude work end-to-end. Save outputs to `runs/<timestamp>-B/`.
+
+3. **Compare.** Score both runs with the rubric. Read `runs/<timestamp>-B/.codex-pair-log.jsonl` to see what Codex flagged. Was any concern actually load-bearing? Did Claude act on it?
+
+4. **Repeat 2–3 times** to control for Claude's run-to-run variance (different completion strategies are normal even on identical prompts).
+
+## What "success" looks like
+
+The hypothesis is that the plugin produces measurably better code on bug-prone tasks. Concretely:
+
+- ✅ Run-B catches the concurrent-file-write race that Run-A misses (most likely concrete win)
+- ✅ Run-B has fewer type-system escape hatches (`as`, `any`, unsafe casts)
+- ✅ `.codex-pair-log.jsonl` shows codex stayed silent on `pass`-quality edits and only spoke up on real issues — i.e., a low ratio of `verdict: concern` to `verdict: pass`
+- ❌ FAIL outcomes to watch for:
+  - Codex emits "concern" on every edit (signal-to-noise too low — prompt needs tightening)
+  - Codex emits "concern" but Claude ignores it (feedback channel isn't actually closing the loop)
+  - Run-B is meaningfully slower with no quality improvement (latency tax not justified)
+
+A 2-run A/B with sub-1-of-5 quality delta is inconclusive — schedule more runs or move on. A clear ≥1-of-5 delta with codex's concerns visibly addressed in B's code is a green light to invest further.

--- a/experiments/codex-pair-poc/hooks/codex-pair-watch.mjs
+++ b/experiments/codex-pair-poc/hooks/codex-pair-watch.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+// codex-pair-watch — PostToolUse hook that runs Codex as a background validator
+// after each file edit. Designed for high-precision, low-recall: Codex stays
+// silent on most edits (returning PASS) and only emits feedback when it has a
+// load-bearing concern. Non-PASS responses go to stderr (Claude sees on next
+// turn) and every call is logged to .codex-pair-log.jsonl for benchmark
+// analysis afterward.
+//
+// See ../README.md for benchmark methodology (Claude alone vs Claude + Codex).
+
+import { spawn } from "node:child_process";
+import { readFile, appendFile, mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+// Hard cap on Codex call duration. Default 60s — gpt-5.5 on a few hundred lines
+// of code finishes in 10–40s typically; the cap exists so a stuck Codex doesn't
+// strand Claude indefinitely. Override via env for benchmark experiments.
+const CODEX_TIMEOUT_MS = Number(process.env.CODEX_PAIR_TIMEOUT_MS ?? 60_000);
+
+// Tool names we care about. Edit/Write/MultiEdit are the file-mutating tools;
+// everything else (Read, Bash, Glob, etc.) we silently pass through.
+const WATCHED_TOOLS = new Set(["Edit", "Write", "MultiEdit"]);
+
+// Log file lives in the user's cwd at hook-invocation time, which is normally
+// the project root. Benchmark scripts read this to count fires + extract
+// codex's verdicts.
+const LOG_PATH = resolve(process.cwd(), ".codex-pair-log.jsonl");
+
+// The validator prompt. Constructed once per call; the file content gets
+// interpolated. Discipline is enforced by the prompt — Codex must default to
+// silence (PASS) and only speak up if a concern is genuinely load-bearing.
+function buildPrompt({ filePath, fileContent, toolName }) {
+  return `You are a senior software engineer watching another AI agent (Claude) edit a file in real time. Your job is to provide a sanity check — but ONLY if you have a LOAD-BEARING concern. Most edits are fine; you should default to silence.
+
+## What "load-bearing" means
+
+A load-bearing concern is one of:
+- The code is wrong (will crash, will produce wrong output, will silently corrupt state).
+- The code contradicts something elsewhere in the same file or duplicates logic that already exists.
+- The code introduces a security issue (injection, secret leak, unsanitized input flowing to a sink).
+- The code has a type error or a clear logic bug that tests would catch.
+- The code is misleading — the function name, comment, or signature suggests one behavior but the body does another.
+
+## What is NOT load-bearing (stay silent)
+
+- Style preferences (single vs double quotes, where to put braces, etc.)
+- "Could be cleaner" or "this would be more idiomatic" suggestions.
+- Optimizations that don't matter at this scope.
+- Naming nitpicks unless the name is actively misleading.
+- Missing error handling for cases that genuinely can't happen.
+
+## How to respond
+
+If you have NO load-bearing concern: reply with EXACTLY the word \`PASS\` and nothing else.
+
+If you DO have a load-bearing concern, reply in this format and ONLY this format:
+
+\`\`\`
+CONCERN: <one-line summary, no preamble>
+
+<one-paragraph explanation citing the specific lines / symbols at issue>
+
+SUGGESTED FIX: <one sentence>
+\`\`\`
+
+Do not say "this is mostly good but...". Do not preface with "I notice...". If it's worth raising, raise it directly; if not, reply PASS.
+
+## The edit
+
+The agent (${toolName}) just modified \`${filePath}\`. Here is the file's current state:
+
+\`\`\`
+${fileContent}
+\`\`\``;
+}
+
+// Spawn codex with a strict argv shape. Mirrors the args used by ask-codex-mcp
+// (--skip-git-repo-check, --ephemeral, --ignore-user-config, --ignore-rules,
+// --sandbox workspace-write, --json) for deterministic behavior regardless of
+// the user's local codex config.
+function runCodex(prompt) {
+  return new Promise((resolveCall) => {
+    const args = [
+      "exec",
+      "--skip-git-repo-check",
+      "--ephemeral",
+      "--ignore-user-config",
+      "--ignore-rules",
+      "--sandbox",
+      "workspace-write",
+      "--json",
+      "-m",
+      "gpt-5.5",
+      prompt,
+    ];
+    const child = spawn("codex", args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try {
+        child.kill("SIGTERM");
+      } catch {}
+      resolveCall({ ok: false, reason: "timeout", durationMs: CODEX_TIMEOUT_MS });
+    }, CODEX_TIMEOUT_MS);
+
+    const startedAt = Date.now();
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolveCall({ ok: false, reason: `spawn-error: ${err.message}`, durationMs: Date.now() - startedAt });
+    });
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (code !== 0) {
+        resolveCall({ ok: false, reason: `exit-${code}`, stderr: stderr.slice(0, 500), durationMs: Date.now() - startedAt });
+        return;
+      }
+      // Parse codex's JSONL for the final agent_message
+      let message = "";
+      for (const line of stdout.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const parsed = JSON.parse(trimmed);
+          if (parsed.type === "item.completed" && parsed.item?.type === "agent_message") {
+            message = parsed.item.text ?? "";
+          }
+        } catch {
+          // ignore non-JSON lines
+        }
+      }
+      resolveCall({ ok: true, message: message.trim(), durationMs: Date.now() - startedAt });
+    });
+  });
+}
+
+// Read stdin completely (Claude Code passes the hook payload via stdin)
+async function readStdin() {
+  return new Promise((resolveRead) => {
+    let data = "";
+    process.stdin.on("data", (chunk) => {
+      data += chunk.toString();
+    });
+    process.stdin.on("end", () => resolveRead(data));
+    process.stdin.on("error", () => resolveRead(""));
+  });
+}
+
+async function appendLog(entry) {
+  try {
+    await mkdir(dirname(LOG_PATH), { recursive: true });
+    await appendFile(LOG_PATH, JSON.stringify(entry) + "\n");
+  } catch {
+    // Logging failures should never break Claude's flow
+  }
+}
+
+async function main() {
+  // Parse the hook payload from stdin. Bail silently on malformed input.
+  const raw = await readStdin();
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    process.exit(0);
+  }
+
+  const toolName = payload?.tool_name;
+  if (!WATCHED_TOOLS.has(toolName)) {
+    process.exit(0);
+  }
+
+  const filePath = payload?.tool_input?.file_path;
+  if (!filePath || typeof filePath !== "string") {
+    process.exit(0);
+  }
+
+  // Read the file's current state (after the edit). If the tool just deleted
+  // or moved the file, this read fails — log and pass.
+  let fileContent;
+  try {
+    fileContent = await readFile(filePath, "utf8");
+  } catch (err) {
+    await appendLog({
+      timestamp: new Date().toISOString(),
+      tool: toolName,
+      file: filePath,
+      verdict: "skipped",
+      reason: `unreadable: ${err.message}`,
+    });
+    process.exit(0);
+  }
+
+  // Skip files that aren't worth validating (assets, lockfiles, build output).
+  // The benchmark explicitly tests on source code, so this is a coarse filter.
+  const lower = filePath.toLowerCase();
+  const skipPatterns = ["/node_modules/", "/dist/", "/.git/", "yarn.lock", "package-lock.json", ".png", ".jpg", ".jpeg", ".svg", ".ico"];
+  if (skipPatterns.some((p) => lower.includes(p))) {
+    process.exit(0);
+  }
+
+  // Hard limit on file size — gpt-5.5 reasoning on a 50KB file is wasteful for
+  // this POC. Files larger than this are still logged, just skipped for codex.
+  const MAX_FILE_BYTES = 20_000;
+  if (fileContent.length > MAX_FILE_BYTES) {
+    await appendLog({
+      timestamp: new Date().toISOString(),
+      tool: toolName,
+      file: filePath,
+      verdict: "skipped",
+      reason: `file too large: ${fileContent.length} bytes`,
+    });
+    process.exit(0);
+  }
+
+  const prompt = buildPrompt({ filePath, fileContent, toolName });
+  const result = await runCodex(prompt);
+
+  if (!result.ok) {
+    await appendLog({
+      timestamp: new Date().toISOString(),
+      tool: toolName,
+      file: filePath,
+      verdict: "error",
+      reason: result.reason,
+      stderr: result.stderr,
+      durationMs: result.durationMs,
+    });
+    process.exit(0);
+  }
+
+  const isPass = result.message.trim().toUpperCase() === "PASS" || result.message.trim().startsWith("PASS\n");
+
+  await appendLog({
+    timestamp: new Date().toISOString(),
+    tool: toolName,
+    file: filePath,
+    verdict: isPass ? "pass" : "concern",
+    durationMs: result.durationMs,
+    message: result.message.slice(0, 4000), // cap log entry size
+  });
+
+  if (!isPass && result.message) {
+    // Emit to stderr — Claude Code surfaces this back to Claude as part of the
+    // PostToolUse hook output, so Claude reads Codex's concern on the next turn
+    // and can choose whether to act on it.
+    process.stderr.write(`[codex-pair] ${filePath}\n${result.message}\n`);
+  }
+
+  process.exit(0);
+}
+
+main().catch(async (err) => {
+  await appendLog({
+    timestamp: new Date().toISOString(),
+    verdict: "error",
+    reason: `unhandled: ${err?.message ?? String(err)}`,
+  });
+  process.exit(0);
+});

--- a/experiments/codex-pair-poc/hooks/hooks.json
+++ b/experiments/codex-pair-poc/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/codex-pair-watch.mjs"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Experimental Claude Code plugin to test the hypothesis from the [`project_codex_pair_programmer_idea`](https://github.com/Lykhoyda/ask-llm/blob/experiment/codex-pair-poc/experiments/codex-pair-poc/README.md) memory: does having Codex as a continuous background validator during code writing produce measurably better code than Claude alone?

Lives in `experiments/codex-pair-poc/` — explicitly NOT in `packages/`, signaling POC status. No release-pipeline impact (zero changesets in this PR; workflow on main will be a clean no-op).

## What's in here

| File | Role |
|---|---|
| `hooks/codex-pair-watch.mjs` (273 LOC) | The PostToolUse hook. Reads edited file, sends to `codex exec --json -m gpt-5.5` with a strict "PASS unless load-bearing" prompt. Emits non-PASS to stderr (Claude reads on next turn). Logs every call to `.codex-pair-log.jsonl`. 60s timeout. Skip filters for node_modules, dist, lockfiles, binaries, files >20KB. |
| `hooks/hooks.json` | Hook config matching `Edit\|Write\|MultiEdit` tools |
| `.claude-plugin/plugin.json` | Plugin manifest |
| `benchmarks/task-todo-app.md` | Canonical A/B test task (Express+TS todo app with file persistence) + 1-5 rubric |
| `README.md` | Install + benchmark methodology |

## Design decisions worth knowing

- **Codex, not Gemini**, per the memory's precision-over-throughput analysis. The continuous-validation design is high-precision-low-recall by intent — speed-optimizing with a fast mediocre model would produce false alarms that get tuned out. Slow-smart is correct for this role.
- **Stderr feedback channel**, not blocking. The hook never halts Claude. Codex's concerns appear in Claude's next system reminder; Claude chooses whether to act on them.
- **Hard timeout** (60s default). Prevents a stuck codex from stranding Claude. Matches the pattern in shared `commandExecutor.ts` from ADR-074.
- **Default-silent prompt discipline**, with multiple explicit "NOT load-bearing" examples + a literal "reply EXACTLY the word PASS" instruction. Same pattern as ADR-073's codex-verifier discipline. This is the most fragile part of the POC — if the benchmark shows codex chiming in too often, the prompt is the first thing to tune.

## Smoke test (no codex calls burned)

```
✓ Malformed JSON          → exit 0 silently, no log
✓ Read tool (not watched) → exit 0 silently, no log
✓ Edit on missing file    → exit 0, log with verdict:"skipped", reason: ENOENT
```

The hook never breaks Claude's flow on any error path.

## How to actually run the benchmark

1. Install plugin (see README)
2. **Run A**: disable plugin (rename `.claude-plugin/plugin.json`), fresh Claude session, paste the todo-app task verbatim, save outputs to `runs/<ts>-A/`
3. **Run B**: re-enable, fresh session in a NEW dir, paste SAME task, save outputs to `runs/<ts>-B/`
4. Score both with the 5-axis rubric, read Run B's `.codex-pair-log.jsonl` to see what codex flagged
5. Repeat 2-3× for variance control

## Outcomes that would change next steps

- **Strong positive** (≥2-of-5 delta consistently, codex's concerns acted on): graduate to `packages/`, integrate with ask-llm ecosystem, changesets-driven release
- **Mixed** (occasional wins, noise): tune the prompt's "load-bearing" definition, consider sample-based firing
- **Negative** (no delta or concerns ignored): document why in ADR, freeze POC, don't ship

## Merge notes

This PR is purely additive in `experiments/`. No shipping code touched. Workflow on main will be no-op (zero pending changesets). Safe to merge whenever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)