### PR TITLE
feat(plugin): codex-pair broker transport + JSON-RPC client (M2 PR 1, ADR-093)

### DIFF
--- a/packages/claude-plugin/scripts/lib/broker-rpc.mjs
+++ b/packages/claude-plugin/scripts/lib/broker-rpc.mjs
@@ -1,0 +1,138 @@
+// JSON-RPC 2.0 client layered on a `broker-transport.mjs` connection
+// (ADR-090 + ADR-093 Milestone 2 PR 1). The transport emits WebSocket
+// TEXT frames whose payloads are JSON-RPC envelopes; this module handles
+// request/response correlation by `id`, per-request timeouts, server-
+// pushed notifications, and graceful close.
+//
+// **Tolerance.** Brainstorm probing of the real `codex app-server`
+// (codex-cli 0.130.0) found that responses lack the `"jsonrpc":"2.0"`
+// discriminator (ADR-093 protocol note). This client accepts envelopes
+// with OR without that field; it dispatches purely on the `id` and
+// `method` properties.
+
+// Auto-incrementing request id source. JSON-RPC permits any unique
+// non-null id; integers are simplest. Not cryptographic — exposing the
+// counter doesn't leak anything.
+let nextId = 1;
+function takeNextId() {
+  const id = nextId;
+  nextId = (nextId + 1) | 0; // wrap at 2^31 (effectively never)
+  if (nextId <= 0) nextId = 1;
+  return id;
+}
+
+// Create a JSON-RPC client over a connected `broker-transport.mjs`
+// WebSocketConnection. The caller is responsible for `connection.close()`.
+// This client manages the protocol layer on top, not the socket lifetime.
+//
+// Options:
+//   - defaultTimeoutMs (number, default 30000): per-request budget.
+//   - onNotification (function, default no-op): called with
+//     `{ method, params }` for server-pushed notifications (envelopes
+//     lacking an `id`).
+//   - onProtocolError (function, default no-op): called when an inbound
+//     text frame can't be parsed as JSON or has neither id nor method.
+export function createRpcClient(connection, options = {}) {
+  const { defaultTimeoutMs = 30000, onNotification = () => {}, onProtocolError = () => {} } = options;
+  const pending = new Map(); // id -> { resolve, reject, timer }
+  let closed = false;
+
+  connection.on("message", (text) => {
+    let env;
+    try {
+      env = JSON.parse(text);
+    } catch (err) {
+      onProtocolError(new Error(`broker-rpc: malformed JSON from server: ${err?.message ?? String(err)}`));
+      return;
+    }
+    if (env && typeof env === "object" && "id" in env && env.id != null) {
+      const entry = pending.get(env.id);
+      if (!entry) {
+        // Late response after timeout, or an id we didn't send. Ignore;
+        // surface as a soft protocol error for diagnostics.
+        onProtocolError(new Error(`broker-rpc: response for unknown id ${env.id}`));
+        return;
+      }
+      pending.delete(env.id);
+      clearTimeout(entry.timer);
+      if (env.error) {
+        const err = new Error(env.error.message ?? `JSON-RPC error ${env.error.code ?? "?"}`);
+        err.code = env.error.code;
+        err.data = env.error.data;
+        entry.reject(err);
+      } else {
+        entry.resolve(env.result);
+      }
+      return;
+    }
+    if (env && typeof env === "object" && typeof env.method === "string") {
+      // Server-pushed notification (or a server-initiated request, which
+      // codex-pair refuses since approvalPolicy:"never" — but pass it up
+      // either way and let the caller decide).
+      onNotification({ method: env.method, params: env.params, id: env.id });
+      return;
+    }
+    onProtocolError(new Error(`broker-rpc: envelope has neither id nor method: ${text.slice(0, 120)}`));
+  });
+
+  connection.on("close", () => {
+    closed = true;
+    for (const [id, entry] of pending.entries()) {
+      clearTimeout(entry.timer);
+      entry.reject(new Error("broker-rpc: connection closed before response"));
+      pending.delete(id);
+    }
+  });
+
+  connection.on("error", (err) => {
+    // Pending requests still time out via their own timers, but surface
+    // transport errors immediately too.
+    for (const [id, entry] of pending.entries()) {
+      clearTimeout(entry.timer);
+      entry.reject(err);
+      pending.delete(id);
+    }
+  });
+
+  return {
+    request(method, params, opts = {}) {
+      if (closed) return Promise.reject(new Error("broker-rpc: client is closed"));
+      const id = takeNextId();
+      const timeoutMs = opts.timeoutMs ?? defaultTimeoutMs;
+      const envelope = JSON.stringify({ jsonrpc: "2.0", id, method, params });
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          pending.delete(id);
+          reject(new Error(`broker-rpc: timeout after ${timeoutMs}ms (method=${method}, id=${id})`));
+        }, timeoutMs);
+        timer.unref?.();
+        pending.set(id, { resolve, reject, timer });
+        try {
+          connection.sendText(envelope);
+        } catch (err) {
+          pending.delete(id);
+          clearTimeout(timer);
+          reject(err);
+        }
+      });
+    },
+    notify(method, params) {
+      // Notifications have no id and expect no response.
+      if (closed) throw new Error("broker-rpc: client is closed");
+      connection.sendText(JSON.stringify({ jsonrpc: "2.0", method, params }));
+    },
+    get pendingCount() {
+      return pending.size;
+    },
+    get closed() {
+      return closed;
+    },
+  };
+}
+
+// Exports for tests
+export const __testing__ = {
+  resetIdCounter() {
+    nextId = 1;
+  },
+};

--- a/packages/claude-plugin/scripts/lib/broker-transport.mjs
+++ b/packages/claude-plugin/scripts/lib/broker-transport.mjs
@@ -1,0 +1,349 @@
+// WebSocket-over-net transport for the codex-pair broker (ADR-090 + ADR-093
+// Milestone 2 PR 1). Minimal hand-rolled RFC 6455 client supporting both
+// unix-domain-socket (`unix://`) and TCP (`ws://`) transports through one
+// code path. Pure Node built-ins per ADR-078 — no `ws` package, no
+// workspace imports.
+//
+// **Scope discipline.** This is the smallest subset of RFC 6455 that
+// satisfies codex `app-server`'s usage:
+//   - Single client connection, no multiplexing.
+//   - TEXT opcode (0x1) for JSON-RPC frames, no BINARY, no fragmentation.
+//   - Client masks all frames (RFC 6455 §5.3). Server does not.
+//   - Auto-respond to server PING with PONG mirroring the payload.
+//   - Send CLOSE (0x8) on `close()`, handle inbound CLOSE.
+//   - No permessage-deflate or other extensions.
+//   - No subprotocols.
+//
+// **Tolerance.** codex app-server's JSON-RPC responses observed in the
+// wild lack the `"jsonrpc":"2.0"` discriminator (verified by brainstorm
+// probing — see ADR-093 protocol notes). The JSON parsing here passes
+// raw text up; the RPC layer in `broker-rpc.mjs` does the tolerant
+// matching by id.
+
+import { Buffer } from "node:buffer";
+import { createHash, randomBytes } from "node:crypto";
+import { connect } from "node:net";
+
+// RFC 6455 frame opcodes we recognize.
+const OPCODE_CONTINUATION = 0x0;
+const OPCODE_TEXT = 0x1;
+const OPCODE_BINARY = 0x2;
+const OPCODE_CLOSE = 0x8;
+const OPCODE_PING = 0x9;
+const OPCODE_PONG = 0xa;
+
+// RFC 6455 magic GUID for the Sec-WebSocket-Accept derivation (§4.2.2).
+const WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+// Parse a transport URL into `net.connect` options. Supports:
+//   unix:///absolute/path/to/socket
+//   unix://relative/from/cwd
+//   ws://host:port           — also accepts host without port (defaults 80)
+// Returns `{ connectOptions, host, isUnix }`.
+export function parseTransportUrl(url) {
+  if (typeof url !== "string") {
+    throw new TypeError(`broker-transport: transport URL must be string, got ${typeof url}`);
+  }
+  if (url.startsWith("unix://")) {
+    const path = url.slice("unix://".length);
+    if (!path) throw new Error(`broker-transport: unix:// URL has empty path`);
+    return { connectOptions: { path }, host: "localhost", isUnix: true };
+  }
+  if (url.startsWith("ws://")) {
+    const rest = url.slice("ws://".length);
+    const slashIdx = rest.indexOf("/");
+    const authority = slashIdx === -1 ? rest : rest.slice(0, slashIdx);
+    const colonIdx = authority.lastIndexOf(":");
+    const host = colonIdx === -1 ? authority : authority.slice(0, colonIdx);
+    const port = colonIdx === -1 ? 80 : Number(authority.slice(colonIdx + 1));
+    if (!Number.isFinite(port) || port <= 0) {
+      throw new Error(`broker-transport: ws:// URL has invalid port: ${authority}`);
+    }
+    return { connectOptions: { host, port }, host: authority, isUnix: false };
+  }
+  throw new Error(`broker-transport: unsupported transport URL scheme: ${url} (need unix:// or ws://)`);
+}
+
+// Build the HTTP/1.1 upgrade request bytes for a given parsed URL. The
+// `Host:` header is required for the HTTP/1.1 framing even when the
+// transport is a unix socket (it's not used for routing but the codex
+// server's upgrade parser requires it). We send a fixed "localhost" for
+// unix sockets and the authority for TCP.
+function buildUpgradeRequest(host, secKey) {
+  return [
+    `GET / HTTP/1.1`,
+    `Host: ${host}`,
+    `Upgrade: websocket`,
+    `Connection: Upgrade`,
+    `Sec-WebSocket-Key: ${secKey}`,
+    `Sec-WebSocket-Version: 13`,
+    ``,
+    ``,
+  ].join("\r\n");
+}
+
+// Validate the server's upgrade response (RFC 6455 §4.1 step 4). The
+// 101 status + Sec-WebSocket-Accept header derived from our Sec-WebSocket-Key
+// are the mandatory checks. We ignore optional fields.
+function validateUpgradeResponse(headerText, sentKey) {
+  const lines = headerText.split("\r\n");
+  if (!lines[0] || !/^HTTP\/1\.[01]\s+101\b/.test(lines[0])) {
+    throw new Error(`broker-transport: upgrade rejected, status line: ${lines[0] ?? "(empty)"}`);
+  }
+  let accept = null;
+  for (let i = 1; i < lines.length; i++) {
+    const colon = lines[i].indexOf(":");
+    if (colon === -1) continue;
+    const name = lines[i].slice(0, colon).trim().toLowerCase();
+    if (name === "sec-websocket-accept") {
+      accept = lines[i].slice(colon + 1).trim();
+      break;
+    }
+  }
+  const expected = createHash("sha1").update(sentKey + WS_GUID).digest("base64");
+  if (accept !== expected) {
+    throw new Error(
+      `broker-transport: Sec-WebSocket-Accept mismatch (got ${accept ?? "(missing)"}, expected ${expected})`,
+    );
+  }
+}
+
+// Encode a TEXT frame. Client frames MUST be masked per RFC 6455 §5.3.
+// Returns a Buffer ready to write to the socket.
+function encodeTextFrame(text) {
+  const payload = Buffer.from(text, "utf-8");
+  const mask = randomBytes(4);
+  const masked = Buffer.allocUnsafe(payload.length);
+  for (let i = 0; i < payload.length; i++) masked[i] = payload[i] ^ mask[i % 4];
+
+  let lenBytes;
+  if (payload.length < 126) {
+    lenBytes = Buffer.from([0x80 | payload.length]); // MASK bit + 7-bit length
+  } else if (payload.length < 0x10000) {
+    lenBytes = Buffer.allocUnsafe(3);
+    lenBytes[0] = 0x80 | 126;
+    lenBytes.writeUInt16BE(payload.length, 1);
+  } else {
+    lenBytes = Buffer.allocUnsafe(9);
+    lenBytes[0] = 0x80 | 127;
+    // 64-bit big-endian. JS BigInt for >32-bit lengths; we cap at Node's
+    // Buffer.allocUnsafe practical limit anyway.
+    lenBytes.writeBigUInt64BE(BigInt(payload.length), 1);
+  }
+
+  return Buffer.concat([
+    Buffer.from([0x80 | OPCODE_TEXT]), // FIN bit + TEXT opcode
+    lenBytes,
+    mask,
+    masked,
+  ]);
+}
+
+// Encode a CLOSE frame with optional status code + reason. Client-masked.
+function encodeCloseFrame(code = 1000, reason = "") {
+  const reasonBuf = Buffer.from(reason, "utf-8");
+  const payload = Buffer.allocUnsafe(2 + reasonBuf.length);
+  payload.writeUInt16BE(code, 0);
+  reasonBuf.copy(payload, 2);
+  const mask = randomBytes(4);
+  const masked = Buffer.allocUnsafe(payload.length);
+  for (let i = 0; i < payload.length; i++) masked[i] = payload[i] ^ mask[i % 4];
+  return Buffer.concat([
+    Buffer.from([0x80 | OPCODE_CLOSE, 0x80 | payload.length]),
+    mask,
+    masked,
+  ]);
+}
+
+// Encode a PONG frame echoing the server's PING payload. Client-masked.
+function encodePongFrame(payload) {
+  const mask = randomBytes(4);
+  const masked = Buffer.allocUnsafe(payload.length);
+  for (let i = 0; i < payload.length; i++) masked[i] = payload[i] ^ mask[i % 4];
+  // Control frames have payload < 126 (RFC 6455 §5.5).
+  return Buffer.concat([
+    Buffer.from([0x80 | OPCODE_PONG, 0x80 | payload.length]),
+    mask,
+    masked,
+  ]);
+}
+
+// Stateful frame parser. Accumulates incoming bytes and emits whole frames
+// via `onFrame({ opcode, payload })`. Caller drains via `feed(chunk)`.
+// Server→client frames are NOT masked, so we ignore the MASK bit on parse.
+function createFrameParser(onFrame, onError) {
+  let buf = Buffer.alloc(0);
+  return (chunk) => {
+    buf = Buffer.concat([buf, chunk]);
+    while (buf.length >= 2) {
+      const first = buf[0];
+      const second = buf[1];
+      const fin = (first & 0x80) !== 0;
+      const opcode = first & 0x0f;
+      let len = second & 0x7f;
+      let offset = 2;
+      if (len === 126) {
+        if (buf.length < 4) return; // need more
+        len = buf.readUInt16BE(2);
+        offset = 4;
+      } else if (len === 127) {
+        if (buf.length < 10) return;
+        // Cast BigInt to Number — control frames have len<126 anyway, and
+        // for data frames we cap at safe-integer range. 2GB payload is far
+        // larger than any conceivable RPC response.
+        len = Number(buf.readBigUInt64BE(2));
+        offset = 10;
+      }
+      // Per RFC 6455, server→client frames must NOT be masked (we'd see
+      // bit 0x80 set on byte[1]). If we see it, the peer is buggy; just
+      // skip the mask bytes if present.
+      const maskBit = (second & 0x80) !== 0;
+      if (maskBit) offset += 4;
+      if (buf.length < offset + len) return; // need more
+      const payload = buf.slice(offset, offset + len);
+      buf = buf.slice(offset + len);
+      if (!fin && opcode !== OPCODE_CONTINUATION) {
+        // We don't support fragmentation. Codex doesn't fragment small
+        // JSON-RPC frames. Emit an error and move on.
+        onError(new Error(`broker-transport: fragmentation not supported (opcode=${opcode})`));
+        continue;
+      }
+      onFrame({ opcode, payload });
+    }
+  };
+}
+
+// Top-level connector. Returns a Promise<WebSocketConnection> after a
+// successful HTTP upgrade. The connection exposes `sendText(s)`,
+// `close(code?, reason?)`, and event listeners `on("message", cb)` /
+// `on("close", cb)` / `on("error", cb)`.
+//
+// **Timeout semantics.** Connect + upgrade must complete within
+// `handshakeTimeoutMs` (default 5000). On timeout, the underlying socket
+// is destroyed and the promise rejects. After upgrade success, the caller
+// owns the connection's lifetime.
+export async function connectWebSocket(transportUrl, options = {}) {
+  const { handshakeTimeoutMs = 5000 } = options;
+  const { connectOptions, host } = parseTransportUrl(transportUrl);
+
+  return new Promise((resolve, reject) => {
+    const socket = connect(connectOptions);
+    const listeners = { message: [], close: [], error: [] };
+    let upgraded = false;
+    let headerBuf = Buffer.alloc(0);
+    let parser = null;
+
+    const timer = setTimeout(() => {
+      if (!upgraded) {
+        socket.destroy();
+        reject(new Error(`broker-transport: handshake timeout after ${handshakeTimeoutMs}ms`));
+      }
+    }, handshakeTimeoutMs);
+    timer.unref?.();
+
+    const secKey = randomBytes(16).toString("base64");
+
+    socket.once("error", (err) => {
+      if (!upgraded) {
+        clearTimeout(timer);
+        reject(err);
+      } else {
+        for (const cb of listeners.error) cb(err);
+      }
+    });
+
+    socket.once("close", () => {
+      clearTimeout(timer);
+      if (!upgraded) reject(new Error("broker-transport: socket closed before upgrade"));
+      else for (const cb of listeners.close) cb();
+    });
+
+    socket.on("data", (chunk) => {
+      if (upgraded) {
+        parser(chunk);
+        return;
+      }
+      headerBuf = Buffer.concat([headerBuf, chunk]);
+      const end = headerBuf.indexOf("\r\n\r\n");
+      if (end === -1) return;
+      const headerText = headerBuf.slice(0, end).toString("utf-8");
+      const tail = headerBuf.slice(end + 4);
+      try {
+        validateUpgradeResponse(headerText, secKey);
+      } catch (err) {
+        socket.destroy();
+        clearTimeout(timer);
+        reject(err);
+        return;
+      }
+      upgraded = true;
+      clearTimeout(timer);
+      parser = createFrameParser(
+        ({ opcode, payload }) => {
+          if (opcode === OPCODE_TEXT) {
+            const text = payload.toString("utf-8");
+            for (const cb of listeners.message) cb(text);
+          } else if (opcode === OPCODE_PING) {
+            // Auto-respond with PONG mirroring the payload (RFC §5.5.2).
+            socket.write(encodePongFrame(payload));
+          } else if (opcode === OPCODE_CLOSE) {
+            // Echo close + half-close (RFC §5.5.1).
+            try {
+              socket.write(encodeCloseFrame(1000, ""));
+            } catch {
+              // best-effort
+            }
+            socket.end();
+          } else if (opcode === OPCODE_BINARY) {
+            // codex doesn't send binary for JSON-RPC; ignore silently.
+          }
+          // PONG and CONTINUATION are no-ops here.
+        },
+        (err) => {
+          for (const cb of listeners.error) cb(err);
+        },
+      );
+
+      const conn = {
+        sendText(text) {
+          socket.write(encodeTextFrame(text));
+        },
+        close(code = 1000, reason = "") {
+          try {
+            socket.write(encodeCloseFrame(code, reason));
+          } catch {
+            // best-effort — caller treats close as fire-and-forget
+          }
+          socket.end();
+        },
+        on(event, cb) {
+          if (!listeners[event]) throw new Error(`broker-transport: unknown event ${event}`);
+          listeners[event].push(cb);
+        },
+        get destroyed() {
+          return socket.destroyed;
+        },
+        // For tests / diagnostics
+        _underlyingSocket() {
+          return socket;
+        },
+      };
+
+      // If the upgrade response had body bytes already buffered, feed them.
+      if (tail.length > 0) parser(tail);
+
+      resolve(conn);
+    });
+  });
+}
+
+// Exports for tests
+export const __testing__ = {
+  encodeTextFrame,
+  encodeCloseFrame,
+  encodePongFrame,
+  createFrameParser,
+  validateUpgradeResponse,
+  buildUpgradeRequest,
+  WS_GUID,
+};

--- a/packages/claude-plugin/scripts/lib/broker.mjs
+++ b/packages/claude-plugin/scripts/lib/broker.mjs
@@ -23,6 +23,8 @@
 //   - Health probe: `model/list` (cheap) or `initialize` with deadline
 
 import { join } from "node:path";
+import { connectWebSocket } from "./broker-transport.mjs";
+import { createRpcClient } from "./broker-rpc.mjs";
 
 // State file under <markerDir>/.codex-pair/state/ (ADR-092).
 export const BROKER_STATE_FILE = "broker.json";
@@ -144,14 +146,85 @@ export function clearStaleBrokerState(_markerDir) {
   // (per the configured policy).
 }
 
-// Health-probe stub. Real implementation (Milestone 3) will open the
-// transport (unix socket or websocket), send `model/list` (cheap, no side
-// effects), wait up to BROKER_HEALTH_TIMEOUT_MS for a response, and
-// return boolean. `model/list` is preferred over `initialize` for the
-// probe because initialize has side effects (allocates a connection
-// context); model/list is idempotent and lighter.
-export async function probeBrokerHealth(_state) {
-  return false;
+// Open a transport connection to a running broker, perform the JSON-RPC
+// `initialize` handshake, and return `{ connection, rpc, initializeResult }`.
+// Caller owns connection lifetime — call `connection.close()` and stop
+// using `rpc` when done. On any failure (transport error, handshake
+// timeout, initialize rejection) this rejects; caller falls back to the
+// per-edit spawn path per ADR-077.
+//
+// `clientInfo` is the InitializeParams.clientInfo object — codex-cli
+// 0.130.0 requires `{ name, title, version }` (brainstorm-verified;
+// ADR-093 protocol note). Callers should pass real plugin identity.
+export async function initializeBroker(transportUrl, clientInfo, options = {}) {
+  const { handshakeTimeoutMs = 5000, initializeTimeoutMs = 5000 } = options;
+  const connection = await connectWebSocket(transportUrl, { handshakeTimeoutMs });
+  const rpc = createRpcClient(connection, { defaultTimeoutMs: initializeTimeoutMs });
+  try {
+    const initializeResult = await rpc.request(
+      JSONRPC_METHODS.INITIALIZE,
+      { clientInfo },
+      { timeoutMs: initializeTimeoutMs },
+    );
+    return { connection, rpc, initializeResult };
+  } catch (err) {
+    try {
+      connection.close(1011, "initialize failed");
+    } catch {
+      // already torn down
+    }
+    throw err;
+  }
+}
+
+// Health probe: open the transport, send `model/list` (idempotent, cheap),
+// wait up to BROKER_HEALTH_TIMEOUT_MS for a response. Returns boolean.
+// Never throws — callers in the hook path treat any failure as "broker
+// unreachable, fall back to per-edit spawn" per ADR-077.
+//
+// `state` is the broker descriptor read from .codex-pair/state/broker.json
+// (shape: `{ transportUrl, pid, codexVersion, protocolVersion, startedAt }`).
+// Health probe uses transportUrl + initializes ad-hoc because the long-
+// lived connection lives in the per-edit hook process, not here.
+//
+// Implementation note: model/list is preferred over `initialize` for the
+// probe because the brainstorm verified that codex's `initialize` is
+// metadata-rich + always-succeeds. `model/list` exercises the actual
+// JSON-RPC plumbing AND validates that the broker can complete a real
+// request — a stricter health signal.
+export async function probeBrokerHealth(state) {
+  if (!state || typeof state.transportUrl !== "string") return false;
+  let connection;
+  let rpc;
+  try {
+    connection = await connectWebSocket(state.transportUrl, {
+      handshakeTimeoutMs: BROKER_HEALTH_TIMEOUT_MS,
+    });
+    rpc = createRpcClient(connection, { defaultTimeoutMs: BROKER_HEALTH_TIMEOUT_MS });
+    // `model/list` requires the connection to have completed `initialize`
+    // first per the codex protocol. The PROBE path opens a fresh
+    // connection (no broker-side state shared with the long-lived hook
+    // connection), so we must initialize here before model/list.
+    await rpc.request(
+      JSONRPC_METHODS.INITIALIZE,
+      { clientInfo: { name: "codex-pair-health-probe", title: "codex-pair health probe", version: "0.0.0" } },
+      { timeoutMs: BROKER_HEALTH_TIMEOUT_MS },
+    );
+    await rpc.request(JSONRPC_METHODS.MODEL_LIST, undefined, {
+      timeoutMs: BROKER_HEALTH_TIMEOUT_MS,
+    });
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (connection && !connection.destroyed) {
+      try {
+        connection.close(1000, "probe done");
+      } catch {
+        // best-effort
+      }
+    }
+  }
 }
 
 // Submit-review API. The hook calls this when isBrokerEnabled returns

--- a/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
+++ b/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
@@ -2041,4 +2041,232 @@ describe("scripts/codex-pair-watch.mjs — runtime behavior (no codex calls)", (
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
   });
+
+  // Milestone 2 PR 1: broker-transport + broker-rpc unit tests. Validates
+  // the hand-rolled RFC 6455 frame codec, the upgrade-handshake validator,
+  // and the JSON-RPC request/response correlation. End-to-end integration
+  // against a real `codex app-server` lives in Milestone 4; these are
+  // protocol-layer correctness pins.
+
+  it("ADR-093 transport: parseTransportUrl handles unix:// and ws:// schemes", async () => {
+    const { parseTransportUrl } = await import("../../scripts/lib/broker-transport.mjs");
+    const unix = parseTransportUrl("unix:///tmp/foo.sock");
+    expect(unix.isUnix).toBe(true);
+    expect(unix.connectOptions.path).toBe("/tmp/foo.sock");
+    const tcp = parseTransportUrl("ws://127.0.0.1:4500");
+    expect(tcp.isUnix).toBe(false);
+    expect(tcp.connectOptions.host).toBe("127.0.0.1");
+    expect(tcp.connectOptions.port).toBe(4500);
+  });
+
+  it("ADR-093 transport: parseTransportUrl rejects unsupported schemes", async () => {
+    const { parseTransportUrl } = await import("../../scripts/lib/broker-transport.mjs");
+    expect(() => parseTransportUrl("http://x.com")).toThrow(/unsupported transport URL scheme/);
+    expect(() => parseTransportUrl("wss://x.com")).toThrow(/unsupported transport URL scheme/);
+    expect(() => parseTransportUrl("unix://")).toThrow(/empty path/);
+    expect(() => parseTransportUrl("ws://host:notanumber")).toThrow(/invalid port/);
+  });
+
+  it("ADR-093 transport: encodeTextFrame produces masked TEXT frame with FIN bit", async () => {
+    const { __testing__ } = await import("../../scripts/lib/broker-transport.mjs");
+    const frame = __testing__.encodeTextFrame("hi");
+    // Byte 0: 0x80 (FIN) | 0x01 (TEXT) = 0x81
+    expect(frame[0]).toBe(0x81);
+    // Byte 1: 0x80 (MASK) | 0x02 (len)
+    expect(frame[1]).toBe(0x82);
+    // Bytes 2..5: 4-byte mask key. Bytes 6..7: masked payload.
+    const mask = frame.slice(2, 6);
+    const payload = frame.slice(6, 8);
+    const unmasked = Buffer.from([payload[0] ^ mask[0], payload[1] ^ mask[1]]);
+    expect(unmasked.toString()).toBe("hi");
+  });
+
+  it("ADR-093 transport: createFrameParser decodes unmasked server frames (RFC 6455 §5.3)", async () => {
+    const { __testing__ } = await import("../../scripts/lib/broker-transport.mjs");
+    const frames: Array<{ opcode: number; payload: Buffer }> = [];
+    const parser = __testing__.createFrameParser(
+      (f: { opcode: number; payload: Buffer }) => frames.push(f),
+      () => {},
+    );
+    // Server frame: TEXT, FIN, unmasked, payload "hi"
+    const serverFrame = Buffer.from([0x81, 0x02, 0x68, 0x69]);
+    parser(serverFrame);
+    expect(frames).toHaveLength(1);
+    expect(frames[0].opcode).toBe(0x1);
+    expect(frames[0].payload.toString()).toBe("hi");
+  });
+
+  it("ADR-093 transport: createFrameParser handles 16-bit length encoding", async () => {
+    const { __testing__ } = await import("../../scripts/lib/broker-transport.mjs");
+    const frames: Array<{ opcode: number; payload: Buffer }> = [];
+    const parser = __testing__.createFrameParser(
+      (f: { opcode: number; payload: Buffer }) => frames.push(f),
+      () => {},
+    );
+    // 200-byte payload triggers 16-bit length
+    const body = Buffer.alloc(200, "a");
+    const header = Buffer.from([0x81, 126, 0x00, 0xc8]); // 0xc8 = 200
+    parser(Buffer.concat([header, body]));
+    expect(frames).toHaveLength(1);
+    expect(frames[0].payload.length).toBe(200);
+  });
+
+  it("ADR-093 transport: validateUpgradeResponse accepts valid 101 with correct Accept hash", async () => {
+    const { __testing__ } = await import("../../scripts/lib/broker-transport.mjs");
+    const sentKey = "dGhlIHNhbXBsZSBub25jZQ==";
+    // From RFC 6455 example: SHA1(key + GUID) base64 = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+    const validResponse = [
+      "HTTP/1.1 101 Switching Protocols",
+      "Upgrade: websocket",
+      "Connection: Upgrade",
+      "Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=",
+    ].join("\r\n");
+    expect(() => __testing__.validateUpgradeResponse(validResponse, sentKey)).not.toThrow();
+  });
+
+  it("ADR-093 transport: validateUpgradeResponse rejects bad status + bad Accept hash", async () => {
+    const { __testing__ } = await import("../../scripts/lib/broker-transport.mjs");
+    expect(() => __testing__.validateUpgradeResponse("HTTP/1.1 400 Bad Request", "x")).toThrow(/upgrade rejected/);
+    expect(() =>
+      __testing__.validateUpgradeResponse(
+        "HTTP/1.1 101 Switching Protocols\r\nSec-WebSocket-Accept: WRONG=",
+        "dGhlIHNhbXBsZSBub25jZQ==",
+      ),
+    ).toThrow(/Sec-WebSocket-Accept mismatch/);
+  });
+
+  // Mock-connection helper for broker-rpc tests. Captures `sendText` calls
+  // and exposes a `pushMessage(text)` to simulate inbound frames.
+  function createMockConnection() {
+    const sent: string[] = [];
+    const listeners: Record<string, Array<(arg?: unknown) => void>> = {
+      message: [],
+      close: [],
+      error: [],
+    };
+    return {
+      conn: {
+        sendText: (text: string) => sent.push(text),
+        close: () => {
+          for (const cb of listeners.close) cb();
+        },
+        on: (event: string, cb: (arg?: unknown) => void) => {
+          listeners[event]?.push(cb);
+        },
+        get destroyed() {
+          return false;
+        },
+      },
+      sent,
+      pushMessage(text: string) {
+        for (const cb of listeners.message) cb(text);
+      },
+      pushClose() {
+        for (const cb of listeners.close) cb();
+      },
+      pushError(err: Error) {
+        for (const cb of listeners.error) cb(err);
+      },
+    };
+  }
+
+  it("ADR-093 rpc: request correlates response by id and resolves with result", async () => {
+    const { createRpcClient, __testing__ } = await import("../../scripts/lib/broker-rpc.mjs");
+    __testing__.resetIdCounter();
+    const mock = createMockConnection();
+    // biome-ignore lint/suspicious/noExplicitAny: mock connection shape
+    const rpc = createRpcClient(mock.conn as any, { defaultTimeoutMs: 1000 });
+    const p = rpc.request("model/list", undefined);
+    // The sent envelope should have id=1 (counter reset)
+    expect(mock.sent).toHaveLength(1);
+    const sentEnv = JSON.parse(mock.sent[0]);
+    expect(sentEnv.id).toBe(1);
+    expect(sentEnv.method).toBe("model/list");
+    // Simulate the server response
+    mock.pushMessage(JSON.stringify({ id: 1, result: { models: ["gpt-5.5"] } }));
+    await expect(p).resolves.toEqual({ models: ["gpt-5.5"] });
+  });
+
+  it("ADR-093 rpc: request rejects when server returns an error envelope", async () => {
+    const { createRpcClient, __testing__ } = await import("../../scripts/lib/broker-rpc.mjs");
+    __testing__.resetIdCounter();
+    const mock = createMockConnection();
+    // biome-ignore lint/suspicious/noExplicitAny: mock connection shape
+    const rpc = createRpcClient(mock.conn as any, { defaultTimeoutMs: 1000 });
+    const p = rpc.request("bad/method", undefined);
+    mock.pushMessage(JSON.stringify({ id: 1, error: { code: -32601, message: "Method not found" } }));
+    await expect(p).rejects.toThrow(/Method not found/);
+  });
+
+  it("ADR-093 rpc: request rejects on timeout", async () => {
+    const { createRpcClient, __testing__ } = await import("../../scripts/lib/broker-rpc.mjs");
+    __testing__.resetIdCounter();
+    const mock = createMockConnection();
+    // biome-ignore lint/suspicious/noExplicitAny: mock connection shape
+    const rpc = createRpcClient(mock.conn as any, { defaultTimeoutMs: 50 });
+    const p = rpc.request("hangs", undefined);
+    await expect(p).rejects.toThrow(/timeout after 50ms/);
+  });
+
+  it("ADR-093 rpc: tolerates responses missing the jsonrpc:'2.0' field (ADR-093 finding)", async () => {
+    const { createRpcClient, __testing__ } = await import("../../scripts/lib/broker-rpc.mjs");
+    __testing__.resetIdCounter();
+    const mock = createMockConnection();
+    // biome-ignore lint/suspicious/noExplicitAny: mock connection shape
+    const rpc = createRpcClient(mock.conn as any, { defaultTimeoutMs: 1000 });
+    const p = rpc.request("model/list", undefined);
+    // No jsonrpc field — codex's actual response shape per ADR-093
+    mock.pushMessage(JSON.stringify({ id: 1, result: { models: [] } }));
+    await expect(p).resolves.toEqual({ models: [] });
+  });
+
+  it("ADR-093 rpc: dispatches server-pushed notifications to onNotification", async () => {
+    const { createRpcClient } = await import("../../scripts/lib/broker-rpc.mjs");
+    const mock = createMockConnection();
+    const notifications: Array<{ method: string; params: unknown }> = [];
+    createRpcClient(
+      // biome-ignore lint/suspicious/noExplicitAny: mock connection shape
+      mock.conn as any,
+      { onNotification: (n) => notifications.push({ method: n.method, params: n.params }) },
+    );
+    mock.pushMessage(JSON.stringify({ method: "turn/completed", params: { turnId: "abc" } }));
+    expect(notifications).toEqual([{ method: "turn/completed", params: { turnId: "abc" } }]);
+  });
+
+  it("ADR-093 rpc: close rejects all pending requests", async () => {
+    const { createRpcClient, __testing__ } = await import("../../scripts/lib/broker-rpc.mjs");
+    __testing__.resetIdCounter();
+    const mock = createMockConnection();
+    // biome-ignore lint/suspicious/noExplicitAny: mock connection shape
+    const rpc = createRpcClient(mock.conn as any, { defaultTimeoutMs: 5000 });
+    const p1 = rpc.request("a", undefined);
+    const p2 = rpc.request("b", undefined);
+    mock.pushClose();
+    await expect(p1).rejects.toThrow(/connection closed before response/);
+    await expect(p2).rejects.toThrow(/connection closed before response/);
+  });
+
+  it("ADR-093 broker: probeBrokerHealth returns false on null state (defensive)", async () => {
+    const { probeBrokerHealth } = await import("../../scripts/lib/broker.mjs");
+    expect(await probeBrokerHealth(null)).toBe(false);
+    expect(await probeBrokerHealth({})).toBe(false);
+    expect(await probeBrokerHealth({ transportUrl: 42 })).toBe(false);
+  });
+
+  it("ADR-093 broker: probeBrokerHealth returns false when transport unreachable", async () => {
+    const { probeBrokerHealth } = await import("../../scripts/lib/broker.mjs");
+    // ENOENT on a definitely-not-existing unix socket — never throws,
+    // returns false per ADR-077 silent-on-error contract.
+    const result = await probeBrokerHealth({
+      transportUrl: "unix:///tmp/definitely-not-a-broker-socket-codex-pair-test.sock",
+    });
+    expect(result).toBe(false);
+  });
+
+  it("ADR-093 broker: initializeBroker rejects on bad transport URL", async () => {
+    const { initializeBroker } = await import("../../scripts/lib/broker.mjs");
+    await expect(initializeBroker("nope://invalid", { name: "test", title: "test", version: "0.0.0" })).rejects.toThrow(
+      /unsupported transport URL scheme/,
+    );
+  });
 });


### PR DESCRIPTION
## Summary

**Tier 3 Milestone 2, PR 1 of 3.** Adds the transport + JSON-RPC layers the broker lifecycle (M2 PR 2) and `submitReview` (Milestone 3) will build on. **Zero hook wiring** — production behavior byte-identical to v0.7.x main.

## Why this PR exists

Brainstorm-coordinator (Codex + Claude probing real codex-cli 0.130.0) discovered the actual codex `app-server` JSON-RPC protocol is richer than ADR-090 anticipated AND that several of Codex's initial design suggestions were wrong for our use case:

1. **`unix://` and `ws://` both use WebSocket framing**, not raw NDJSON. Stdio is the only NDJSON transport, but stdio dies with the parent hook — unusable for a long-lived sidecar.
2. **Node 24's built-in `WebSocket` rejects `ws+unix://` URLs** with SyntaxError. Verified empirically via brainstorm. So "use Node built-in WebSocket" is NOT a free win on POSIX — we must hand-roll RFC 6455 over `net.Socket` for the unix transport. Hand-rolling the TCP path too keeps one code path.
3. **codex responses lack the `"jsonrpc":"2.0"` discriminator** — parser must dispatch purely on id/method, not on the discriminator field.
4. **`InitializeParams.clientInfo` requires `{ name, title, version }`** — note `title` (ADR-093 will get a doc update separately).
5. **Readiness ≠ socket reachability** — readiness is `initialize` round-trip success. `probeBrokerHealth` performs `initialize` + `model/list` as the strictest "broker actually works" signal.

## Files added

- **`scripts/lib/broker-transport.mjs`** (~280 lines) — minimal RFC 6455 client. unix:// + ws:// via one `net.Socket` code path. Client-masked frames per §5.3 (verified at byte level in tests). Auto-PONG on server PING. TEXT-only, no fragmentation, no extensions, no subprotocols. Handshake validates 101 + Sec-WebSocket-Accept SHA-1+base64 derivation. 5s default handshake timeout.

- **`scripts/lib/broker-rpc.mjs`** (~135 lines) — JSON-RPC 2.0 client on top of a transport connection. Auto-incrementing id counter. Pending-request map with per-request timeout enforcement. Tolerant response parser (no `jsonrpc` field required). Server-pushed notifications dispatch to `onNotification` callback. `close()` rejects all pending.

## Files modified

- **`broker.mjs`** — `probeBrokerHealth` (was a stub returning `false`) implemented end-to-end: opens transport, performs `initialize` + `model/list` within `BROKER_HEALTH_TIMEOUT_MS` budget, returns boolean. Never throws per ADR-077. Added `initializeBroker(transportUrl, clientInfo)` helper returning `{ connection, rpc, initializeResult }` for the broker lifecycle path used in M2 PR 2.

## Tests added (16 new pins, 229 → 245)

**Transport layer:**
- `parseTransportUrl` handles unix:// and ws:// correctly
- `parseTransportUrl` rejects http://, wss://, empty unix path, invalid port
- `encodeTextFrame` produces RFC 6455-correct client-masked TEXT frame (verified at byte level — FIN bit, MASK bit, payload XOR)
- `createFrameParser` decodes unmasked server frames + handles 16-bit length encoding (the path most fragile to off-by-one bugs)
- `validateUpgradeResponse` accepts RFC 6455 example + rejects bad status + rejects bad Accept hash

**JSON-RPC layer:**
- `request` correlates response by id, resolves with `result`
- `request` rejects on `error` envelope (code + message + data propagated)
- `request` rejects on timeout (50ms budget proven)
- Tolerates responses missing `"jsonrpc":"2.0"` field (ADR-093 finding)
- Dispatches server notifications to `onNotification`
- `close()` rejects all pending

**broker.mjs:**
- `probeBrokerHealth` returns false on null/empty/bad state (defensive — ADR-077 silent-on-error)
- `probeBrokerHealth` returns false on unreachable transport
- `initializeBroker` rejects on bad transport URL

## Out of scope

- **M2 PR 2:** SessionStart lifecycle (spawn `codex app-server`, atomic lock via mkdir, descriptor write after initialize succeeds)
- **M2 PR 3:** SessionEnd lifecycle (SIGTERM → wait → SIGKILL, `terminateProcessTree`, unlink descriptor + socket + lock) + `clearStaleBrokerState` minimal implementation
- **Milestone 3:** `submitReview` 3-step flow (thread/start ephemeral + turn/start + listen for turn/completed)
- **Milestone 4:** hook integration + end-to-end test against a real `codex app-server`

## Test plan

- [x] Plugin tests: 229 → 245 passing
- [x] Lint clean across 6 workspaces
- [x] No hook surface change — `isBrokerEnabled` still returns false; `submitReview` still throws "not implemented yet"
- [x] No new runtime deps (pure Node built-ins per ADR-078)
- [x] Brainstorm's recommended sub-PR shape followed (transport library first, no hook wiring)
- [ ] Integration against real `codex app-server` deferred to Milestone 4's end-to-end test (per brainstorm's recommendation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)