### PR TITLE
chore(docs): codex-pair marker fixes + project-settings workaround docs (#74)

### DIFF
--- a/.codex-pair-context.md
+++ b/.codex-pair-context.md
@@ -13,7 +13,7 @@ Yarn workspaces monorepo with these packages:
 - **`ask-codex-mcp`** (npm) — Codex CLI wrapper + MCP server. `packages/codex-mcp/src/utils/codexExecutor.ts` is the canonical source of truth for codex CLI invocation.
 - **`ask-ollama-mcp`** (npm) — Local Ollama HTTP executor + MCP server
 - **`ask-llm-mcp`** (npm, orchestrator) — Auto-detects installed providers and routes
-- **`@ask-llm/plugin`** (Claude Code plugin) — Agents, skills, hooks. Distributed via marketplace.json at repo root.
+- **`@ask-llm/plugin`** (Claude Code plugin) — Agents, skills, hooks. Distributed via `.claude-plugin/marketplace.json` (at repo root), which references the plugin's own manifest at `packages/claude-plugin/.claude-plugin/plugin.json` and the hook script at `packages/claude-plugin/scripts/codex-pair-watch.mjs`.
 
 ## Critical invariants (must NOT be violated)
 
@@ -39,7 +39,7 @@ Yarn workspaces monorepo with these packages:
 - New CLI flags in `buildCodexArgs` that don't also exist in `codexExecutor.ts:buildArgs`.
 - Shell-interpreted subprocess invocations (the variant that takes a single command string) when the safer `spawn` / `execFile` form would suffice.
 - Hand-edited version numbers in any of the three plugin manifests.
-- Test count regression below the current baseline (194 tests as of v0.6.0). Any drop in the suite size relative to `main`'s most recent count requires explicit justification — never silently shrinking tests.
+- Test count regression below `main`'s most recent count. Any drop in suite size requires explicit justification — never silently shrinking tests. (Cite the exact number from the latest commit on `main` rather than hardcoding here, since the baseline drifts with every shipped change.)
 
 ## Things you should NOT complain about
 
@@ -49,8 +49,8 @@ Yarn workspaces monorepo with these packages:
 - **"Why not Jest"** — we use Vitest. Not a regression.
 - **English vs en-dash dashes in docs** — stylistic; not a real concern.
 
-## v0.6.0 release complete
+## Release history
 
-The plugin is at v0.6.0 (PR #64 set the umbrella version). All 10 planned items shipped via PRs #66-#72: log rotation, structured verdicts, expanded skip patterns, default-model drift guard (Phase 1, PR #66); YAML frontmatter config, adaptive context at file-size boundary, `.codex-pair-ignore` (Phase 2, PRs #67-#69); content-hash response cache, log viewer CLI, failure-class retry with jitter (Phase 3, PRs #70-#72). Test count 141 → 194. ADRs 079-082 cover the architectural changes. The next batch (if any) resumes normal per-PR changeset bumping (v0.6.1+ or v0.7.0).
+The plugin is currently at **v0.6.1** (PR #76, marker-resolution from edited file's directory — fixes cross-repo log routing per issue #65). It built on the v0.6.0 umbrella batch (PR #64 set v0.6.0; PRs #66-#72 shipped 10 items: log rotation, structured verdicts, expanded skip patterns, default-model drift guard in Phase 1 PR #66; YAML frontmatter config, adaptive context, `.codex-pair-ignore` in Phase 2 PRs #67-#69; content-hash cache, log viewer CLI, failure-class retry in Phase 3 PRs #70-#72). Test count 141 → 195 across the v0.6.0 batch and the v0.6.1 patch. ADRs 079-082 document the v0.6.0 architectural changes.
 
-**Live dogfooding active**: this hook now reviews every Edit/Write/MultiEdit in this repo. To inspect activity: `node packages/claude-plugin/scripts/codex-pair-log.mjs --summary`.
+**Live dogfooding active** (v0.6.1, via `.claude/settings.local.json` workaround — see issue #74 for the Claude Code plugin-hook dispatch bug): this hook reviews every Edit/Write/MultiEdit in this repo, with marker resolution anchored to the edited file's directory (not cwd) — so cross-repo edits land logs at the correct project. To inspect activity: `node packages/claude-plugin/scripts/codex-pair-log.mjs --summary`.

--- a/apps/docs/plugin/hooks.md
+++ b/apps/docs/plugin/hooks.md
@@ -138,6 +138,66 @@ Output shape (one line per entry):
 
 Zero workspace imports — runs on a marketplace install with no `node_modules`.
 
+### If the hook isn't firing automatically: the project-settings workaround (issue #74)
+
+Some Claude Code installations don't auto-invoke plugin-declared PostToolUse hooks even though the plugin is correctly installed and `/reload-plugins` reports the hook count. This appears to be a Claude Code platform issue with the plugin-hook dispatch path — see [issue #74](https://github.com/Lykhoyda/ask-llm/issues/74) for the full diagnostic chain. The hook script itself works perfectly when invoked manually or when registered via a `~/.claude/settings.json` / `.claude/settings.local.json` `hooks` block.
+
+**Quick diagnostic**: edit any file under your marker-anchored project. If `.codex-pair-log.jsonl` mtime doesn't advance within ~60s, you're hitting the dispatch bug.
+
+**Workaround**: add a `hooks.PostToolUse` block to your **project-local** `.claude/settings.local.json` (per-developer; gitignored by convention) that invokes the hook script directly, bypassing the plugin-dispatch path. Pick the command form that matches your use case:
+
+### Form A — Plugin maintainer (you're working on the ask-llm repo itself)
+
+Point at the local repo source. Always reflects your current branch's working tree, so you're dogfooding the code you're actually writing — and no manual update needed on version bumps:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node /absolute/path/to/ask-llm/packages/claude-plugin/scripts/codex-pair-watch.mjs"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Form B — Plugin user (you installed via marketplace)
+
+Resolve the highest semver-sorted version from the cache at invocation time, so the workaround keeps working across plugin updates without manual edits:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'V=$(ls -1d $HOME/.claude/plugins/cache/ask-llm-plugins/ask-llm/*/ 2>/dev/null | sort -V | tail -1); [ -n \"$V\" ] && node \"$V/scripts/codex-pair-watch.mjs\"'"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The `sort -V | tail -1` picks the highest semver directory under the cache. Silent no-op if no install is present.
+
+### After either form
+
+Run `/reload-plugins` to pick up the new hook config. The next Edit/Write/MultiEdit should fire the hook automatically (proven by `codex-pair OK:`/`WARN:` systemMessage in the transcript + a new `.codex-pair-log.jsonl` entry — typical wall clock 5-30s per call).
+
+Note: this workaround is per-developer (project-local) and gitignored. Once Claude Code's plugin-hook dispatch is fixed upstream, you can remove the `hooks` block and rely on the plugin's own registration again.
+
 ## CLI Binaries
 
 The plugin also ships CLI binaries you can call directly from your shell — useful for piping diffs into a provider outside of any hook:


### PR DESCRIPTION
## Summary

Two related cleanups from the v0.6.1 dogfooding session:

### 1. `.codex-pair-context.md` — five drift fixes caught by the hook reviewing itself

While running through the project-settings workaround (because of [#74](https://github.com/Lykhoyda/ask-llm/issues/74)), codex-pair caught five real documentation contradictions in its own context file in five minutes:

- "v0.6.0 release in progress" → "Release history" covering both batches (v0.6.0 complete, v0.6.1 patch current)
- Test-count baseline **de-hardcoded** — went stale through 152 → 194 → 195 across consecutive edits; now points reviewers at `main`'s most recent count instead of a literal that drifts on every shipped change
- Marketplace path corrected — was "marketplace.json at repo root"; actual paths are `.claude-plugin/marketplace.json` (marketplace) and `packages/claude-plugin/.claude-plugin/plugin.json` (plugin)
- "Live dogfooding active" note updated to describe the workaround instead of claiming the plugin path works

Same recall-first catch class ADR-077 calibrated for: cross-cutting consistency contradictions that compile clean and slip past human review.

### 2. `apps/docs/plugin/hooks.md` — workaround documented for both audiences

New "If the hook isn't firing automatically" subsection covers two command forms:

- **Form A (plugin maintainers)**: points at the local repo source — always reflects the working tree, no manual update on version bumps
- **Form B (plugin users)**: shell one-liner that resolves the highest semver-sorted version from the cache at invocation time — keeps working across plugin updates without manual edits

Both forms are placed in `.claude/settings.local.json` (project-local, gitignored per-developer). Links back to #74 for the upstream Claude Code dispatch bug.

## Why this matters

The dogfooding session proved the hook works end-to-end when properly invoked (5 real catches in 5 minutes) AND surfaced a Claude Code platform issue that affects every user installing this plugin. Documenting the workaround unblocks the user-facing experience while we wait on the upstream fix.

## Test plan

- [x] Marker file changes reviewed for consistency (no more internal contradictions)
- [x] Docs site builds (markdown only, no schema changes)
- [x] No code changes / no version bump
- [x] Smoke tests passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)