### PR TITLE
feat(plugin): always surface codex-pair verdict; auto-manage plugin version via changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,7 +10,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@ask-llm/plugin"],
+  "ignore": [],
   "privatePackages": {
     "version": true,
     "tag": false

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,14 +17,22 @@
         "path": "packages/claude-plugin"
       },
       "description": "AI-to-AI collaboration — review code, brainstorm ideas, and debate plans across Gemini, Codex, and Ollama providers",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "author": {
         "name": "Anton Lykhoyda"
       },
       "homepage": "https://lykhoyda.github.io/ask-llm/plugin/overview",
       "repository": "https://github.com/Lykhoyda/ask-llm",
       "license": "MIT",
-      "keywords": ["ai", "gemini", "codex", "ollama", "mcp", "code-review", "brainstorm"],
+      "keywords": [
+        "ai",
+        "gemini",
+        "codex",
+        "ollama",
+        "mcp",
+        "code-review",
+        "brainstorm"
+      ],
       "category": "external-integrations"
     }
   ]

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "docs:preview": "yarn workspace docs run preview",
     "benchmark": "yarn build && npx tsx scripts/benchmark-overhead.ts",
     "changeset": "changeset",
-    "changeset:version": "changeset version",
+    "changeset:version": "changeset version && node scripts/sync-plugin-manifests.mjs",
     "changeset:status": "changeset status --verbose",
     "changeset:publish": "yarn build && changeset publish",
     "prepare": "husky"

--- a/packages/claude-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ask-llm",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "AI-to-AI collaboration — review code, brainstorm ideas, and debate plans across Gemini, Codex, and Ollama",
   "author": {
     "name": "Anton Lykhoyda",
@@ -8,5 +8,12 @@
   },
   "repository": "https://github.com/Lykhoyda/ask-llm",
   "license": "MIT",
-  "keywords": ["gemini", "codex", "ollama", "code-review", "ai-collaboration", "brainstorm"]
+  "keywords": [
+    "gemini",
+    "codex",
+    "ollama",
+    "code-review",
+    "ai-collaboration",
+    "brainstorm"
+  ]
 }

--- a/packages/claude-plugin/CHANGELOG.md
+++ b/packages/claude-plugin/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @ask-llm/plugin
+
+## 0.5.0
+
+### Minor Changes
+
+- codex-pair hook now emits a `systemMessage` notice to Claude Code on every run — `OK` when no concerns are found, `WARN` with HIGH/MED bodies when concerns surface, and `SKIP`/`ERROR` when the hook attempts work but can't complete (unreadable file, oversize file, codex timeout). Previously the hook was silent on the happy path, so review activity was only visible in `.codex-pair-log.jsonl`. The threshold-in-hook design from ADR-077 is preserved: LOW concern bodies still go to the log only, with a count surfaced in the verdict header.

--- a/packages/claude-plugin/package.json
+++ b/packages/claude-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ask-llm/plugin",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/claude-plugin/scripts/codex-pair-watch.mjs
+++ b/packages/claude-plugin/scripts/codex-pair-watch.mjs
@@ -55,6 +55,36 @@ async function readStdin() {
   });
 }
 
+// Surface a one-line (or multi-line) notice to the Claude Code UI by emitting
+// hook JSON to stdout. Claude Code parses `systemMessage` and renders it as an
+// inline transcript message. We await the write-callback so the bytes are
+// flushed to the parent before process.exit terminates us.
+function emitSystemMessage(text) {
+  return new Promise((resolveWrite) => {
+    const payload = JSON.stringify({ continue: true, systemMessage: text });
+    process.stdout.write(`${payload}\n`, () => resolveWrite());
+  });
+}
+
+function formatDuration(durationMs) {
+  return `${(durationMs / 1000).toFixed(1)}s`;
+}
+
+function buildVerdictMessage({ filePath, concerns, fellBack, durationMs }) {
+  const total = concerns.high.length + concerns.med.length + concerns.low.length;
+  const flag = fellBack ? " [fallback model]" : "";
+  if (total === 0) {
+    return `codex-pair OK${flag}: ${filePath} — no concerns (${formatDuration(durationMs)})`;
+  }
+  const counts = `${concerns.high.length}H / ${concerns.med.length}M / ${concerns.low.length}L`;
+  const header = `codex-pair WARN${flag}: ${filePath} — ${counts} (${formatDuration(durationMs)})`;
+  const details = [
+    ...concerns.high.map((c) => `[HIGH]\n${c}`),
+    ...concerns.med.map((c) => `[MED]\n${c}`),
+  ];
+  return details.length > 0 ? `${header}\n\n${details.join("\n\n")}` : header;
+}
+
 async function findMarkerUp(startDir) {
   const home = homedir();
   let current = resolve(startDir);
@@ -311,6 +341,7 @@ async function main() {
       verdict: "skipped",
       reason: `unreadable: ${err.message}`,
     });
+    await emitSystemMessage(`codex-pair SKIP: ${filePath} — unreadable (${err.message})`);
     process.exit(0);
   }
 
@@ -323,6 +354,9 @@ async function main() {
       verdict: "skipped",
       reason: `file too large: ${fileBytes} bytes (cap: ${MAX_FILE_BYTES})`,
     });
+    await emitSystemMessage(
+      `codex-pair SKIP: ${filePath} — file too large (${fileBytes} bytes, cap ${MAX_FILE_BYTES})`,
+    );
     process.exit(0);
   }
 
@@ -343,19 +377,25 @@ async function main() {
     response = result.response;
     fellBack = result.fellBack;
   } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    const durationMs = Date.now() - startedAt;
     await appendLog(markerDir, {
       timestamp: new Date().toISOString(),
       tool: toolName,
       file: filePath,
       verdict: "error",
-      reason: err instanceof Error ? err.message : String(err),
-      durationMs: Date.now() - startedAt,
+      reason,
+      durationMs,
     });
+    await emitSystemMessage(
+      `codex-pair ERROR: ${filePath} — review failed: ${reason} (${formatDuration(durationMs)})`,
+    );
     process.exit(0);
   }
 
   const concerns = parseConcerns(response);
   const total = concerns.high.length + concerns.med.length + concerns.low.length;
+  const durationMs = Date.now() - startedAt;
 
   await appendLog(markerDir, {
     timestamp: new Date().toISOString(),
@@ -368,7 +408,7 @@ async function main() {
       med: concerns.med.length,
       low: concerns.low.length,
     },
-    durationMs: Date.now() - startedAt,
+    durationMs,
     concerns: {
       high: concerns.high.map((c) => c.slice(0, 800)),
       med: concerns.med.map((c) => c.slice(0, 800)),
@@ -376,13 +416,7 @@ async function main() {
     },
   });
 
-  const surfaced = [
-    ...concerns.high.map((c) => `[HIGH] ${c}`),
-    ...concerns.med.map((c) => `[MED] ${c}`),
-  ];
-  if (surfaced.length > 0) {
-    process.stderr.write(`[codex-pair] ${filePath}\n${surfaced.join("\n\n")}\n`);
-  }
+  await emitSystemMessage(buildVerdictMessage({ filePath, concerns, fellBack, durationMs }));
 
   process.exit(0);
 }

--- a/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
+++ b/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
@@ -95,14 +95,31 @@ describe("scripts/codex-pair-watch.mjs — structural invariants (ADR-077)", () 
     expect(script).toMatch(/parseConcerns/);
   });
 
-  it("surfaces HIGH+MED to stderr, suppresses LOW (threshold in hook, not prompt)", () => {
-    // The threshold-in-hook design is load-bearing per ADR-077
-    expect(script).toMatch(/concerns\.high.*HIGH/s);
-    expect(script).toMatch(/concerns\.med.*MED/s);
-    // LOW must NOT appear in the stderr surface array
-    const surfaceBlock = script.match(/const surfaced[\s\S]*?process\.stderr\.write/);
-    expect(surfaceBlock).toBeTruthy();
-    expect(surfaceBlock?.[0]).not.toMatch(/concerns\.low/);
+  it("surfaces HIGH+MED via systemMessage stdout, suppresses LOW (threshold in hook, not prompt)", () => {
+    // The threshold-in-hook design is load-bearing per ADR-077. The surface
+    // moved from stderr to a JSON systemMessage on stdout so Claude Code can
+    // render it as an inline UI notice instead of a stderr warning.
+    expect(script).toMatch(/buildVerdictMessage/);
+    expect(script).toMatch(/emitSystemMessage/);
+    expect(script).toMatch(/systemMessage/);
+
+    const verdictBlock = script.match(/function buildVerdictMessage[\s\S]*?^}/m);
+    expect(verdictBlock).toBeTruthy();
+    expect(verdictBlock?.[0]).toMatch(/concerns\.high.*HIGH/s);
+    expect(verdictBlock?.[0]).toMatch(/concerns\.med.*MED/s);
+    // LOW details must NOT be expanded into the surfaced body. A count
+    // mention (e.g. "0L") is fine — it nudges the user to check the log —
+    // but `concerns.low.map(...)` would surface the actual concern text.
+    expect(verdictBlock?.[0]).not.toMatch(/concerns\.low\.map/);
+  });
+
+  it("emits hook JSON to stdout (continue:true + systemMessage) instead of stderr", () => {
+    // Previously the hook wrote raw lines to process.stderr.write. The new
+    // contract is structured stdout JSON parsed by Claude Code.
+    expect(script).toMatch(/process\.stdout\.write/);
+    expect(script).toMatch(/JSON\.stringify\(\s*\{\s*continue:\s*true/);
+    // No more direct stderr writes for the verdict
+    expect(script).not.toMatch(/process\.stderr\.write/);
   });
 
   it("logs every call to .codex-pair-log.jsonl", () => {
@@ -176,8 +193,9 @@ describe("scripts/codex-pair-watch.mjs — runtime behavior (no codex calls)", (
     });
     const result = runHook(payload, tempDir);
     expect(result.status).toBe(0);
-    // Should produce no stderr (silent passthrough)
+    // Should produce no output at all — silent passthrough on non-watched tools
     expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("");
   });
 
   it("exits 0 silently when marker file is absent (the load-bearing gate)", () => {
@@ -192,6 +210,8 @@ describe("scripts/codex-pair-watch.mjs — runtime behavior (no codex calls)", (
     const result = runHook(payload, tempDir);
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
+    // No stdout either — gating path must not pollute Claude Code with notices
+    expect(result.stdout).toBe("");
     // No log file should be created without the marker — zero-cost no-op
     expect(fs.existsSync(path.join(tempDir, ".codex-pair-log.jsonl"))).toBe(false);
   });
@@ -241,6 +261,13 @@ describe("scripts/codex-pair-watch.mjs — runtime behavior (no codex calls)", (
     const logEntry = JSON.parse(fs.readFileSync(logPath, "utf-8").trim());
     expect(logEntry.verdict).toBe("skipped");
     expect(logEntry.reason).toMatch(/unreadable/i);
+    // New UI contract: hook surfaces a SKIP systemMessage so the user sees in
+    // the Claude Code transcript that the hook attempted to run.
+    expect(result.stdout.trim().length).toBeGreaterThan(0);
+    const hookOutput = JSON.parse(result.stdout.trim());
+    expect(hookOutput.continue).toBe(true);
+    expect(hookOutput.systemMessage).toMatch(/codex-pair SKIP/);
+    expect(hookOutput.systemMessage).toMatch(/unreadable/i);
   });
 
   it("processes a file containing literal triple-backticks without breaking the gate", () => {

--- a/scripts/sync-plugin-manifests.mjs
+++ b/scripts/sync-plugin-manifests.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// Mirror packages/claude-plugin/package.json `version` into the two other
+// manifests that carry the same version field:
+//   - packages/claude-plugin/.claude-plugin/plugin.json (read by Claude Code)
+//   - .claude-plugin/marketplace.json (the marketplace listing)
+//
+// Run automatically after `yarn changeset version` via the `changeset:version`
+// composed script. Keeps the three manifests in lockstep so a contributor can
+// never accidentally ship a version mismatch.
+
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SOURCE = resolve(ROOT, "packages/claude-plugin/package.json");
+const PLUGIN_JSON = resolve(ROOT, "packages/claude-plugin/.claude-plugin/plugin.json");
+const MARKETPLACE_JSON = resolve(ROOT, ".claude-plugin/marketplace.json");
+const PLUGIN_NAME = "ask-llm";
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+async function writeJson(path, data) {
+  await writeFile(path, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+async function syncPluginJson(version) {
+  const pluginJson = await readJson(PLUGIN_JSON);
+  if (pluginJson.version === version) return false;
+  pluginJson.version = version;
+  await writeJson(PLUGIN_JSON, pluginJson);
+  return true;
+}
+
+async function syncMarketplaceJson(version) {
+  const marketplace = await readJson(MARKETPLACE_JSON);
+  const entry = marketplace.plugins?.find((p) => p.name === PLUGIN_NAME);
+  if (!entry) {
+    throw new Error(`marketplace.json: no plugin entry named "${PLUGIN_NAME}"`);
+  }
+  if (entry.version === version) return false;
+  entry.version = version;
+  await writeJson(MARKETPLACE_JSON, marketplace);
+  return true;
+}
+
+async function main() {
+  const source = await readJson(SOURCE);
+  const version = source.version;
+  if (typeof version !== "string" || version.length === 0) {
+    throw new Error(`${SOURCE}: missing "version" field`);
+  }
+
+  const pluginChanged = await syncPluginJson(version);
+  const marketplaceChanged = await syncMarketplaceJson(version);
+
+  if (pluginChanged || marketplaceChanged) {
+    const changed = [
+      pluginChanged ? "plugin.json" : null,
+      marketplaceChanged ? "marketplace.json" : null,
+    ].filter(Boolean);
+    console.log(`sync-plugin-manifests: synced ${version} to ${changed.join(", ")}`);
+  } else {
+    console.log(`sync-plugin-manifests: already at ${version}, no changes`);
+  }
+}
+
+main().catch((err) => {
+  console.error(`sync-plugin-manifests: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **codex-pair hook** now emits a structured `systemMessage` JSON to stdout on every actual run (`OK` / `WARN` / `SKIP` / `ERROR`). Review activity is visible in the main Claude Code transcript instead of only in `.codex-pair-log.jsonl`. The threshold-in-hook design from ADR-077 is preserved — LOW concern bodies stay in the log, with a count surfaced in the verdict header.
- **Silent self-gating exits** (no marker, wrong tool, skip pattern, `CODEX_PAIR_DISABLED=1`) remain truly silent — no stdout/stderr pollution on paths where the hook isn't supposed to act.
- **Versioning workflow**: removes `@ask-llm/plugin` from the changesets `ignore` list and adds `scripts/sync-plugin-manifests.mjs` to mirror the bumped `package.json` version into `plugin.json` and the marketplace.json plugin entry. `yarn changeset:version` now does the full bump end-to-end — no more hand-editing version strings across three manifest files.

## Before / After

**Before**: Hook emitted `stderr` only when HIGH/MED concerns were found. The common `NONE` happy path was silent in the terminal; user had to tail the log file to know the hook ran.

**After**: Every completed run produces an inline notice in the Claude Code UI:
- `codex-pair OK: /path/to/foo.ts — no concerns (3.2s)`
- `codex-pair WARN: /path/to/foo.ts — 2H / 1M / 0L (8.1s)` (with HIGH/MED bodies)
- `codex-pair SKIP: /path/to/foo.ts — file too large (52341 bytes, cap 20000)`
- `codex-pair ERROR: /path/to/foo.ts — review failed: codex exec timed out after 800s (800.0s)`

## Files

- `packages/claude-plugin/scripts/codex-pair-watch.mjs` — new `emitSystemMessage()` + `buildVerdictMessage()` helpers; surface points wired into all completion paths
- `packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts` — assertions updated for the new contract; new structural test pinning `{ continue: true, systemMessage }` shape
- `.changeset/config.json` — removes plugin from `ignore`
- `scripts/sync-plugin-manifests.mjs` — keeps three manifests in lockstep
- `package.json` — `changeset:version` now composes `changeset version && node scripts/sync-plugin-manifests.mjs`
- Auto-bumped: `packages/claude-plugin/{package,plugin}.json`, `.claude-plugin/marketplace.json`, `packages/claude-plugin/CHANGELOG.md` (all to 0.5.0)

## Test plan

- [x] All 141 plugin tests pass locally
- [x] `yarn workspace @ask-llm/plugin run lint` clean
- [x] Pre-push smoke tests (Ollama / Gemini / Codex) pass
- [x] `yarn changeset:version` ran end-to-end; all three plugin manifests synced to 0.5.0
- [ ] Manual smoke after install: hook fires from marketplace install, OK line shows in transcript on a NONE response

🤖 Generated with [Claude Code](https://claude.com/claude-code)