### PR TITLE
feat(plugin): failure-class retry with jitter (v0.6.0 item #10)

### DIFF
--- a/packages/claude-plugin/scripts/codex-pair-watch.mjs
+++ b/packages/claude-plugin/scripts/codex-pair-watch.mjs
@@ -61,6 +61,22 @@ const VALID_THRESHOLDS = new Set(["high", "med", "low"]);
 const DEFAULT_SURFACE_THRESHOLD = "med";
 const QUOTA_SIGNALS = ["rate_limit_exceeded", "quota_exceeded", "429", "insufficient_quota"];
 
+// Transient failure signatures (item #10). Errors matching any of these get
+// ONE retry with jittered delay before propagating. Quota errors take the
+// existing model-fallback path (not retry — quota exhaustion isn't transient).
+// Hook-side timeouts and JSONL parse failures are excluded by verdict tag
+// (see isTransientError) — those are deterministic failures that retry can't fix.
+const TRANSIENT_SIGNALS = [
+  /ECONNRESET/,
+  /ECONNREFUSED/,
+  /ETIMEDOUT/,
+  /EAI_AGAIN/,
+  /UND_ERR/,
+  /\b502\b/,
+  /\b503\b/,
+  /\b504\b/,
+];
+
 // Cache configuration (item #8). Cache lives at `<markerDir>/.codex-pair-cache/<hash[0:2]>/<rest>.json`.
 // Value: { high, med, low, durationMs }. Keyed on the inputs that
 // deterministically produce a codex review outcome (same prompt + same model
@@ -701,6 +717,24 @@ function isQuotaError(err) {
   return QUOTA_SIGNALS.some((sig) => msg.includes(sig));
 }
 
+// Transient = retryable. Excludes hook-side timeout and parse_failed by
+// verdict tag (those are deterministic and retry can't help). Quota errors
+// take the model-fallback path instead — they're not transient either.
+function isTransientError(err) {
+  if (err && typeof err === "object") {
+    if (err.verdict === "timeout" || err.verdict === "parse_failed") return false;
+  }
+  if (isQuotaError(err)) return false;
+  const msg = err instanceof Error ? err.message : String(err);
+  return TRANSIENT_SIGNALS.some((sig) => sig.test(msg));
+}
+
+function sleepMs(ms) {
+  return new Promise((r) => {
+    setTimeout(r, ms);
+  });
+}
+
 // Attach a verdict tag to an Error so the main() catch can classify the
 // failure into the closed VERDICT_PREFIXES set without re-parsing the message.
 function taggedError(message, verdict) {
@@ -782,12 +816,44 @@ function spawnCodex({ prompt, model, timeoutMs }) {
   });
 }
 
-async function runCodexWithFallback({ prompt, timeoutMs, model, fallbackModel }) {
+// Spawn codex with one retry on transient failures. The retry is jittered
+// (1000 + Math.random()*1500 ms) to avoid synchronized retries across
+// multiple concurrent hook invocations. Quota errors fall through unretried
+// (handled by the outer fallback layer); hook-side timeouts and parse_failed
+// errors are explicitly excluded by verdictFromError tag.
+async function spawnCodexWithRetry({ prompt, model, timeoutMs, markerDir }) {
   try {
-    return { response: await spawnCodex({ prompt, model, timeoutMs }), fellBack: false };
+    return await spawnCodex({ prompt, model, timeoutMs });
+  } catch (err) {
+    if (!isTransientError(err)) throw err;
+    const reason = err instanceof Error ? err.message : String(err);
+    const delayMs = 1000 + Math.random() * 1500;
+    await appendLog(markerDir, {
+      timestamp: new Date().toISOString(),
+      verdict: "retried",
+      reason,
+      model,
+      delayMs: Math.round(delayMs),
+    });
+    await sleepMs(delayMs);
+    return await spawnCodex({ prompt, model, timeoutMs });
+  }
+}
+
+async function runCodexWithFallback({ prompt, timeoutMs, model, fallbackModel, markerDir }) {
+  try {
+    return {
+      response: await spawnCodexWithRetry({ prompt, model, timeoutMs, markerDir }),
+      fellBack: false,
+    };
   } catch (err) {
     if (isQuotaError(err) && model !== fallbackModel) {
-      const response = await spawnCodex({ prompt, model: fallbackModel, timeoutMs });
+      const response = await spawnCodexWithRetry({
+        prompt,
+        model: fallbackModel,
+        timeoutMs,
+        markerDir,
+      });
       return { response, fellBack: true };
     }
     throw err;
@@ -964,6 +1030,7 @@ async function main() {
       timeoutMs: config.timeoutMs,
       model: config.model,
       fallbackModel: config.fallbackModel,
+      markerDir,
     });
     response = result.response;
     fellBack = result.fellBack;

--- a/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
+++ b/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
@@ -372,6 +372,61 @@ describe("scripts/codex-pair-watch.mjs — structural invariants (ADR-077)", () 
     expect(cli).not.toMatch(/from\s+["']@ask-llm/);
   });
 
+  // Phase 3 item #10: failure-class retry with jitter
+  it("declares TRANSIENT_SIGNALS for retryable codex failure modes", () => {
+    const block = script.match(/const TRANSIENT_SIGNALS\s*=\s*\[[\s\S]*?\];/);
+    expect(block).toBeTruthy();
+    const body = block?.[0] ?? "";
+    expect(body).toMatch(/ECONNRESET/);
+    expect(body).toMatch(/ECONNREFUSED/);
+    expect(body).toMatch(/ETIMEDOUT/);
+    expect(body).toMatch(/EAI_AGAIN/);
+    expect(body).toMatch(/UND_ERR/);
+    expect(body).toMatch(/502/);
+    expect(body).toMatch(/503/);
+    expect(body).toMatch(/504/);
+  });
+
+  it("isTransientError excludes hook-side timeout and parse_failed (not retryable)", () => {
+    const block = script.match(/function isTransientError[\s\S]*?^\}\s*$/m);
+    expect(block).toBeTruthy();
+    const body = block?.[0] ?? "";
+    // explicit verdict guards
+    expect(body).toMatch(/err\.verdict\s*===\s*["']timeout["']/);
+    expect(body).toMatch(/err\.verdict\s*===\s*["']parse_failed["']/);
+    // also excludes quota (those use model fallback path instead)
+    expect(body).toMatch(/isQuotaError/);
+    // signal scan
+    expect(body).toMatch(/TRANSIENT_SIGNALS/);
+  });
+
+  it("spawnCodexWithRetry retries once with jittered delay and logs `retried` verdict", () => {
+    expect(script).toMatch(/async function spawnCodexWithRetry/);
+    const block = script.match(/async function spawnCodexWithRetry[\s\S]*?^\}\s*$/m);
+    expect(block).toBeTruthy();
+    const body = block?.[0] ?? "";
+    // Jitter: 1000 + Math.random() * 1500
+    expect(body).toMatch(/1000\s*\+\s*Math\.random\(\)\s*\*\s*1500/);
+    // Log entry with verdict:"retried"
+    expect(body).toMatch(/verdict:\s*["']retried["']/);
+    // Sleeps before retry
+    expect(body).toMatch(/sleepMs|setTimeout/);
+    // Only ONE retry — body invokes spawnCodex twice (once in try, once after delay)
+    const spawnCount = (body.match(/await spawnCodex\(/g) ?? []).length;
+    expect(spawnCount).toBe(2);
+  });
+
+  it("runCodexWithFallback wraps spawnCodexWithRetry (not raw spawnCodex)", () => {
+    const block = script.match(/async function runCodexWithFallback[\s\S]*?^\}\s*$/m);
+    expect(block).toBeTruthy();
+    const body = block?.[0] ?? "";
+    // Use the retry-wrapping spawner, not the raw one
+    expect(body).toMatch(/spawnCodexWithRetry/);
+    // Quota fallback path also goes through retry wrapper
+    const retryCallCount = (body.match(/spawnCodexWithRetry/g) ?? []).length;
+    expect(retryCallCount).toBeGreaterThanOrEqual(2);
+  });
+
   it("codex-pair-log CLI declares all four subcommands plus --since filter", () => {
     const cli = fs.readFileSync(path.join(PLUGIN_ROOT, "scripts", "codex-pair-log.mjs"), "utf-8");
     expect(cli).toMatch(/--latest/);


### PR DESCRIPTION
## Summary

Phase 3 item #10 — final v0.6.0 batch item. Retry codex spawn once with jittered delay on transient network/5xx errors. Quota errors keep the existing model-fallback path; hook-side timeouts and parse failures are explicitly excluded (deterministic failures, retry can't fix them). Ships under v0.6.0 umbrella.

References CHANGELOG item #10. No ADR needed (per the goal command: only items 5-8 require ADRs).

## Failure classification

| Class | Signal pattern | Behavior |
|---|---|---|
| Quota | `rate_limit_exceeded`, `429`, `quota_exceeded`, `insufficient_quota` | Existing model fallback (gpt-5.5 → gpt-5.5-mini), no retry |
| Transient | `ECONNRESET`, `ECONNREFUSED`, `ETIMEDOUT`, `EAI_AGAIN`, `UND_ERR`, `502\b`, `503\b`, `504\b` | Retry once at `1000 + Math.random() * 1500` ms |
| Timeout | hook's own timer fired (`err.verdict === "timeout"`) | No retry — the timeout was already long |
| Parse error | JSONL malformed (`err.verdict === "parse_failed"`) | No retry — deterministic |

## Implementation

**`isTransientError(err)`** is the single classification function. Checks `err.verdict` tag first (for hook-tagged errors from Phase 1 item #2 — `spawn_failed`, `timeout`, `parse_failed`) and falls through to regex-matching against `TRANSIENT_SIGNALS`. Quota check via `isQuotaError` is the explicit "no retry, take the fallback path" route.

**`spawnCodexWithRetry`** wraps `spawnCodex` with the retry logic. On transient failure: logs `verdict: "retried"` entry capturing the original error message + model + delayMs, sleeps with jitter, retries once.

**`runCodexWithFallback`** now wraps `spawnCodexWithRetry` (both for the initial call AND for the quota-fallback model retry — both layers get the transient-retry benefit).

## Tests

+4 structural pins (TRANSIENT_SIGNALS array contents, isTransientError verdict guards + quota exclusion + signal scan, spawnCodexWithRetry jitter formula + single-retry behavior, fallback wraps the retry layer). Plugin test count **190 → 194**.

## Files

- `packages/claude-plugin/scripts/codex-pair-watch.mjs` — TRANSIENT_SIGNALS, isTransientError, sleepMs, spawnCodexWithRetry, runCodexWithFallback refactor
- `packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts` — +4 tests

NO `package.json` / `plugin.json` / `marketplace.json` / `CHANGELOG.md` touched.

## Closes the v0.6.0 batch

This is the 10th and final item of the v0.6.0 umbrella release. Once merged: plugin at v0.6.0 with all 10 planned items shipped. Test baseline 141 → **194** (preserved throughout, +53 from the v0.6.0 work).

## Test plan

- [x] 194 plugin tests pass
- [x] Plugin lint clean
- [x] Husky smoke tests passed
- [x] Jitter formula matches spec (1000 + Math.random() * 1500)
- [x] Quota path still uses model fallback (not retry)
- [x] Timeout/parse_failed paths excluded from retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)