### PR TITLE
chore(plugin): prep v0.6.0 — codex-pair hook improvements release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,7 +17,7 @@
         "path": "packages/claude-plugin"
       },
       "description": "AI-to-AI collaboration — review code, brainstorm ideas, and debate plans across Gemini, Codex, and Ollama providers",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "author": {
         "name": "Anton Lykhoyda"
       },

--- a/packages/claude-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ask-llm",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "AI-to-AI collaboration — review code, brainstorm ideas, and debate plans across Gemini, Codex, and Ollama",
   "author": {
     "name": "Anton Lykhoyda",

--- a/packages/claude-plugin/CHANGELOG.md
+++ b/packages/claude-plugin/CHANGELOG.md
@@ -1,5 +1,32 @@
 # @ask-llm/plugin
 
+## 0.6.0
+
+### Minor Changes
+
+- Prep v0.6.0 — codex-pair hook improvements release. Umbrella version covering a coordinated batch of hardening, observability, speed, and DX improvements to the codex-pair PostToolUse hook. Planned scope across three phases:
+
+  **Phase 1 — Hardening + observability (bundled PR):**
+
+  - Log rotation: cap `.codex-pair-log.jsonl` at ~2MB / 1000 entries via atomic rewrite (env override `CODEX_PAIR_MAX_LOG_BYTES`).
+  - Structured run-state verdicts: explicit `none | concerns | skipped | error | spawn_failed | timeout | parse_failed | cached`, mirrored into the `systemMessage` prefix.
+  - Expanded skip patterns: add font files, archives, language-specific lockfiles, minified assets.
+  - Default-model drift guard: read model defaults from a shipped `codex-pair-defaults.json` instead of hardcoded literals; structural test links the file to `codex-mcp/constants.ts`.
+
+  **Phase 2 — Foundation + adaptive context (sequential PRs):**
+
+  - Local config in marker frontmatter: YAML frontmatter in `.codex-pair-context.md` for `model`, `fallbackModel`, `timeoutMs`, `maxFileBytes`, `surfaceThreshold`. Hand-rolled zero-dependency parser.
+  - Adaptive context strategy at the file-size boundary: under-cap → full file (unchanged); over-cap + tracked → imports header + `git diff -U20 HEAD` + partial-view instruction; over-cap + untracked → head+tail slice with same instruction. Replaces today's silent skip.
+  - `.codex-pair-ignore`: gitignore-style globs for granular per-file/per-directory opt-out, no `systemMessage` on match (preserves silent-gating UX).
+
+  **Phase 3 — Speed + recovery (parallelizable PRs):**
+
+  - Content-hash response cache: `sha256(model + prompt + fileContent + surfaceThreshold)` keyed cache under `<markerDir>/.codex-pair-cache/`, 10-minute TTL, 50-file LRU eviction.
+  - Log viewer CLI: standalone `scripts/codex-pair-log.mjs` with `--latest`, `--summary`, `--file`, `--since` subcommands. Zero workspace imports.
+  - Failure-class retry with jitter: retry-once on transient network/5xx errors (`ECONNRESET`, `ETIMEDOUT`, `502`/`503`/`504`, etc.). Quota and timeout failures keep their existing terminal paths.
+
+  Constraints preserved through all items: zero workspace imports (marketplace install compatibility), always exit 0 (never break Claude's tool flow), LOW concerns stay in log only by default (ADR-077 threshold-in-hook), synchronous-blocking hook semantics (agent-accountability argument). Reasoning-effort tuning and async/fire-and-forget patterns are explicitly out of scope for this batch.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/claude-plugin/package.json
+++ b/packages/claude-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ask-llm/plugin",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

**Umbrella version bump only — no code changes in this PR.**

Establishes v0.6.0 as the version contract for a coordinated batch of codex-pair hook improvements. Implementation PRs follow under this version without further bumps, per the bump-first release model.

## What changes

- `packages/claude-plugin/package.json`: 0.5.0 → 0.6.0
- `packages/claude-plugin/.claude-plugin/plugin.json`: 0.5.0 → 0.6.0
- `.claude-plugin/marketplace.json` (plugin entry): 0.5.0 → 0.6.0
- `packages/claude-plugin/CHANGELOG.md`: new 0.6.0 entry listing planned three-phase scope

All version-string updates flowed through `yarn changeset:version`, with the `scripts/sync-plugin-manifests.mjs` post-step mirroring `package.json` into the other two manifests automatically.

## Planned scope under v0.6.0 (lands in follow-up PRs)

**Phase 1 — Hardening + observability (bundled PR):**
- Log rotation (`.codex-pair-log.jsonl` capped at ~2MB / 1000 entries)
- Structured run-state verdicts in log + `systemMessage` prefix
- Expanded skip patterns (fonts, archives, lockfiles, minified assets)
- Default-model drift guard via shipped `codex-pair-defaults.json`

**Phase 2 — Foundation + adaptive context (sequential PRs):**
- YAML frontmatter config in `.codex-pair-context.md`
- Adaptive context strategy at file-size boundary (replaces silent skip with diff+context+header for over-cap files)
- `.codex-pair-ignore` gitignore-style globs

**Phase 3 — Speed + recovery (parallelizable PRs):**
- Content-hash response cache
- Log viewer CLI (`scripts/codex-pair-log.mjs`)
- Failure-class retry with jitter

## Constraints preserved through the v0.6.0 batch

- Zero workspace imports (marketplace install compatibility)
- Hook always exits 0 (never breaks Claude's tool flow)
- LOW concerns stay in log only by default (ADR-077 threshold-in-hook)
- Synchronous-blocking semantics (agent-accountability argument)
- Reasoning-effort tuning and async patterns explicitly out of scope

## Test plan

- [x] Plugin test suite passes locally (141 tests)
- [x] Plugin lint clean (Biome + tsc)
- [x] Husky pre-push smoke tests passed (Ollama, Gemini 103/103, Codex 46/46)
- [x] Three plugin manifests verified at 0.6.0; marketplace schema version 1.0.0 preserved
- [x] CHANGELOG.md 0.6.0 entry generated by changesets
- [ ] Marketplace install of v0.6.0 verified once merged (no behavior change expected vs v0.5.0 since this is a bump-only PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)