### PR TITLE
test(plugin): lock ADR-092 containment invariant via end-to-end regression test

### DIFF
--- a/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
+++ b/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
@@ -1323,6 +1323,37 @@ describe("scripts/codex-pair-watch.mjs — runtime behavior (no codex calls)", (
     expect(content).toMatch(/FAKE_CODEX_SCENARIO/);
   });
 
+  // ADR-092 containment invariant. Every artifact the hook produces (log,
+  // cache, inflight lock, pause sentinel, broker descriptor) must live under
+  // `<markerDir>/.codex-pair/`. Earlier intermediate dev states have leaked
+  // `log.jsonl` and `cache/` into the repo root because a code path bypassed
+  // the state.mjs resolvers; this test exercises the full hook pipeline with
+  // the fake-codex fixture and asserts nothing escapes the directory.
+  it("ADR-092 containment: hook writes only under <markerDir>/.codex-pair/, never to cwd or markerDir top-level", () => {
+    setupMarker(tempDir, "# ctx");
+    const filePath = path.join(tempDir, "src.ts");
+    fs.writeFileSync(filePath, "export const x = 1;");
+    const payload = JSON.stringify({
+      tool_name: "Edit",
+      tool_input: { file_path: filePath },
+    });
+    const result = runHookWithFakeCodex(payload, tempDir, "concerns-labeled");
+    expect(result.status).toBe(0);
+    // Top-level invariant: only the source file we created + `.codex-pair/`.
+    // No `log.jsonl`, no `cache/`, no `state/`, no `ignore` at top level.
+    const top = fs.readdirSync(tempDir).sort();
+    expect(top).toEqual([".codex-pair", "src.ts"]);
+    // Sanity: legitimate artifacts ARE under .codex-pair/ (proves the hook
+    // actually ran, not that it crashed silently before any write).
+    const pairContents = fs.readdirSync(path.join(tempDir, ".codex-pair"));
+    expect(pairContents).toContain("context.md");
+    expect(pairContents).toContain("log.jsonl");
+    // Cache shard appears for any review that produced concerns. Use
+    // existsSync rather than toContain because the directory is what we
+    // care about, not specific shard names.
+    expect(fs.existsSync(path.join(tempDir, ".codex-pair", "cache"))).toBe(true);
+  });
+
   it("fake-codex 'none' scenario → verdict:none + OK systemMessage + log entry", () => {
     setupMarker(tempDir, "# ctx");
     const filePath = path.join(tempDir, "src.ts");


### PR DESCRIPTION
## Summary

Adds a runtime regression test that asserts the codex-pair hook **never writes any artifact outside `<markerDir>/.codex-pair/`**.

This locks the ADR-092 containment invariant against future regressions. Earlier today during the layout consolidation, an intermediate dev state leaked `log.jsonl` and `cache/` to the repo root (the catch handler fired during a mid-rename ReferenceError window). Current code can't reproduce it — every write routes through `state.mjs`'s markerDir-rooted resolvers — but the invariant was only enforced by careful review, not by a test. This commit closes that gap.

## Audit of current code (verified against ground truth)

- **All filesystem writes** in `packages/claude-plugin/scripts/lib/state.mjs` (`logPath`, `cacheRoot`, `inflightRoot`, `pausePath`) compose `markerDir` + `.codex-pair/` via the `pairRoot()` resolver. No bare paths possible.
- **Catch handler** at `codex-pair-watch.mjs:947` gates on `if (markerDir)` before any `appendLog` call. Returns silently if the marker isn't found.
- **`.gitignore`** line 56 has `.codex-pair/` — one entry covers every state artifact per ADR-092 (marker, log, cache, ignore globs, pause sentinel, inflight locks, broker descriptor).
- **No bare path literals** (`cache/`, `log.jsonl`, `state/`) anywhere in `scripts/`.
- **The orphan `cache/` directory** still visible at the repo root is leftover from a different tool (not codex-pair — no code path can create a bare `cache/` in current code). It's empty as of this PR; safe to `rm -rf cache/` manually.

## The new test

```typescript
it("ADR-092 containment: hook writes only under <markerDir>/.codex-pair/, never to cwd or markerDir top-level", () => {
  setupMarker(tempDir, "# ctx");
  const filePath = path.join(tempDir, "src.ts");
  fs.writeFileSync(filePath, "export const x = 1;");
  const payload = JSON.stringify({
    tool_name: "Edit",
    tool_input: { file_path: filePath },
  });
  const result = runHookWithFakeCodex(payload, tempDir, "concerns-labeled");
  expect(result.status).toBe(0);
  const top = fs.readdirSync(tempDir).sort();
  expect(top).toEqual([".codex-pair", "src.ts"]);
  // ... sanity that artifacts ARE under .codex-pair/
});
```

Exercises the full hook pipeline (marker resolution → cache check → codex spawn → JSONL parse → verdict classification → log + cache write) via the fake-codex fixture — deterministic, no real API calls.

This is a **runtime invariant test**, complementary to existing **structural-pin tests** that grep `state.mjs` source for resolver composition. Two layers: structural pins catch deletion of guard code; runtime tests catch new code that bypasses the guard. Belt and suspenders.

## Test plan

- [x] Plugin tests: 230 → 231 passing
- [x] Lint clean across 6 workspaces
- [x] Test runs in <100ms (uses fake-codex fixture, no real API call)
- [x] Test failure points directly at the offending write site (any leaked filename will show in the `top` array assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)