### PR TITLE
fix(plugin): codex-pair marker resolution anchors to edited file path (v0.6.1, closes #65, #74)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,7 +17,7 @@
         "path": "packages/claude-plugin"
       },
       "description": "AI-to-AI collaboration — review code, brainstorm ideas, and debate plans across Gemini, Codex, and Ollama providers",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "author": {
         "name": "Anton Lykhoyda"
       },

--- a/packages/claude-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ask-llm",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "AI-to-AI collaboration — review code, brainstorm ideas, and debate plans across Gemini, Codex, and Ollama",
   "author": {
     "name": "Anton Lykhoyda",

--- a/packages/claude-plugin/CHANGELOG.md
+++ b/packages/claude-plugin/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ask-llm/plugin
 
+## 0.6.1
+
+### Patch Changes
+
+- Fix: codex-pair marker resolution now anchors to the edited file's directory, not `process.cwd()` (issue [#65](https://github.com/Lykhoyda/ask-llm/issues/65)). In multi-repo workflows where Claude Code's cwd is one repo but the edit happens in another, the previous behavior wrote logs to the cwd's repo instead of the edited file's repo, producing "where did my log go?" confusion. The fix uses `dirname(tool_input.file_path)` — always absolute per Claude Code's hook payload contract — as the marker walk's anchor. The `main().catch` unhandled-exception fallback retains its cwd-based lookup since `filePath` isn't in scope there; the structural test was tightened to allow this distinction.
+
+  Side effect: shipping this as v0.6.1 also triggers Claude Code's plugin cache refresh for pre-existing sessions still pinned to the stale v0.6.0 install (issue [#74](https://github.com/Lykhoyda/ask-llm/issues/74)) — the next `/reload-plugins` or session restart will see "new version available" and re-fetch from origin.
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/claude-plugin/package.json
+++ b/packages/claude-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ask-llm/plugin",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/claude-plugin/scripts/codex-pair-watch.mjs
+++ b/packages/claude-plugin/scripts/codex-pair-watch.mjs
@@ -877,7 +877,14 @@ async function main() {
   const filePath = payload?.tool_input?.file_path;
   if (!filePath || typeof filePath !== "string") process.exit(0);
 
-  const markerPath = await findMarkerUp(process.cwd());
+  // Marker resolution starts from the edited file's directory, not cwd.
+  // In multi-repo workflows where Claude Code's cwd is one repo but the edit
+  // happens in another (e.g. cross-repo navigation, monorepo with linked
+  // siblings), cwd-anchored resolution writes logs to the wrong repo. The
+  // file_path is always absolute per Claude Code's tool_input contract, so
+  // its dirname is a reliable anchor that matches the edit's actual project.
+  // See issue #65.
+  const markerPath = await findMarkerUp(dirname(filePath));
   if (!markerPath) process.exit(0);
   const markerDir = dirname(markerPath);
 

--- a/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
+++ b/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
@@ -60,10 +60,18 @@ describe("scripts/codex-pair-watch.mjs — structural invariants (ADR-077)", () 
     expect(script).toMatch(/\.codex-pair-context\.md/);
   });
 
-  it("self-gates: walks up from cwd looking for the marker", () => {
+  it("self-gates: walks up from edited file's directory looking for the marker (issue #65)", () => {
     expect(script).toMatch(/findMarkerUp/);
-    // Walks up via dirname loop
+    // Walks up via dirname loop (inside findMarkerUp's body)
     expect(script).toMatch(/dirname\(.*current\)/);
+    // main()'s primary marker resolution uses dirname(filePath), not cwd.
+    // Cross-repo edits land logs at the edited file's repo, not the cwd's repo.
+    const mainBlock = script.match(/async function main\(\)\s*\{[\s\S]*?^\}\s*$/m);
+    expect(mainBlock).toBeTruthy();
+    expect(mainBlock?.[0]).toMatch(/findMarkerUp\(dirname\(filePath\)\)/);
+    expect(mainBlock?.[0]).not.toMatch(/findMarkerUp\(process\.cwd\(\)\)/);
+    // The main().catch unhandled-exception fallback is allowed to use cwd —
+    // filePath isn't in scope there. So we don't forbid cwd globally.
   });
 
   it("respects CODEX_PAIR_DISABLED env var as kill switch", () => {
@@ -741,6 +749,37 @@ describe("scripts/codex-pair-watch.mjs — runtime behavior (no codex calls)", (
     const result = runHook(payload, tempDir, { CODEX_PAIR_DISABLED: "1" });
     expect(result.status).toBe(0);
     expect(result.signal).toBeNull();
+  });
+
+  it("issue #65: marker resolves from edited file's path even when cwd is in an unrelated dir", () => {
+    // Repro: marker at tempDir; file edited deep inside tempDir; hook invoked
+    // with cwd=otherDir (no marker on otherDir's walk). Old behavior: marker
+    // not found, silent exit, log goes nowhere. New behavior: marker found
+    // via dirname(filePath), log lands at tempDir.
+    fs.writeFileSync(path.join(tempDir, ".codex-pair-context.md"), "# ctx");
+    const editedDir = path.join(tempDir, "src", "deep", "nested");
+    fs.mkdirSync(editedDir, { recursive: true });
+    const missingPath = path.join(editedDir, "does-not-exist.ts");
+    const otherDir = fs.mkdtempSync(path.join(os.tmpdir(), "other-cwd-"));
+    try {
+      const payload = JSON.stringify({
+        tool_name: "Edit",
+        tool_input: { file_path: missingPath },
+      });
+      // Run hook FROM otherDir (cwd), which has no marker on its parent chain.
+      const result = runHook(payload, otherDir);
+      expect(result.status).toBe(0);
+      // Log MUST land at tempDir (where the marker is), NOT at otherDir.
+      expect(fs.existsSync(path.join(tempDir, ".codex-pair-log.jsonl"))).toBe(true);
+      expect(fs.existsSync(path.join(otherDir, ".codex-pair-log.jsonl"))).toBe(false);
+      const logEntry = JSON.parse(
+        fs.readFileSync(path.join(tempDir, ".codex-pair-log.jsonl"), "utf-8").trim().split("\n")[0],
+      );
+      expect(logEntry.verdict).toBe("skipped");
+      expect(logEntry.reason).toMatch(/unreadable/i);
+    } finally {
+      fs.rmSync(otherDir, { recursive: true, force: true });
+    }
   });
 
   it("finds marker file in parent directory (walks up from cwd)", () => {


### PR DESCRIPTION
## Summary

Switches `main()`'s marker resolution from `findMarkerUp(process.cwd())` to `findMarkerUp(dirname(filePath))`. Fixes the multi-repo workflow bug described in #65 where edits in one repo would log to a different repo's `.codex-pair-log.jsonl` based on whatever shell cwd Claude Code happened to have at session start.

Side effect (closes #74): shipping as v0.6.1 forces Claude Code's plugin cache refresh for pre-existing sessions still pinned to stale v0.6.0 installs.

## What changes

```diff
- const markerPath = await findMarkerUp(process.cwd());
+ const markerPath = await findMarkerUp(dirname(filePath));
```

`filePath` is always absolute per Claude Code's `tool_input.file_path` contract, so its `dirname` is a reliable anchor that matches the edit's actual project regardless of cwd.

## What doesn't change

- The `main().catch` unhandled-exception fallback retains its `findMarkerUp(process.cwd())` lookup. `filePath` isn't in scope inside the catch handler (a separate callback that receives only the rejected Error). That's the rare last-resort path; falling back to cwd there is an acceptable degradation that keeps the hook's "always exit 0" invariant intact.
- The structural test was tightened to scope the `findMarkerUp(dirname(filePath))` assertion to `main()`'s body only, allowing the catch handler's cwd fallback.

## Reproduction (from issue #65)

1. Claude Code session with cwd=`~/Github/repo-A`
2. Both `repo-A` and `repo-B` have `.codex-pair-context.md` markers
3. Edit a file in `repo-B`
4. **Before**: log appended to `repo-A/.codex-pair-log.jsonl` (wrong)
5. **After**: log appended to `repo-B/.codex-pair-log.jsonl` (correct)

## Tests

+1 runtime test exercising the cross-cwd scenario: marker at `tempDir`, file edited deep inside `tempDir`, hook invoked with cwd=unrelated `otherDir`. Verifies log lands at `tempDir`, NOT at `otherDir`. Plugin test count **194 → 195**.

## Version bump

`0.6.0 → 0.6.1` (patch) via changesets. The umbrella v0.6.0 batch is complete; per-PR bumping resumes per the release model documented in ADR-076.

## Closes

- Closes #65 — primary motivation
- Closes #74 — side-effect cache refresh on Claude Code's next plugin load

🤖 Generated with [Claude Code](https://claude.com/claude-code)