### PR TITLE
feat(plugin): hardening + observability for codex-pair (v0.6.0 phase 1)

### DIFF
--- a/packages/claude-plugin/codex-pair-defaults.json
+++ b/packages/claude-plugin/codex-pair-defaults.json
@@ -1,0 +1,4 @@
+{
+  "model": "gpt-5.5",
+  "fallbackModel": "gpt-5.5-mini"
+}

--- a/packages/claude-plugin/scripts/codex-pair-watch.mjs
+++ b/packages/claude-plugin/scripts/codex-pair-watch.mjs
@@ -16,31 +16,93 @@
 // invocation is inlined; semantics mirror `codexExecutor.ts` deliberately.
 
 import { spawn } from "node:child_process";
-import { access, appendFile, readFile } from "node:fs/promises";
+import { access, appendFile, readFile, rename, stat, writeFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const DEFAULTS_PATH = join(SCRIPT_DIR, "..", "codex-pair-defaults.json");
+
+// codex-pair-defaults.json carries the canonical default + fallback model
+// names so the hook stays in sync with codex-mcp/src/constants.ts:MODELS
+// without duplicating literals across files. A structural test links the
+// JSON values to constants.ts so drift fails CI. If the file is missing or
+// malformed, fall through to env vars and hardcoded literals.
+let CODEX_PAIR_DEFAULTS = { model: "gpt-5.5", fallbackModel: "gpt-5.5-mini" };
+try {
+  CODEX_PAIR_DEFAULTS = JSON.parse(readFileSync(DEFAULTS_PATH, "utf8"));
+} catch {
+  // intentional fallback to inline defaults
+}
 
 const MARKER_FILE = ".codex-pair-context.md";
 const WATCHED_TOOLS = new Set(["Edit", "Write", "MultiEdit"]);
 const LOG_FILENAME = ".codex-pair-log.jsonl";
-const DEFAULT_MODEL = process.env.ASK_CODEX_MODEL ?? "gpt-5.5";
-const FALLBACK_MODEL = process.env.ASK_CODEX_FALLBACK_MODEL ?? "gpt-5.5-mini";
+const DEFAULT_MODEL = process.env.ASK_CODEX_MODEL ?? CODEX_PAIR_DEFAULTS.model;
+const FALLBACK_MODEL = process.env.ASK_CODEX_FALLBACK_MODEL ?? CODEX_PAIR_DEFAULTS.fallbackModel;
 const DEFAULT_TIMEOUT_MS = Number(process.env.ASK_CODEX_TIMEOUT_MS ?? 800_000);
 const MAX_FILE_BYTES = Number(process.env.CODEX_PAIR_MAX_FILE_BYTES ?? 20_000);
+const MAX_LOG_BYTES = Number(process.env.CODEX_PAIR_MAX_LOG_BYTES ?? 2_000_000);
+const MAX_LOG_ENTRIES = 1000;
 const QUOTA_SIGNALS = ["rate_limit_exceeded", "quota_exceeded", "429", "insufficient_quota"];
 
+// Closed verdict set. Every log entry's `verdict` field is one of these
+// strings. `systemMessage` prefixes mirror via VERDICT_PREFIXES so the user
+// can distinguish at a glance: OK (none), WARN (concerns), SKIP (intentional
+// skip), and the codex-side failure modes TIMEOUT / SPAWN_FAILED /
+// PARSE_FAILED / ERROR. The `cached` verdict is reserved for the Phase 3
+// response cache and unused today.
+const VERDICT_PREFIXES = {
+  none: "OK",
+  concerns: "WARN",
+  skipped: "SKIP",
+  error: "ERROR",
+  spawn_failed: "SPAWN_FAILED",
+  timeout: "TIMEOUT",
+  parse_failed: "PARSE_FAILED",
+  cached: "CACHED",
+};
+
 const SKIP_PATTERNS = [
+  // Path patterns — leading/trailing slash guards against substring matches
   "/node_modules/",
   "/dist/",
   "/.git/",
+  // Lockfiles by exact filename
   "yarn.lock",
   "package-lock.json",
+  "pnpm-lock.yaml",
+  "Cargo.lock",
+  "Gemfile.lock",
+  "composer.lock",
+  "poetry.lock",
+  "go.sum",
+  // Images
   ".png",
   ".jpg",
   ".jpeg",
   ".gif",
   ".svg",
   ".ico",
+  // Fonts
+  ".woff",
+  ".woff2",
+  ".ttf",
+  ".otf",
+  ".eot",
+  // Documents + archives
+  ".pdf",
+  ".zip",
+  ".tar",
+  ".gz",
+  // Snapshots, sourcemaps, minified assets
+  ".snap",
+  ".map",
+  ".min.js",
+  ".min.css",
+  // Generic .lock catch-all (matches anything ending in .lock)
   ".lock",
 ];
 
@@ -74,10 +136,10 @@ function buildVerdictMessage({ filePath, concerns, fellBack, durationMs }) {
   const total = concerns.high.length + concerns.med.length + concerns.low.length;
   const flag = fellBack ? " [fallback model]" : "";
   if (total === 0) {
-    return `codex-pair OK${flag}: ${filePath} — no concerns (${formatDuration(durationMs)})`;
+    return `codex-pair ${VERDICT_PREFIXES.none}${flag}: ${filePath} — no concerns (${formatDuration(durationMs)})`;
   }
   const counts = `${concerns.high.length}H / ${concerns.med.length}M / ${concerns.low.length}L`;
-  const header = `codex-pair WARN${flag}: ${filePath} — ${counts} (${formatDuration(durationMs)})`;
+  const header = `codex-pair ${VERDICT_PREFIXES.concerns}${flag}: ${filePath} — ${counts} (${formatDuration(durationMs)})`;
   const details = [
     ...concerns.high.map((c) => `[HIGH]\n${c}`),
     ...concerns.med.map((c) => `[MED]\n${c}`),
@@ -176,12 +238,34 @@ function parseConcerns(message) {
   return concerns;
 }
 
-async function appendLog(markerDir, entry) {
+// Cap log growth: when the file exceeds MAX_LOG_BYTES, keep only the most
+// recent MAX_LOG_ENTRIES lines via tmp-write + atomic rename. Rotation
+// failures must NEVER break Claude's flow — silent return on any error.
+async function rotateLogIfNeeded(logPath) {
   try {
-    await appendFile(join(markerDir, LOG_FILENAME), JSON.stringify(entry) + "\n");
+    const stats = await stat(logPath);
+    if (stats.size <= MAX_LOG_BYTES) return;
+    const content = await readFile(logPath, "utf8");
+    const lines = content.split("\n").filter((l) => l.length > 0);
+    if (lines.length <= MAX_LOG_ENTRIES) return;
+    const tail = lines.slice(-MAX_LOG_ENTRIES);
+    const tmpPath = `${logPath}.tmp`;
+    await writeFile(tmpPath, `${tail.join("\n")}\n`);
+    await rename(tmpPath, logPath);
+  } catch {
+    // intentional no-op — rotation is best-effort
+  }
+}
+
+async function appendLog(markerDir, entry) {
+  const logPath = join(markerDir, LOG_FILENAME);
+  try {
+    await appendFile(logPath, JSON.stringify(entry) + "\n");
   } catch {
     // logging failures must never break Claude's flow
+    return;
   }
+  await rotateLogIfNeeded(logPath);
 }
 
 // Build codex CLI args. Mirrors packages/codex-mcp/src/utils/codexExecutor.ts
@@ -231,6 +315,21 @@ function isQuotaError(err) {
   return QUOTA_SIGNALS.some((sig) => msg.includes(sig));
 }
 
+// Attach a verdict tag to an Error so the main() catch can classify the
+// failure into the closed VERDICT_PREFIXES set without re-parsing the message.
+function taggedError(message, verdict) {
+  const err = new Error(message);
+  err.verdict = verdict;
+  return err;
+}
+
+function verdictFromError(err) {
+  if (err && typeof err === "object" && typeof err.verdict === "string" && err.verdict in VERDICT_PREFIXES) {
+    return err.verdict;
+  }
+  return "error";
+}
+
 // Single codex invocation. The stdio + stdin-end pattern (and the SIGTERM →
 // SIGKILL escalation) mirrors `packages/shared/src/commandExecutor.ts`.
 // Critically: stdin must be "pipe" (not "ignore") and must be ended explicitly,
@@ -267,14 +366,16 @@ function spawnCodex({ prompt, model, timeoutMs }) {
           child.kill("SIGKILL");
         } catch {}
       }, 5000);
-      rejectCall(new Error(`codex exec timed out after ${Math.round(timeoutMs / 1000)}s`));
+      rejectCall(
+        taggedError(`codex exec timed out after ${Math.round(timeoutMs / 1000)}s`, "timeout"),
+      );
     }, timeoutMs);
 
     child.on("error", (err) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      rejectCall(new Error(`failed to spawn codex: ${err.message}`));
+      rejectCall(taggedError(`failed to spawn codex: ${err.message}`, "spawn_failed"));
     });
 
     child.on("close", (code) => {
@@ -285,10 +386,11 @@ function spawnCodex({ prompt, model, timeoutMs }) {
         try {
           resolveCall(parseCodexJsonl(stdout));
         } catch (err) {
-          rejectCall(err);
+          const msg = err instanceof Error ? err.message : String(err);
+          rejectCall(taggedError(msg, "parse_failed"));
         }
       } else {
-        rejectCall(new Error(stderr.trim() || `codex exit ${code}`));
+        rejectCall(taggedError(stderr.trim() || `codex exit ${code}`, "error"));
       }
     });
   });
@@ -341,7 +443,9 @@ async function main() {
       verdict: "skipped",
       reason: `unreadable: ${err.message}`,
     });
-    await emitSystemMessage(`codex-pair SKIP: ${filePath} — unreadable (${err.message})`);
+    await emitSystemMessage(
+      `codex-pair ${VERDICT_PREFIXES.skipped}: ${filePath} — unreadable (${err.message})`,
+    );
     process.exit(0);
   }
 
@@ -355,7 +459,7 @@ async function main() {
       reason: `file too large: ${fileBytes} bytes (cap: ${MAX_FILE_BYTES})`,
     });
     await emitSystemMessage(
-      `codex-pair SKIP: ${filePath} — file too large (${fileBytes} bytes, cap ${MAX_FILE_BYTES})`,
+      `codex-pair ${VERDICT_PREFIXES.skipped}: ${filePath} — file too large (${fileBytes} bytes, cap ${MAX_FILE_BYTES})`,
     );
     process.exit(0);
   }
@@ -378,17 +482,19 @@ async function main() {
     fellBack = result.fellBack;
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
+    const verdict = verdictFromError(err);
+    const prefix = VERDICT_PREFIXES[verdict] ?? VERDICT_PREFIXES.error;
     const durationMs = Date.now() - startedAt;
     await appendLog(markerDir, {
       timestamp: new Date().toISOString(),
       tool: toolName,
       file: filePath,
-      verdict: "error",
+      verdict,
       reason,
       durationMs,
     });
     await emitSystemMessage(
-      `codex-pair ERROR: ${filePath} — review failed: ${reason} (${formatDuration(durationMs)})`,
+      `codex-pair ${prefix}: ${filePath} — review failed: ${reason} (${formatDuration(durationMs)})`,
     );
     process.exit(0);
   }

--- a/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
+++ b/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
@@ -79,6 +79,131 @@ describe("scripts/codex-pair-watch.mjs — structural invariants (ADR-077)", () 
     expect(script).toMatch(/WATCHED_TOOLS.*Edit.*Write.*MultiEdit/s);
   });
 
+  // Phase 1 item #1: log rotation
+  it("caps log growth via CODEX_PAIR_MAX_LOG_BYTES env var (default 2_000_000) and MAX_LOG_ENTRIES", () => {
+    expect(script).toMatch(/CODEX_PAIR_MAX_LOG_BYTES/);
+    expect(script).toMatch(/2_000_000|2000000/);
+    expect(script).toMatch(/MAX_LOG_ENTRIES/);
+    expect(script).toMatch(/rotateLogIfNeeded/);
+    // atomic rewrite pattern: writeFile to .tmp, then rename
+    expect(script).toMatch(/writeFile.*\.tmp/s);
+    expect(script).toMatch(/rename\(/);
+  });
+
+  it("rotation failures must never throw — wrapped in try/catch with silent no-op", () => {
+    const rotateBlock = script.match(/async function rotateLogIfNeeded[\s\S]*?^}/m);
+    expect(rotateBlock).toBeTruthy();
+    expect(rotateBlock?.[0]).toMatch(/try\s*\{/);
+    expect(rotateBlock?.[0]).toMatch(/catch\s*\{/);
+  });
+
+  // Phase 1 item #2: structured verdicts
+  it("declares the closed verdict set via VERDICT_PREFIXES table", () => {
+    const tableBlock = script.match(/const VERDICT_PREFIXES\s*=\s*\{[\s\S]*?\};/);
+    expect(tableBlock).toBeTruthy();
+    const t = tableBlock?.[0] ?? "";
+    expect(t).toMatch(/none:\s*["']OK["']/);
+    expect(t).toMatch(/concerns:\s*["']WARN["']/);
+    expect(t).toMatch(/skipped:\s*["']SKIP["']/);
+    expect(t).toMatch(/error:\s*["']ERROR["']/);
+    expect(t).toMatch(/spawn_failed:\s*["']SPAWN_FAILED["']/);
+    expect(t).toMatch(/timeout:\s*["']TIMEOUT["']/);
+    expect(t).toMatch(/parse_failed:\s*["']PARSE_FAILED["']/);
+    expect(t).toMatch(/cached:\s*["']CACHED["']/);
+  });
+
+  it("tags spawnCodex rejections with verdict metadata (taggedError)", () => {
+    expect(script).toMatch(/function taggedError/);
+    expect(script).toMatch(/err\.verdict\s*=/);
+    // each rejection inside spawnCodex carries a verdict
+    expect(script).toMatch(/taggedError\([^,]+,\s*["']timeout["']\)/);
+    expect(script).toMatch(/taggedError\([^,]+,\s*["']spawn_failed["']\)/);
+    expect(script).toMatch(/taggedError\([^,]+,\s*["']parse_failed["']\)/);
+    expect(script).toMatch(/taggedError\([^,]+,\s*["']error["']\)/);
+  });
+
+  it("systemMessage prefix is derived from VERDICT_PREFIXES, not hardcoded ERROR", () => {
+    // The main() catch resolves verdict via verdictFromError and looks up prefix.
+    expect(script).toMatch(/verdictFromError/);
+    // buildVerdictMessage routes both OK and WARN through the table
+    const verdictMsgBlock = script.match(/function buildVerdictMessage[\s\S]*?^}/m);
+    expect(verdictMsgBlock).toBeTruthy();
+    expect(verdictMsgBlock?.[0]).toMatch(/VERDICT_PREFIXES\.none/);
+    expect(verdictMsgBlock?.[0]).toMatch(/VERDICT_PREFIXES\.concerns/);
+  });
+
+  // Phase 1 item #3: expanded skip patterns
+  it("skips font files, archives, sourcemaps, snapshots, minified assets, and additional lockfiles", () => {
+    // Fonts
+    expect(script).toMatch(/["']\.woff["']/);
+    expect(script).toMatch(/["']\.woff2["']/);
+    expect(script).toMatch(/["']\.ttf["']/);
+    expect(script).toMatch(/["']\.otf["']/);
+    expect(script).toMatch(/["']\.eot["']/);
+    // Docs + archives
+    expect(script).toMatch(/["']\.pdf["']/);
+    expect(script).toMatch(/["']\.zip["']/);
+    expect(script).toMatch(/["']\.tar["']/);
+    expect(script).toMatch(/["']\.gz["']/);
+    // Snapshots, sourcemaps, minified
+    expect(script).toMatch(/["']\.snap["']/);
+    expect(script).toMatch(/["']\.map["']/);
+    expect(script).toMatch(/["']\.min\.js["']/);
+    expect(script).toMatch(/["']\.min\.css["']/);
+    // Additional lockfiles
+    expect(script).toMatch(/["']pnpm-lock\.yaml["']/);
+    expect(script).toMatch(/["']Cargo\.lock["']/);
+    expect(script).toMatch(/["']Gemfile\.lock["']/);
+    expect(script).toMatch(/["']composer\.lock["']/);
+    expect(script).toMatch(/["']poetry\.lock["']/);
+    expect(script).toMatch(/["']go\.sum["']/);
+  });
+
+  // Phase 1 item #4: default-model drift guard
+  it("loads model defaults from codex-pair-defaults.json with env + literal fallback", () => {
+    expect(script).toMatch(/codex-pair-defaults\.json/);
+    expect(script).toMatch(/CODEX_PAIR_DEFAULTS/);
+    expect(script).toMatch(/readFileSync/);
+    // Path is resolved from import.meta.url, not cwd
+    expect(script).toMatch(/fileURLToPath\(import\.meta\.url\)/);
+    // DEFAULT_MODEL: env > JSON > inline fallback
+    expect(script).toMatch(/DEFAULT_MODEL\s*=\s*process\.env\.ASK_CODEX_MODEL\s*\?\?\s*CODEX_PAIR_DEFAULTS\.model/);
+    expect(script).toMatch(
+      /FALLBACK_MODEL\s*=\s*process\.env\.ASK_CODEX_FALLBACK_MODEL\s*\?\?\s*CODEX_PAIR_DEFAULTS\.fallbackModel/,
+    );
+  });
+
+  it("codex-pair-defaults.json exists and contains model+fallbackModel keys", () => {
+    const defaultsPath = path.join(PLUGIN_ROOT, "codex-pair-defaults.json");
+    expect(fs.existsSync(defaultsPath)).toBe(true);
+    const defaults = JSON.parse(fs.readFileSync(defaultsPath, "utf-8"));
+    expect(typeof defaults.model).toBe("string");
+    expect(typeof defaults.fallbackModel).toBe("string");
+    expect(defaults.model.length).toBeGreaterThan(0);
+    expect(defaults.fallbackModel.length).toBeGreaterThan(0);
+  });
+
+  it("codex-pair-defaults.json values match codex-mcp constants.ts MODELS (drift guard)", () => {
+    // The hook intentionally mirrors codex-mcp's central model constants without
+    // workspace-importing them. This test links the two so a future bump to
+    // codex-mcp's MODELS.DEFAULT without also updating the JSON fails CI.
+    const defaultsPath = path.join(PLUGIN_ROOT, "codex-pair-defaults.json");
+    const defaults = JSON.parse(fs.readFileSync(defaultsPath, "utf-8"));
+
+    const constantsPath = path.join(PLUGIN_ROOT, "..", "codex-mcp", "src", "constants.ts");
+    const constantsSource = fs.readFileSync(constantsPath, "utf-8");
+
+    const defaultMatch = constantsSource.match(/DEFAULT:\s*process\.env\.ASK_CODEX_MODEL\s*\|\|\s*"([^"]+)"/);
+    const fallbackMatch = constantsSource.match(
+      /FALLBACK:\s*process\.env\.ASK_CODEX_FALLBACK_MODEL\s*\|\|\s*"([^"]+)"/,
+    );
+
+    expect(defaultMatch).toBeTruthy();
+    expect(fallbackMatch).toBeTruthy();
+    expect(defaults.model).toBe(defaultMatch?.[1]);
+    expect(defaults.fallbackModel).toBe(fallbackMatch?.[1]);
+  });
+
   it("skips node_modules, dist, .git, lockfiles, and common image assets", () => {
     expect(script).toMatch(/node_modules/);
     expect(script).toMatch(/\/dist\//);
@@ -308,5 +433,77 @@ describe("scripts/codex-pair-watch.mjs — runtime behavior (no codex calls)", (
     // Log should land alongside the marker (at tempDir), not at the subdir
     const expectedLogPath = path.join(tempDir, ".codex-pair-log.jsonl");
     expect(fs.existsSync(expectedLogPath)).toBe(true);
+  });
+
+  // Phase 1 item #1 — runtime: log rotation triggers when the file exceeds the cap.
+  it("rotates the log when size exceeds CODEX_PAIR_MAX_LOG_BYTES", () => {
+    fs.writeFileSync(path.join(tempDir, ".codex-pair-context.md"), "# test context");
+    const logPath = path.join(tempDir, ".codex-pair-log.jsonl");
+    // Seed the log with 1500 fake entries (well above the 1000-entry cap).
+    const fakeEntries: string[] = [];
+    for (let i = 0; i < 1500; i++) {
+      fakeEntries.push(JSON.stringify({ seq: i, verdict: "none", file: `seed-${i}.ts` }));
+    }
+    fs.writeFileSync(logPath, `${fakeEntries.join("\n")}\n`);
+    const sizeBefore = fs.statSync(logPath).size;
+
+    // Trigger ONE more log write via the unreadable-file path — that appendLog
+    // call should observe the over-cap state and rotate to the last 1000 lines.
+    const missingPath = path.join(tempDir, "does-not-exist.ts");
+    const payload = JSON.stringify({
+      tool_name: "Edit",
+      tool_input: { file_path: missingPath },
+    });
+    const result = runHook(payload, tempDir, { CODEX_PAIR_MAX_LOG_BYTES: "10000" });
+    expect(result.status).toBe(0);
+
+    const sizeAfter = fs.statSync(logPath).size;
+    expect(sizeAfter).toBeLessThan(sizeBefore);
+
+    // Verify the rotation kept the tail: highest seq survives, lowest is gone.
+    const linesAfter = fs.readFileSync(logPath, "utf-8").trim().split("\n");
+    // 1500 originals + 1 appended skip entry = 1501; trimmed to 1000.
+    expect(linesAfter.length).toBeLessThanOrEqual(1000);
+    // The MOST RECENT seed entry (1499) should survive
+    const survived = linesAfter.some((line) => {
+      try {
+        const obj = JSON.parse(line);
+        return obj.seq === 1499;
+      } catch {
+        return false;
+      }
+    });
+    expect(survived).toBe(true);
+    // The OLDEST seed entry (0) should have been dropped
+    const oldestSurvived = linesAfter.some((line) => {
+      try {
+        const obj = JSON.parse(line);
+        return obj.seq === 0;
+      } catch {
+        return false;
+      }
+    });
+    expect(oldestSurvived).toBe(false);
+    // No stale .tmp file left behind
+    expect(fs.existsSync(`${logPath}.tmp`)).toBe(false);
+  });
+
+  // Phase 1 item #2 — runtime: structured verdict appears in both log + systemMessage.
+  it("structured verdict appears in log AND in systemMessage prefix", () => {
+    fs.writeFileSync(path.join(tempDir, ".codex-pair-context.md"), "# test context");
+    const missingPath = path.join(tempDir, "does-not-exist.ts");
+    const payload = JSON.stringify({
+      tool_name: "Edit",
+      tool_input: { file_path: missingPath },
+    });
+    const result = runHook(payload, tempDir);
+    expect(result.status).toBe(0);
+
+    const logEntry = JSON.parse(fs.readFileSync(path.join(tempDir, ".codex-pair-log.jsonl"), "utf-8").trim());
+    expect(logEntry.verdict).toBe("skipped");
+
+    const hookOutput = JSON.parse(result.stdout.trim());
+    // Prefix in systemMessage matches the verdict via VERDICT_PREFIXES.skipped = "SKIP"
+    expect(hookOutput.systemMessage).toMatch(/^codex-pair SKIP:/);
   });
 });


### PR DESCRIPTION
## Summary

Phase 1 of the v0.6.0 codex-pair improvements batch — four S-effort hardening + observability items bundled into one PR. Ships **under the existing v0.6.0 umbrella** (PR #64); no version bump or changeset here.

References CHANGELOG items 1-4 from `packages/claude-plugin/CHANGELOG.md@0.6.0`.

## What ships

**1. Log rotation.** `.codex-pair-log.jsonl` capped at ~2MB / 1000 entries via atomic tmp-write + rename inside `appendLog`. Env override `CODEX_PAIR_MAX_LOG_BYTES` (default `2_000_000`). Rotation failure is silent no-op — never breaks Claude's tool flow.

**2. Structured run-state verdicts.** Every log entry's `verdict` is one of the closed set: `none | concerns | skipped | error | spawn_failed | timeout | parse_failed | cached`. `systemMessage` prefixes mirror via `VERDICT_PREFIXES` — user now sees `codex-pair TIMEOUT:`, `codex-pair SPAWN_FAILED:`, `codex-pair PARSE_FAILED:` instead of the previous generic `codex-pair ERROR:`. `spawnCodex` rejections carry a `taggedError(.verdict)` tag so `main()` can classify without re-parsing the message.

**3. Expanded skip patterns.** Added:
- Fonts: `.woff`, `.woff2`, `.ttf`, `.otf`, `.eot`
- Archives + docs: `.pdf`, `.zip`, `.tar`, `.gz`
- Snapshots, sourcemaps, minified: `.snap`, `.map`, `.min.js`, `.min.css`
- Lockfiles: `pnpm-lock.yaml`, `Cargo.lock`, `Gemfile.lock`, `composer.lock`, `poetry.lock`, `go.sum`

Path-with-slash patterns still come first; extension patterns grouped by category with comments.

**4. Default-model drift guard.** New `packages/claude-plugin/codex-pair-defaults.json` shape `{model, fallbackModel}`. Hook resolves via `import.meta.url`, falls back to env vars and inline literals if the file is missing or malformed. A drift-guard test links the JSON values to `packages/codex-mcp/src/constants.ts:MODELS` via regex so a future bump there without updating the JSON fails CI.

## Tests

- 11 new tests covering all four items: 7 structural (rotation constants, verdict table, taggedError, expanded skip globs, defaults JSON existence, drift-guard linkage, systemMessage prefix routing) + 4 runtime (rotation drops oldest/keeps newest/no `.tmp` leftover, verdict-to-systemMessage mapping)
- Plugin test count: 141 → **152** (baseline preserved + 11)
- Lint clean (Biome + tsc)
- Husky pre-push smoke tests passed (Ollama 31/31, Gemini 103/103, Codex 46/46)

## Constraints preserved

- Zero workspace imports (only `node:fs/promises`, `node:fs`, `node:child_process`, `node:path`, `node:os`, `node:url` added)
- `process.exit(0)` everywhere; `main().catch(...)` wraps
- LOW concerns still log-only (ADR-077)
- Synchronous-blocking semantics unchanged

## Files

- `packages/claude-plugin/scripts/codex-pair-watch.mjs` — hook
- `packages/claude-plugin/codex-pair-defaults.json` — new defaults file
- `packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts` — +11 tests

NO version bumps; NO `CHANGELOG.md`/manifest edits.

## Test plan

- [x] 152 plugin tests pass
- [x] Plugin lint clean
- [x] Smoke tests pass (Ollama/Gemini/Codex)
- [x] Drift-guard test verifies linkage to codex-mcp/src/constants.ts
- [ ] Post-merge: marketplace install reads the new defaults JSON correctly (cold-start verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)