### PR TITLE
feat(plugin): codex-pair-log CLI viewer (v0.6.0 item #9)

### DIFF
--- a/apps/docs/plugin/hooks.md
+++ b/apps/docs/plugin/hooks.md
@@ -104,11 +104,39 @@ integer cents. Use integer minor units such as
 
 - ~$0.04–0.07 per file reviewed (Codex GPT-5.5 with reasoning tokens)
 - ~13–50s per file wall-clock
-- Files >20 KB skipped (override with `CODEX_PAIR_MAX_FILE_BYTES`)
-- `node_modules/`, `dist/`, lockfiles, and common images skipped automatically
-- A 50-edit session is roughly $2–3.50 plus ~10–40 minutes of cumulative Codex latency
+- Files over the size cap fall back to an adaptive partial-view review (header + git diff against HEAD, OR head + tail) — see [ADR-080](https://github.com/Lykhoyda/ask-llm/blob/main/docs/DECISIONS.md)
+- `node_modules/`, `dist/`, lockfiles, fonts, archives, sourcemaps, snapshots, minified assets skipped automatically
+- A 50-edit session is roughly $2–3.50 plus ~10–40 minutes of cumulative Codex latency — significantly less after the content-hash cache warms (item #8 / [ADR-082](https://github.com/Lykhoyda/ask-llm/blob/main/docs/DECISIONS.md))
 
 For typical opted-in projects (small surface where review depth matters), the cost is acceptable. For routine refactor work across a whole repo, leave the marker file out and use `/codex-review` on demand instead.
+
+### Inspecting log activity: `codex-pair-log` CLI
+
+Shipped alongside the hook at `packages/claude-plugin/scripts/codex-pair-log.mjs`. Walks up from cwd to find the marker (same gate as the hook), then renders the sibling `.codex-pair-log.jsonl`. Useful for "is the hook actually running" diagnostics and for forensic analysis of what's been reviewed.
+
+```bash
+# Default: last 10 entries
+node packages/claude-plugin/scripts/codex-pair-log.mjs
+
+# Aggregate stats — verdict breakdown, top 5 files, cache hit rate, fallback frequency
+node packages/claude-plugin/scripts/codex-pair-log.mjs --summary
+
+# Filter to one file's history
+node packages/claude-plugin/scripts/codex-pair-log.mjs --file src/billing/charge.ts
+
+# Only the last 24 hours
+node packages/claude-plugin/scripts/codex-pair-log.mjs --since 24h --latest 50
+```
+
+Output shape (one line per entry):
+
+```
+2026-05-18T15:11:02.341Z  none          src/billing/charge.ts        0H/0M/0L    6.2s
+2026-05-18T15:11:14.892Z  concerns      src/billing/charge.ts        1H/0M/0L    8.7s
+2026-05-18T15:11:18.001Z  cached        src/billing/charge.ts        1H/0M/0L    3ms
+```
+
+Zero workspace imports — runs on a marketplace install with no `node_modules`.
 
 ## CLI Binaries
 

--- a/packages/claude-plugin/scripts/codex-pair-log.mjs
+++ b/packages/claude-plugin/scripts/codex-pair-log.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+// codex-pair-log — standalone CLI viewer for the .codex-pair-log.jsonl
+// written by the codex-pair PostToolUse hook. Walks up from cwd to find the
+// .codex-pair-context.md marker (same gate as the hook itself), then reads
+// and renders the sibling log file.
+//
+// Subcommands:
+//   --latest [N]      Show last N entries (default 10). DEFAULT subcommand.
+//   --summary         Aggregate stats: verdict breakdown, top files, durations.
+//   --file <path>     Filter to one file's history.
+//   --since <dur>     Filter to entries within the last <dur>. Examples: 24h, 7d, 30m.
+//
+// Zero workspace imports — distributed via marketplace `git-subdir` install,
+// no node_modules at runtime. Same constraint as codex-pair-watch.mjs (ADR-078).
+
+import { readFileSync } from "node:fs";
+import { access } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+const MARKER_FILE = ".codex-pair-context.md";
+const LOG_FILENAME = ".codex-pair-log.jsonl";
+
+async function findMarkerUp(startDir) {
+  const home = homedir();
+  let current = resolve(startDir);
+  for (let depth = 0; depth < 20; depth++) {
+    const candidate = join(current, MARKER_FILE);
+    try {
+      await access(candidate);
+      return candidate;
+    } catch {
+      // not found here
+    }
+    const parent = dirname(current);
+    if (parent === current) return null;
+    if (current === home) return null;
+    current = parent;
+  }
+  return null;
+}
+
+function parseDuration(s) {
+  const m = s.match(/^(\d+)([smhd])$/);
+  if (!m) return null;
+  const n = Number(m[1]);
+  const unit = m[2];
+  if (unit === "s") return n * 1000;
+  if (unit === "m") return n * 60 * 1000;
+  if (unit === "h") return n * 60 * 60 * 1000;
+  if (unit === "d") return n * 24 * 60 * 60 * 1000;
+  return null;
+}
+
+function parseArgs(argv) {
+  const args = { cmd: "latest", n: 10, file: null, sinceMs: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--latest") {
+      args.cmd = "latest";
+      const next = argv[i + 1];
+      if (next && /^\d+$/.test(next)) {
+        args.n = Number(next);
+        i++;
+      }
+    } else if (a === "--summary") {
+      args.cmd = "summary";
+    } else if (a === "--file") {
+      args.cmd = "file";
+      args.file = argv[i + 1] ?? null;
+      i++;
+    } else if (a === "--since") {
+      const next = argv[i + 1];
+      const ms = next ? parseDuration(next) : null;
+      if (ms === null) {
+        process.stderr.write(`codex-pair-log: invalid --since duration "${next ?? ""}"\n`);
+        process.exit(2);
+      }
+      args.sinceMs = ms;
+      i++;
+    } else if (a === "--help" || a === "-h") {
+      args.cmd = "help";
+    } else {
+      process.stderr.write(`codex-pair-log: unknown arg "${a}"\n`);
+      process.exit(2);
+    }
+  }
+  return args;
+}
+
+function loadEntries(logPath) {
+  let content;
+  try {
+    content = readFileSync(logPath, "utf8");
+  } catch {
+    return [];
+  }
+  const entries = [];
+  for (const line of content.split("\n")) {
+    if (line.length === 0) continue;
+    try {
+      entries.push(JSON.parse(line));
+    } catch {
+      // skip malformed lines silently
+    }
+  }
+  return entries;
+}
+
+function applySinceFilter(entries, sinceMs) {
+  if (sinceMs == null) return entries;
+  const cutoff = Date.now() - sinceMs;
+  return entries.filter((e) => {
+    if (!e.timestamp) return false;
+    const t = new Date(e.timestamp).getTime();
+    return Number.isFinite(t) && t >= cutoff;
+  });
+}
+
+function formatCounts(entry) {
+  if (entry.counts) {
+    return `${entry.counts.high}H/${entry.counts.med}M/${entry.counts.low}L`;
+  }
+  return "—";
+}
+
+function formatDuration(ms) {
+  if (ms == null) return "—";
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function showLatest(entries, n) {
+  const slice = entries.slice(-n);
+  for (const e of slice) {
+    const verdict = (e.verdict || (e.level ? `[${e.level}]` : "?")).padEnd(13);
+    const file = (e.file || "—").padEnd(50);
+    const counts = formatCounts(e).padEnd(11);
+    const dur = formatDuration(e.durationMs);
+    const ts = e.timestamp || "—";
+    process.stdout.write(`${ts}  ${verdict} ${file} ${counts} ${dur}\n`);
+  }
+}
+
+function showFile(entries, filePath) {
+  const filtered = entries.filter((e) => e.file === filePath);
+  if (filtered.length === 0) {
+    process.stdout.write(`codex-pair-log: no entries for file ${filePath}\n`);
+    return;
+  }
+  showLatest(filtered, filtered.length);
+}
+
+function showSummary(entries) {
+  const verdictCounts = {};
+  const fileCounts = {};
+  let durationSum = 0;
+  let durationCount = 0;
+  let fallbackCount = 0;
+  let cachedCount = 0;
+  let runCount = 0;
+  for (const e of entries) {
+    if (e.verdict) {
+      verdictCounts[e.verdict] = (verdictCounts[e.verdict] || 0) + 1;
+    }
+    if (e.file) {
+      fileCounts[e.file] = (fileCounts[e.file] || 0) + 1;
+    }
+    if (e.fellBack) fallbackCount++;
+    if (e.verdict === "cached") cachedCount++;
+    if (
+      e.verdict === "none" ||
+      e.verdict === "concerns" ||
+      e.verdict === "cached"
+    ) {
+      runCount++;
+    }
+    if (
+      e.durationMs != null &&
+      (e.verdict === "none" || e.verdict === "concerns")
+    ) {
+      durationSum += e.durationMs;
+      durationCount++;
+    }
+  }
+  const topFiles = Object.entries(fileCounts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5);
+  process.stdout.write(`codex-pair log summary\n`);
+  process.stdout.write(`Total entries:    ${entries.length}\n`);
+  process.stdout.write(`Verdict breakdown:\n`);
+  for (const [v, c] of Object.entries(verdictCounts).sort((a, b) => b[1] - a[1])) {
+    process.stdout.write(`  ${v.padEnd(15)} ${c}\n`);
+  }
+  process.stdout.write(`Top 5 files by entry count:\n`);
+  for (const [f, c] of topFiles) {
+    process.stdout.write(`  ${String(c).padStart(4)}  ${f}\n`);
+  }
+  if (durationCount > 0) {
+    const avg = durationSum / durationCount;
+    process.stdout.write(
+      `Average codex duration (uncached runs only): ${formatDuration(avg)} over ${durationCount} runs\n`,
+    );
+  }
+  if (runCount > 0) {
+    const cacheRate = ((cachedCount / runCount) * 100).toFixed(1);
+    process.stdout.write(`Cache hit rate: ${cachedCount} / ${runCount} (${cacheRate}%)\n`);
+  }
+  if (fallbackCount > 0) {
+    process.stdout.write(`Fallback model used: ${fallbackCount} time(s)\n`);
+  }
+}
+
+function showHelp() {
+  process.stdout.write(
+    [
+      "codex-pair-log — view the .codex-pair-log.jsonl written by the codex-pair hook",
+      "",
+      "Usage: codex-pair-log [SUBCOMMAND] [--since DURATION]",
+      "",
+      "Subcommands:",
+      "  --latest [N]      Show last N entries (default 10). Default subcommand.",
+      "  --summary         Aggregate stats over the log.",
+      "  --file <path>     Filter to one file's history.",
+      "  --since <dur>     Filter to entries within the last <dur>. Examples: 30m, 24h, 7d.",
+      "  --help, -h        Show this help.",
+      "",
+    ].join("\n"),
+  );
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.cmd === "help") {
+    showHelp();
+    return;
+  }
+  const markerPath = await findMarkerUp(process.cwd());
+  if (!markerPath) {
+    process.stderr.write(
+      `codex-pair-log: no .codex-pair-context.md marker found in cwd or parents\n`,
+    );
+    process.exit(1);
+  }
+  const logPath = join(dirname(markerPath), LOG_FILENAME);
+  let entries = loadEntries(logPath);
+  if (entries.length === 0) {
+    process.stdout.write(`codex-pair-log: no entries in ${logPath}\n`);
+    return;
+  }
+  entries = applySinceFilter(entries, args.sinceMs);
+  if (args.cmd === "latest") {
+    showLatest(entries, args.n);
+  } else if (args.cmd === "summary") {
+    showSummary(entries);
+  } else if (args.cmd === "file") {
+    if (!args.file) {
+      process.stderr.write(`codex-pair-log: --file requires a path argument\n`);
+      process.exit(2);
+    }
+    showFile(entries, args.file);
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`codex-pair-log: ${err?.message ?? String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
+++ b/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
@@ -354,6 +354,34 @@ describe("scripts/codex-pair-watch.mjs — structural invariants (ADR-077)", () 
     expect(script).toMatch(/setCachedConcerns/);
   });
 
+  // Phase 3 item #9: log viewer CLI (in a sibling script, but tested here for proximity)
+  it("scripts/codex-pair-log.mjs exists, has shebang, is executable", () => {
+    const logCliPath = path.join(PLUGIN_ROOT, "scripts", "codex-pair-log.mjs");
+    expect(fs.existsSync(logCliPath)).toBe(true);
+    const cli = fs.readFileSync(logCliPath, "utf-8");
+    expect(cli.startsWith("#!/usr/bin/env node")).toBe(true);
+    const stats = fs.statSync(logCliPath);
+    expect((stats.mode & 0o100) !== 0).toBe(true);
+  });
+
+  it("codex-pair-log CLI has zero workspace imports", () => {
+    const cli = fs.readFileSync(path.join(PLUGIN_ROOT, "scripts", "codex-pair-log.mjs"), "utf-8");
+    expect(cli).not.toMatch(/from\s+["']ask-codex-mcp/);
+    expect(cli).not.toMatch(/from\s+["']ask-gemini-mcp/);
+    expect(cli).not.toMatch(/from\s+["']ask-ollama-mcp/);
+    expect(cli).not.toMatch(/from\s+["']@ask-llm/);
+  });
+
+  it("codex-pair-log CLI declares all four subcommands plus --since filter", () => {
+    const cli = fs.readFileSync(path.join(PLUGIN_ROOT, "scripts", "codex-pair-log.mjs"), "utf-8");
+    expect(cli).toMatch(/--latest/);
+    expect(cli).toMatch(/--summary/);
+    expect(cli).toMatch(/--file/);
+    expect(cli).toMatch(/--since/);
+    // Reuses findMarkerUp logic inline (no import from the hook)
+    expect(cli).toMatch(/function findMarkerUp/);
+  });
+
   it("buildVerdictMessage emits [cached] suffix when cached:true", () => {
     const block = script.match(/function buildVerdictMessage[\s\S]*?^\}\s*$/m);
     expect(block).toBeTruthy();
@@ -907,6 +935,105 @@ describe("scripts/codex-pair-watch.mjs — runtime behavior (no codex calls)", (
     expect(lines.some((l) => /matched \.codex-pair-ignore/.test(l.reason ?? ""))).toBe(false);
     expect(lines[0].verdict).toBe("skipped");
     expect(lines[0].reason).toMatch(/unreadable/);
+  });
+
+  // Phase 3 item #9 — runtime: log viewer CLI subcommands
+  it("codex-pair-log CLI: --latest prints last N entries from the log", () => {
+    fs.writeFileSync(path.join(tempDir, ".codex-pair-context.md"), "# ctx");
+    const logPath = path.join(tempDir, ".codex-pair-log.jsonl");
+    const entries: string[] = [];
+    for (let i = 0; i < 12; i++) {
+      entries.push(
+        JSON.stringify({
+          timestamp: new Date(2026, 4, 18, 10, i, 0).toISOString(),
+          tool: "Edit",
+          file: `file-${i}.ts`,
+          verdict: i % 3 === 0 ? "concerns" : "none",
+          counts: { high: 0, med: 0, low: 0 },
+          durationMs: 5000 + i * 100,
+        }),
+      );
+    }
+    fs.writeFileSync(logPath, `${entries.join("\n")}\n`);
+    const cliPath = path.join(PLUGIN_ROOT, "scripts", "codex-pair-log.mjs");
+    const result = spawnSync("node", [cliPath, "--latest", "3"], {
+      cwd: tempDir,
+      env: process.env,
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    expect(result.status).toBe(0);
+    // Last 3: file-9, file-10, file-11
+    expect(result.stdout).toMatch(/file-9\.ts/);
+    expect(result.stdout).toMatch(/file-10\.ts/);
+    expect(result.stdout).toMatch(/file-11\.ts/);
+    // First entry should NOT appear
+    expect(result.stdout).not.toMatch(/file-0\.ts/);
+  });
+
+  it("codex-pair-log CLI: --summary aggregates verdict counts and file stats", () => {
+    fs.writeFileSync(path.join(tempDir, ".codex-pair-context.md"), "# ctx");
+    const logPath = path.join(tempDir, ".codex-pair-log.jsonl");
+    const entries = [
+      { verdict: "none", file: "a.ts", durationMs: 5000 },
+      { verdict: "none", file: "a.ts", durationMs: 6000 },
+      { verdict: "concerns", file: "b.ts", durationMs: 8000 },
+      { verdict: "cached", file: "a.ts", durationMs: 5 },
+      { verdict: "skipped", file: "c.ts" },
+    ].map((e) => JSON.stringify({ timestamp: new Date().toISOString(), ...e }));
+    fs.writeFileSync(logPath, `${entries.join("\n")}\n`);
+    const cliPath = path.join(PLUGIN_ROOT, "scripts", "codex-pair-log.mjs");
+    const result = spawnSync("node", [cliPath, "--summary"], {
+      cwd: tempDir,
+      env: process.env,
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/Total entries:\s*5/);
+    expect(result.stdout).toMatch(/none\s+2/);
+    expect(result.stdout).toMatch(/concerns\s+1/);
+    expect(result.stdout).toMatch(/cached\s+1/);
+    expect(result.stdout).toMatch(/Top 5 files/);
+    expect(result.stdout).toMatch(/a\.ts/);
+    expect(result.stdout).toMatch(/Cache hit rate:\s*1\s*\/\s*4/);
+  });
+
+  it("codex-pair-log CLI: --file filters entries by file path", () => {
+    fs.writeFileSync(path.join(tempDir, ".codex-pair-context.md"), "# ctx");
+    const logPath = path.join(tempDir, ".codex-pair-log.jsonl");
+    const entries = [
+      { file: "src/foo.ts", verdict: "none", durationMs: 1000 },
+      { file: "src/bar.ts", verdict: "none", durationMs: 1000 },
+      { file: "src/foo.ts", verdict: "concerns", durationMs: 2000 },
+    ].map((e) => JSON.stringify({ timestamp: new Date().toISOString(), ...e }));
+    fs.writeFileSync(logPath, `${entries.join("\n")}\n`);
+    const cliPath = path.join(PLUGIN_ROOT, "scripts", "codex-pair-log.mjs");
+    const result = spawnSync("node", [cliPath, "--file", "src/foo.ts"], {
+      cwd: tempDir,
+      env: process.env,
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    expect(result.status).toBe(0);
+    // Both foo.ts entries shown
+    const fooMatches = (result.stdout.match(/src\/foo\.ts/g) ?? []).length;
+    expect(fooMatches).toBe(2);
+    // bar.ts NOT shown
+    expect(result.stdout).not.toMatch(/src\/bar\.ts/);
+  });
+
+  it("codex-pair-log CLI: exits non-zero with no marker", () => {
+    // No marker file in tempDir
+    const cliPath = path.join(PLUGIN_ROOT, "scripts", "codex-pair-log.mjs");
+    const result = spawnSync("node", [cliPath, "--latest"], {
+      cwd: tempDir,
+      env: process.env,
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/no \.codex-pair-context\.md/);
   });
 
   // Phase 2 item #6 — runtime: adaptive context uses head+tail when git unavailable.


### PR DESCRIPTION
## Summary

Phase 3 item #9 — standalone log viewer CLI for the `.codex-pair-log.jsonl` written by the codex-pair hook. Answers "is the pair programmer actually firing?" and supports forensic analysis. Ships under v0.6.0 umbrella.

References CHANGELOG item #9. No ADR required (CLI tool, not an architectural change).

## What ships

Script: `packages/claude-plugin/scripts/codex-pair-log.mjs` (executable, zero workspace imports, duplicates `findMarkerUp` inline per ADR-078).

Subcommands:
- `--latest [N]` — last N entries (default 10). Default subcommand.
- `--summary` — aggregate: total entries, verdict breakdown, top 5 files by count, average codex duration (uncached only), cache hit rate, fallback frequency.
- `--file <path>` — filter to one file's history.
- `--since <dur>` — time-window filter. Examples: `30m`, `24h`, `7d`.
- `--help` — inline help.

Example output:

```
2026-05-18T15:11:02.341Z  none          src/billing/charge.ts        0H/0M/0L    6.2s
2026-05-18T15:11:14.892Z  concerns      src/billing/charge.ts        1H/0M/0L    8.7s
2026-05-18T15:11:18.001Z  cached        src/billing/charge.ts        1H/0M/0L    3ms
```

## Docs

`apps/docs/plugin/hooks.md` gains a new "Inspecting log activity: `codex-pair-log` CLI" subsection with usage examples + sample output + zero-workspace-imports note.

## Tests

+6 (3 structural + 4 runtime by spawning the CLI with fixture logs). Checks `--latest` slicing, `--summary` aggregation (including cache hit rate math), `--file` filtering, and the "no marker found" error path. Plugin test count **183 → 190**.

## Files

- `packages/claude-plugin/scripts/codex-pair-log.mjs` — new CLI (executable, ~250 LOC)
- `packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts` — +6 tests
- `apps/docs/plugin/hooks.md` — new subsection

NO `package.json` / `plugin.json` / `marketplace.json` / `CHANGELOG.md` touched.

## Test plan

- [x] 190 plugin tests pass
- [x] Plugin lint clean
- [x] Husky smoke tests passed
- [x] CLI exec bit set; node shebang present
- [x] Zero workspace imports verified by structural test

🤖 Generated with [Claude Code](https://claude.com/claude-code)