### PR TITLE
docs(plugin): sharpen codex-pair communication per multi-LLM brainstorm

### DIFF
--- a/apps/docs/plugin/hooks.md
+++ b/apps/docs/plugin/hooks.md
@@ -69,6 +69,7 @@ charge). Concurrent requests are real. URL inputs are untrusted.
 [Add domain invariants Codex can't infer from one file. Examples —
  Security: "all routes check user.role".
  Specs: "protocol XYZ must be followed".
+ State: "cart syncs to localStorage on every mutation".
  Concurrency: "this handler must be idempotent under retry".]
 EOF
 ```

--- a/apps/docs/plugin/hooks.md
+++ b/apps/docs/plugin/hooks.md
@@ -39,7 +39,19 @@ The pre-commit hook is hardcoded to use Gemini via the `gemini` CLI directly. To
 
 > No marker file → the hook exits silently after one `fs.access()` call. **Zero codex calls, zero cost.** This is by design: the hook ships in every plugin install, but does nothing until a project opts in.
 
-The motivation, four-task benchmark, and design rationale are in [ADR-077](https://github.com/Lykhoyda/ask-llm/blob/main/docs/DECISIONS.md). In short: `/codex-review`'s precision filter (confidence ≥ 80) structurally suppresses a class of bug — float-money precision, cross-cutting validation gaps, edge-case clamping — that `codex-pair`'s recall-first HIGH/MED/LOW grading catches. The two surfaces are complementary, not competing.
+**Why this exists** — in the four-task benchmark from [ADR-077](https://github.com/Lykhoyda/ask-llm/blob/main/docs/DECISIONS.md): Claude alone caught **2 of 10** probes; Claude + `/codex-review` caught **7 of 10**; Claude + `codex-pair` caught **10 of 10**. The three probes `/codex-review` missed — float-money precision, validation bypass, edge-case clamping — are exactly the "domain-wrong but won't crash" class its ≥80-confidence precision filter structurally suppresses. `codex-pair`'s recall-first HIGH/MED/LOW grading catches that class. The two surfaces are **complementary, not competing**.
+
+### When to enable it
+
+Decide BEFORE you opt in — the hook costs real money per edit, and the value is highest on code where missed concerns have outsized blast radius.
+
+| Use the hook (recall-first) | Stick with `/codex-review` only (precision-first) |
+|---|---|
+| Money / billing code | Routine PR review |
+| Security-sensitive paths (auth, untrusted input) | Glue code, CRUD, refactors |
+| Implementing a written spec (RFC, protocol) | Cost-sensitive sessions |
+| Concurrency-heavy state management | One comprehensive report is enough |
+| Cost (~$0.04–0.07 per file reviewed) is acceptable | |
 
 ### Enable it
 
@@ -54,8 +66,10 @@ This is a payment-processing service. All currency calculations must
 use integer cents internally (floating-point loses precision on every
 charge). Concurrent requests are real. URL inputs are untrusted.
 
-[Add deployment shape, stated requirements, or threat surface the
-reviewer should know when reasoning about a single file in isolation.]
+[Add domain invariants Codex can't infer from one file. Examples —
+ Security: "all routes check user.role".
+ Specs: "protocol XYZ must be followed".
+ Concurrency: "this handler must be idempotent under retry".]
 EOF
 ```
 
@@ -80,16 +94,6 @@ money, which violates the stated requirement that currency uses
 integer cents. Use integer minor units such as
 `priceCents: z.number().int().nonnegative()`.
 ```
-
-### When to enable it
-
-| Use the hook (recall-first) | Stick with `/codex-review` only (precision-first) |
-|---|---|
-| Money / billing code | Routine PR review |
-| Security-sensitive paths (auth, untrusted input) | Glue code, CRUD, refactors |
-| Implementing a written spec (RFC, protocol) | Cost-sensitive sessions |
-| Concurrency-heavy state management | One comprehensive report is enough |
-| Cost (~$0.04–0.07 per edit) is acceptable | |
 
 ### Disable it
 

--- a/apps/docs/plugin/overview.md
+++ b/apps/docs/plugin/overview.md
@@ -51,9 +51,10 @@ This gives you `gemini:ask-gemini` rather than `plugin:ask-llm:gemini:ask-gemini
 | `/brainstorm` | Multi + Claude Opus | Claude Opus researches the topic against real files in parallel with external providers, then synthesizes findings |
 | `/brainstorm-all` | All + Claude Opus | Brainstorm with all three external providers plus Claude Opus research |
 | `/compare` | Multi (configurable) | Side-by-side raw responses from selected providers — no synthesis, no consensus extraction. Use when you want to see how each provider phrases the same answer |
-| `codex-pair` *(hook, not slash command)* | Codex | **Opt-in continuous review.** Runs after every Edit/Write/MultiEdit when a `.codex-pair/context.md` marker file is present in the project. Complementary to `/codex-review` — see [Hooks](/plugin/hooks#posttooluse-hook-codex-pair-opt-in-continuous-review) |
 
 > `/codex-review`, `/ollama-review`, and `/brainstorm` require the respective CLI tools to be installed and authenticated.
+>
+> Looking for **continuous background review** (not a slash command)? See [`codex-pair`](/plugin/hooks#posttooluse-hook-codex-pair-opt-in-continuous-review) — a PostToolUse hook that runs Codex against every file edit when a project has opted in via a marker file. It's the recall-first complement to `/codex-review`.
 
 ### Agents
 

--- a/apps/docs/plugin/skills.md
+++ b/apps/docs/plugin/skills.md
@@ -145,7 +145,7 @@ EOF
 
 Once the marker exists at the project root, every file edit triggers a Codex review with the marker's content as project context. `rm -rf .codex-pair/` to disable.
 
-**How it differs from `/codex-review`** — in the [ADR-077](https://github.com/Lykhoyda/ask-llm/blob/main/docs/DECISIONS.md) four-task benchmark: Claude alone caught **2/10** probes; +`/codex-review` caught **7/10**; +`codex-pair` caught **10/10**. The three probes `/codex-review` missed (float-money precision, validation bypass, edge-case clamping) are the "domain-wrong but won't crash" class its ≥80-confidence filter structurally suppresses.
+**How it differs from `/codex-review`** — in the [ADR-077](https://github.com/Lykhoyda/ask-llm/blob/main/docs/DECISIONS.md) four-task benchmark: Claude alone caught **2 of 10** probes; Claude + `/codex-review` caught **7 of 10**; Claude + `codex-pair` caught **10 of 10**. The three probes `/codex-review` missed (float-money precision, validation bypass, edge-case clamping) are the "domain-wrong but won't crash" class its ≥80-confidence filter structurally suppresses. The two surfaces are complementary, not competing.
 
 | Use `/codex-review` (precision-first) | Use `codex-pair` (recall-first) |
 |---|---|
@@ -154,5 +154,3 @@ Once the marker exists at the project root, every file edit triggers a Codex rev
 | You want one comprehensive report | Implementing a written spec (RFC, protocol) |
 | You're cost-sensitive (~$0.04 per review) | Concurrency-heavy state management |
 | Default for everything | Cost (~$0.04–0.07 per file reviewed) is acceptable |
-
-The empirical finding: `/codex-review`'s "confidence ≥ 80" filter structurally suppresses domain-level "this is wrong but won't crash" issues (float-money precision, cross-cutting validation gaps, edge-case clamping). `codex-pair`'s HIGH/MED/LOW threshold catches them. Different classes of bug — the two surfaces are complementary.

--- a/apps/docs/plugin/skills.md
+++ b/apps/docs/plugin/skills.md
@@ -138,13 +138,14 @@ cat > .codex-pair/context.md <<'EOF'
 This is a payment-processing service. Currency must use integer cents.
 Concurrent requests are real. URL inputs are untrusted.
 
-[Add deployment shape, stated requirements, or threat surface here.]
+[Add domain invariants Codex can't infer from one file — e.g.
+"all routes check user.role", "handler must be idempotent under retry".]
 EOF
 ```
 
 Once the marker exists at the project root, every file edit triggers a Codex review with the marker's content as project context. `rm -rf .codex-pair/` to disable.
 
-**How it differs from `/codex-review`** (see [ADR-077](https://github.com/Lykhoyda/ask-llm/blob/main/docs/DECISIONS.md) for the four-task benchmark):
+**How it differs from `/codex-review`** — in the [ADR-077](https://github.com/Lykhoyda/ask-llm/blob/main/docs/DECISIONS.md) four-task benchmark: Claude alone caught **2/10** probes; +`/codex-review` caught **7/10**; +`codex-pair` caught **10/10**. The three probes `/codex-review` missed (float-money precision, validation bypass, edge-case clamping) are the "domain-wrong but won't crash" class its ≥80-confidence filter structurally suppresses.
 
 | Use `/codex-review` (precision-first) | Use `codex-pair` (recall-first) |
 |---|---|
@@ -152,6 +153,6 @@ Once the marker exists at the project root, every file edit triggers a Codex rev
 | Glue code, CRUD, refactors | Security-sensitive paths |
 | You want one comprehensive report | Implementing a written spec (RFC, protocol) |
 | You're cost-sensitive (~$0.04 per review) | Concurrency-heavy state management |
-| Default for everything | Cost is acceptable (~$0.20 per edit pass) |
+| Default for everything | Cost (~$0.04–0.07 per file reviewed) is acceptable |
 
 The empirical finding: `/codex-review`'s "confidence ≥ 80" filter structurally suppresses domain-level "this is wrong but won't crash" issues (float-money precision, cross-cutting validation gaps, edge-case clamping). `codex-pair`'s HIGH/MED/LOW threshold catches them. Different classes of bug — the two surfaces are complementary.

--- a/packages/claude-plugin/README.md
+++ b/packages/claude-plugin/README.md
@@ -34,7 +34,6 @@ claude mcp add --scope user ollama -- npx -y ask-ollama-mcp
 | `/multi-review` | Parallel Gemini + Codex review with 4-phase validation pipeline and consensus highlighting |
 | `/gemini-review` | Gemini-only code review with confidence filtering |
 | `/codex-review` | Codex-only code review (precision-first, ≥80 confidence — default for routine PR review) |
-| `/codex-pair` | **Recall-first** continuous review via PostToolUse hook — opt-in per project via `.codex-pair/context.md` marker file. Complement to `/codex-review` for money/security/spec-implementing code (see [ADR-077](../../docs/DECISIONS.md), layout per [ADR-092](../../docs/DECISIONS.md)) |
 | `/ollama-review` | Local review — no data leaves your machine |
 | `/brainstorm` | Multi-LLM brainstorm with Claude Opus as a first-class research participant (default external: gemini,codex) |
 | `/brainstorm-all` | Brainstorm with all three external providers + Claude Opus research |
@@ -58,7 +57,9 @@ claude mcp add --scope user ollama -- npx -y ask-ollama-mcp
 
 ## Enabling codex-pair mode
 
-The `codex-pair` hook is loaded by default but **self-gates on a marker file**. Without the marker, every edit triggers one `fs.access()` call and exits — zero codex calls, zero cost.
+`codex-pair` is a **PostToolUse hook**, not a slash command — it runs continuously after every file edit when opted in, and is the recall-first complement to `/codex-review`. In the four-task benchmark from [ADR-077](../../docs/DECISIONS.md): Claude alone caught **2 of 10** probes; Claude + `/codex-review` caught **7 of 10**; Claude + `codex-pair` caught **10 of 10**. The three probes `/codex-review` missed (float-money precision, validation bypass, edge-case clamping) are exactly the "domain-wrong but won't crash" class its ≥80-confidence precision filter structurally suppresses.
+
+The hook is loaded by default but **self-gates on a marker file**. Without the marker, every edit triggers one `fs.access()` call and exits — zero codex calls, zero cost.
 
 To enable for a project:
 
@@ -71,10 +72,12 @@ This is a payment-processing service. Currency must use integer cents
 (floats lose precision on every charge). Concurrent requests are real.
 URL inputs are untrusted.
 
-[Add deployment shape, stated requirements, or threat surface the
-reviewer should know.]
+[Add domain invariants Codex can't infer from one file — e.g.
+"all routes check user.role", "handler must be idempotent under retry".]
 EOF
 ```
+
+**Do not commit `.codex-pair/`** — gitignore it. The hook ships with the plugin (project policy); the marker is each developer's own activation switch and review context. A single `.codex-pair/` line in `.gitignore` covers the marker, log, cache, and all state files (see [ADR-092](../../docs/DECISIONS.md)).
 
 Once present, every Edit/Write/MultiEdit triggers a Codex review of the file with the marker's content as project context. HIGH and MED concerns appear to Claude as system reminders on the next turn; LOW concerns are logged to `.codex-pair/log.jsonl` but suppressed from surfacing.
 

--- a/packages/claude-plugin/skills/codex-pair/SKILL.md
+++ b/packages/claude-plugin/skills/codex-pair/SKILL.md
@@ -18,7 +18,7 @@ This is NOT a slash command you invoke. It's a hook that runs automatically when
 | Glue code, CRUD, refactors | Security-sensitive paths (auth, untrusted input) |
 | You want one comprehensive report | Implementing a written spec (RFC, protocol) |
 | You're cost-sensitive (~$0.04/review) | Concurrency-heavy state management |
-| Default for everything | Cost is acceptable (~$0.20/edit pass) |
+| Default for everything | Cost (~$0.04–0.07 per file reviewed) is acceptable |
 
 The empirical finding from the 4-task benchmark: `/codex-review`'s "confidence ≥ 80" filter structurally suppresses domain-level "this is wrong but won't crash" issues (float-money precision, cross-cutting validation gaps, edge-case clamping). codex-pair's HIGH/MED/LOW threshold catches them. Different classes of bug, not the same class with different completeness.
 
@@ -33,8 +33,12 @@ This is a payment-processing service. All currency calculations must use
 integer cents internally (floating-point loses precision on every charge).
 Concurrent requests are real. URL inputs are untrusted.
 
-[Add any deployment shape, stated requirements, or threat surface the
-reviewer should know when reasoning about a single file in isolation.]
+[Add domain invariants Codex can't infer from one file in isolation.
+Examples —
+ Security: "all routes check user.role before any state read".
+ Specs: "protocol XYZ frame format must include version byte".
+ State: "cart syncs to localStorage on every mutation".
+ Concurrency: "this handler must be idempotent under retry".]
 ```
 
 The hook is always loaded by the plugin, but **self-gates on this file's presence**. No file → silent no-op (zero codex calls, zero cost). File present → every Edit/Write/MultiEdit triggers a codex review.


### PR DESCRIPTION
## Summary

Synthesized doc improvements from a Codex + Gemini + Claude Opus brainstorm on how `codex-pair` is communicated across five surfaces (README, hooks.md, overview.md, skills.md, SKILL.md). Six consensus weaknesses identified, all addressed in this PR. No source code changed.

## The brainstorm findings, in priority order

| # | Weakness | Fix | Identified by |
|---|---|---|---|
| 1 | The empirical ROI (2/10 → 7/10 → 10/10) was buried behind an ADR-077 hyperlink on every page | Inline the actual benchmark numbers in README, hooks.md, and skills.md callouts | Consensus (Codex, Gemini, Claude) |
| 2 | `codex-pair` listed in BOTH the Skills table AND the Hooks table (with apologetic *(hook, not slash command)* parenthetical) | Remove from Skills table; add redirect callout in overview.md | Consensus (Codex, Gemini, Claude) |
| 3 | No "do not commit `.codex-pair/`" warning in README — a team installing via README could commit one dev's marker | Mirror hooks.md's warning into README | Codex + Claude |
| 4 | hooks.md gave the curl-style enable snippet BEFORE the decision frame | Reorder: When-to-enable → Enable-it | Gemini + Claude |
| 5 | Cost figures contradicted: SKILL.md said `~$0.20/edit pass`, README/hooks.md said `~$0.04–0.07 per file reviewed` | Reconcile to per-file figure (empirically benchmarked) across all 5 surfaces | Claude only (externals each read a subset of surfaces) |
| 6 | Marker placeholder was generic abstract noun phrase: `[Add deployment shape, stated requirements, or threat surface]` | Replace with categorized concrete invariant examples — Security/Specs/State/Concurrency in long form, two-example terse form in compact contexts | Combined Codex + Gemini synthesis |

## Diff shape

```
 apps/docs/plugin/hooks.md                         | 30 +++++++++++++----------
 apps/docs/plugin/overview.md                      |  3 ++-
 apps/docs/plugin/skills.md                        |  7 +++---
 packages/claude-plugin/README.md                  | 11 ++++++---
 packages/claude-plugin/skills/codex-pair/SKILL.md | 10 +++++---
 5 files changed, 37 insertions(+), 24 deletions(-)
```

## Why brainstorm before editing?

A docs PR by the original author tends to rewrite docs in the order the *implementation* unfolded, not the order a *reader* needs. Dispatching Codex + Gemini + Claude Opus against the current state — each reading the actual files independently — surfaced four weaknesses three providers agreed on plus one (cost-figure contradiction) that only a cross-surface read could catch. The brainstorm synthesis is captured in the commit message footnotes.

## Test plan

- [x] `yarn workspace @ask-llm/plugin run test` — 230/230 passing
- [x] `yarn lint` — clean across 6 workspaces; structural-pin tests (which grep source for ADR invariants) all hold
- [x] All 5 surfaces now agree on `~$0.04–0.07 per file reviewed` for codex-pair; the two remaining `~$0.04/review` figures are for `/codex-review` (a different tool — single comprehensive diff review), correctly differentiated
- [ ] Visual VitePress preview: `yarn docs:dev` and walk through the Plugin → Hooks page to verify the section reorder reads cleanly
- [ ] Read README end-to-end as a first-time evaluator — does the value prop land in the first 90 seconds?

🤖 Generated with [Claude Code](https://claude.com/claude-code)