### PR TITLE
feat(plugin): codex-pair broker SessionStart lifecycle (M2 PR 2, ADR-093)

### DIFF
--- a/packages/claude-plugin/scripts/codex-pair-session.mjs
+++ b/packages/claude-plugin/scripts/codex-pair-session.mjs
@@ -1,22 +1,44 @@
 #!/usr/bin/env node
 // SessionStart / SessionEnd hook for the codex-pair app-server broker
-// (ADR-090). Today this is a stub: invocation reads stdin (Claude Code's
-// hook protocol), inspects the event type, and exits 0 silently.
-//
-// When the broker implementation lands (Tier 3 follow-on):
-//   - SessionStart: walk up from cwd to find .codex-pair/context.md.
-//     If found, spawn `codex app-server --listen <transport>` and write
-//     the descriptor to .codex-pair/state/broker.json (atomic via
-//     tmp+rename, per ADR-086). Path resolution routes through
-//     lib/state.mjs so the layout stays consistent with ADR-092.
-//   - SessionEnd: read .codex-pair/state/broker.json. If a broker is
-//     recorded, send it a graceful shutdown request, wait briefly, then
-//     terminateProcessTree on the pid. Unlink the state file and the
-//     transport socket.
+// (ADR-090, milestones implemented per ADR-093). SessionStart spawns
+// the broker + handshake + descriptor write (Milestone 2 PR 2);
+// SessionEnd teardown remains TODO (Milestone 2 PR 3).
 //
 // The hook MUST exit 0 on every path. A broker spawn failure is logged
-// but doesn't break the session — the hook's main per-edit path keeps
-// working with per-edit spawns.
+// silently to broker.log but doesn't break the session — the per-edit
+// path keeps working via per-edit codex spawns (ADR-077).
+
+import { access } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { bootstrapBroker } from "./lib/broker-lifecycle.mjs";
+import { CONTEXT_FILENAME, PAIR_ROOT_DIR } from "./lib/state.mjs";
+
+const MARKER_FILE = join(PAIR_ROOT_DIR, CONTEXT_FILENAME);
+
+// Walk up from startDir looking for `.codex-pair/context.md`. Returns
+// the marker directory (the directory CONTAINING `.codex-pair/`) or
+// null. Mirrors codex-pair-watch.mjs and codex-pair-log.mjs — duplicated
+// because zero-workspace-imports + the helper is too small to extract
+// (15 LOC × 3 callers).
+async function findMarkerUp(startDir) {
+  const home = homedir();
+  let current = resolve(startDir);
+  for (let depth = 0; depth < 20; depth++) {
+    const candidate = join(current, MARKER_FILE);
+    try {
+      await access(candidate);
+      return current;
+    } catch {
+      // not found here
+    }
+    const parent = dirname(current);
+    if (parent === current) return null;
+    if (current === home) return null;
+    current = parent;
+  }
+  return null;
+}
 
 async function readStdin() {
   return new Promise((resolve) => {
@@ -27,6 +49,24 @@ async function readStdin() {
     process.stdin.on("end", () => resolve(data));
     process.stdin.on("error", () => resolve(""));
   });
+}
+
+async function handleSessionStart() {
+  const cwd = process.cwd();
+  const markerDir = await findMarkerUp(cwd);
+  if (!markerDir) return; // no opt-in marker, nothing to do
+  // bootstrapBroker enforces its own wall-clock budget + exits silently
+  // on every failure path. Either it returns a descriptor (broker is
+  // live) or null (broker was not started). The hook doesn't surface
+  // either outcome — the per-edit hook discovers the broker by reading
+  // the descriptor file at marker resolution time.
+  await bootstrapBroker(markerDir);
+}
+
+async function handleSessionEnd() {
+  // TODO(M2 PR 3): read .codex-pair/state/broker.json, send SIGTERM to
+  // pid, wait briefly, terminateProcessTree if still alive, unlink
+  // descriptor + socket + lock.
 }
 
 async function main() {
@@ -43,15 +83,20 @@ async function main() {
     process.exit(0);
   }
 
-  // Broker is disabled until ASK_CODEX_BROKER=1 ships with a real
-  // implementation. This is a deliberate gating per ADR-090's "land the
-  // ADR + interface; defer implementation" decision.
+  // Broker is disabled until ASK_CODEX_BROKER=1. Production behavior
+  // unchanged: SessionStart/SessionEnd are silent no-ops.
   if (process.env.ASK_CODEX_BROKER !== "1") {
     process.exit(0);
   }
 
-  // TODO(ADR-090 follow-on): spawn/teardown the codex app-server broker
-  // per the design. See lib/broker.mjs for the planned API surface.
+  try {
+    if (event === "SessionStart") await handleSessionStart();
+    else if (event === "SessionEnd") await handleSessionEnd();
+  } catch {
+    // ADR-077 silent-on-error: a failed bootstrap MUST NOT break the
+    // session. bootstrapBroker already catches internally, but defense
+    // in depth.
+  }
   process.exit(0);
 }
 

--- a/packages/claude-plugin/scripts/lib/broker-lifecycle.mjs
+++ b/packages/claude-plugin/scripts/lib/broker-lifecycle.mjs
@@ -1,0 +1,305 @@
+// Broker lifecycle: spawn `codex app-server`, poll readiness, handshake,
+// atomic descriptor write. SessionStart calls `bootstrapBroker`; SessionEnd
+// will call the symmetric teardown helpers (Milestone 2 PR 3).
+//
+// Per ADR-090 + ADR-093 + the brainstorm-coordinator's verified findings:
+// the broker uses RFC 6455 WebSocket framing on BOTH `unix://` and `ws://`
+// transports; readiness is `initialize` round-trip success, not socket
+// existence; descriptor must be written ATOMICALLY only after `initialize`
+// succeeds (no partial-broker states observable from the hook side per
+// ADR-077). Wall-clock budget enforced on the whole bootstrap; on
+// exhaustion or any failure path, the spawned child is terminated and
+// the hook exits 0 silently.
+//
+// Pure Node built-ins + relative `./broker-*.mjs` imports per ADR-078.
+
+import { spawn, execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, openSync, rmSync, statSync } from "node:fs";
+import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
+import { connect as netConnect } from "node:net";
+import { platform } from "node:process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { initializeBroker } from "./broker.mjs";
+import { terminateProcessTree, IS_WINDOWS } from "./process.mjs";
+import { stateRoot } from "./state.mjs";
+
+// Locks live alongside the broker descriptor. Per-marker-dir isolation is
+// inherent because the parent path is `<markerDir>/.codex-pair/state/`.
+const BROKER_LOCK_DIR = "broker.lock";
+const BROKER_LOG_FILE = "broker.log";
+const BROKER_SOCKET_PREFIX = "codex-pair-broker";
+const BOOTSTRAP_BUDGET_MS_DEFAULT = 5000;
+const SOCKET_POLL_INTERVAL_MS = 100;
+
+// Choose the transport URL for this marker directory. POSIX: unix socket
+// under `<markerDir>/.codex-pair/state/`, with sha256-of-markerDir suffix
+// to prevent name collisions across symlinked project trees. Windows:
+// TODO — codex CLI supports `ws://IP:PORT` but cross-platform port
+// reservation has a known race (Brainstorm Risk #3). Punted to a follow-on
+// PR; for Milestone 2 we throw on Windows and the hook treats it as a
+// bootstrap failure (silent exit per ADR-077).
+export function chooseTransport(markerDir) {
+  if (IS_WINDOWS) {
+    throw new Error("broker-lifecycle: Windows transport not implemented yet (see ADR-090)");
+  }
+  const hash = createHash("sha256").update(markerDir).digest("hex").slice(0, 8);
+  const socketPath = join(stateRoot(markerDir), `${BROKER_SOCKET_PREFIX}.${hash}.sock`);
+  return `unix://${socketPath}`;
+}
+
+// Path resolvers for the lifecycle's filesystem state.
+export function brokerLockPath(markerDir) {
+  return join(stateRoot(markerDir), BROKER_LOCK_DIR);
+}
+
+export function brokerLogPath(markerDir) {
+  return join(stateRoot(markerDir), BROKER_LOG_FILE);
+}
+
+// Atomic lock via mkdir(2). The mkdir syscall is atomic across all POSIX
+// filesystems we care about (and on Windows). On success, returns the
+// lock path; on EEXIST, returns null (another SessionStart already
+// holding the lock — caller should exit quietly).
+export function acquireBrokerLock(markerDir) {
+  const lockPath = brokerLockPath(markerDir);
+  try {
+    mkdirSync(stateRoot(markerDir), { recursive: true });
+    mkdirSync(lockPath);
+    return lockPath;
+  } catch (err) {
+    if (err && err.code === "EEXIST") return null;
+    throw err;
+  }
+}
+
+export function releaseBrokerLock(lockPath) {
+  if (!lockPath) return;
+  try {
+    // Lock is a directory created by mkdirSync (so mkdir(2) acted as our
+    // atomic primitive). To remove a directory we need recursive:true on
+    // rmSync — recursive:false throws even with force:true (force only
+    // suppresses ENOENT, not EISDIR).
+    rmSync(lockPath, { recursive: true, force: true });
+  } catch {
+    // Best-effort. A stuck lock will be cleared by stale-recovery at
+    // next SessionStart (Milestone 2 PR 3 / Milestone 4).
+  }
+}
+
+// Poll the transport for reachability. Different probes per scheme:
+//   - unix:// — check the socket file exists + try net.connect once
+//   - ws://   — try net.connect to host:port
+// Returns true on first reachable response, false after the budget. The
+// caller still has to perform `initialize` separately — reachability is
+// necessary but not sufficient for "broker is healthy" per ADR-093.
+export async function pollSocketReachable(transportUrl, budgetMs) {
+  const deadline = Date.now() + budgetMs;
+  while (Date.now() < deadline) {
+    const reachable = await probeOnce(transportUrl);
+    if (reachable) return true;
+    await sleep(SOCKET_POLL_INTERVAL_MS);
+  }
+  return false;
+}
+
+function probeOnce(transportUrl) {
+  return new Promise((resolve) => {
+    let connectOptions;
+    if (transportUrl.startsWith("unix://")) {
+      const path = transportUrl.slice("unix://".length);
+      try {
+        statSync(path);
+      } catch {
+        resolve(false);
+        return;
+      }
+      connectOptions = { path };
+    } else if (transportUrl.startsWith("ws://")) {
+      const rest = transportUrl.slice("ws://".length);
+      const slashIdx = rest.indexOf("/");
+      const authority = slashIdx === -1 ? rest : rest.slice(0, slashIdx);
+      const colonIdx = authority.lastIndexOf(":");
+      const host = colonIdx === -1 ? authority : authority.slice(0, colonIdx);
+      const port = colonIdx === -1 ? 80 : Number(authority.slice(colonIdx + 1));
+      connectOptions = { host, port };
+    } else {
+      resolve(false);
+      return;
+    }
+    const sock = netConnect(connectOptions);
+    const settle = (ok) => {
+      sock.removeAllListeners();
+      try {
+        sock.destroy();
+      } catch {}
+      resolve(ok);
+    };
+    sock.once("connect", () => settle(true));
+    sock.once("error", () => settle(false));
+    sock.once("timeout", () => settle(false));
+    sock.setTimeout(SOCKET_POLL_INTERVAL_MS);
+  });
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms).unref?.());
+}
+
+// Spawn `codex app-server --listen <transport>` detached so it outlives
+// SessionStart's process. stdio is redirected to broker.log (open via
+// O_APPEND so multiple writers — unlikely but defensive — don't tear).
+// Returns the spawned ChildProcess; caller is responsible for tracking
+// the pid and writing it to the descriptor only after handshake succeeds.
+export function spawnBroker(markerDir, transportUrl) {
+  const logFd = openSync(brokerLogPath(markerDir), "a");
+  const child = spawn("codex", ["app-server", "--listen", transportUrl], {
+    detached: true,
+    stdio: ["ignore", logFd, logFd],
+  });
+  // detached + unref so SessionStart can exit cleanly without waiting
+  // for the broker. The broker stays alive as a session-scoped daemon.
+  child.unref();
+  return child;
+}
+
+// Codex version detection. Best-effort: returns the version string or
+// "unknown" if codex isn't on PATH or fails. Used in the descriptor for
+// version-skew detection (stale-broker recovery, Milestone 4).
+export function readCodexVersion() {
+  try {
+    const out = execFileSync("codex", ["--version"], { timeout: 2000, encoding: "utf-8" });
+    return (out || "").trim() || "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+// Atomic descriptor write via tmp+rename (ADR-086). Caller ensures
+// stateRoot(markerDir) exists (acquireBrokerLock creates it).
+export async function writeBrokerDescriptor(markerDir, descriptor) {
+  const finalPath = join(stateRoot(markerDir), "broker.json");
+  const tmpPath = `${finalPath}.tmp.${process.pid}`;
+  await writeFile(tmpPath, JSON.stringify(descriptor, null, 2));
+  await rename(tmpPath, finalPath);
+  return finalPath;
+}
+
+export async function unlinkBrokerDescriptor(markerDir) {
+  const finalPath = join(stateRoot(markerDir), "broker.json");
+  try {
+    await unlink(finalPath);
+  } catch {
+    // best-effort
+  }
+}
+
+// Resolve the plugin version from package.json. Used in clientInfo.title
+// and the descriptor. Falls back to "unknown" if the manifest can't be
+// read (the bundled marketplace install ships package.json adjacent to
+// scripts/).
+let cachedPluginVersion = null;
+export function readPluginVersion() {
+  if (cachedPluginVersion) return cachedPluginVersion;
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    // scripts/lib/*.mjs → packages/claude-plugin/package.json
+    const manifest = join(here, "..", "..", "package.json");
+    // Synchronous read because this is a one-shot startup cost.
+    // biome-ignore lint/style/useNodejsImportProtocol: ESM dynamic
+    const fs = require("node:fs");
+    const text = fs.readFileSync(manifest, "utf-8");
+    cachedPluginVersion = (JSON.parse(text)?.version || "unknown").trim();
+  } catch {
+    cachedPluginVersion = "unknown";
+  }
+  return cachedPluginVersion;
+}
+
+// Full bootstrap orchestrator. Acquires lock, spawns broker, polls for
+// socket reachability, performs initialize handshake, writes descriptor
+// atomically. Enforces wall-clock budget. On ANY failure, terminates
+// the spawned child + releases the lock + returns null (caller exits 0
+// per ADR-077). On success, returns the descriptor object that was
+// written + closes the initialize connection (long-lived RPC is the
+// per-edit hook's responsibility, not SessionStart's).
+//
+// Options:
+//   - budgetMs (default 5000) — total wall-clock budget for spawn+poll+
+//     initialize. Exhaustion = treated as failure.
+//   - injectDeps — testing hook to inject mocked spawn / initializeBroker
+//     for unit tests. Real production calls leave this undefined.
+export async function bootstrapBroker(markerDir, options = {}) {
+  const { budgetMs = BOOTSTRAP_BUDGET_MS_DEFAULT, injectDeps } = options;
+  const spawnFn = injectDeps?.spawnBroker ?? spawnBroker;
+  const initFn = injectDeps?.initializeBroker ?? initializeBroker;
+  const pollFn = injectDeps?.pollSocketReachable ?? pollSocketReachable;
+  const versionFn = injectDeps?.readCodexVersion ?? readCodexVersion;
+
+  const lockPath = acquireBrokerLock(markerDir);
+  if (!lockPath) return null; // another SessionStart holds the lock
+
+  const deadline = Date.now() + budgetMs;
+  let child = null;
+  try {
+    const transportUrl = chooseTransport(markerDir);
+    child = spawnFn(markerDir, transportUrl);
+
+    const pollBudget = Math.max(100, deadline - Date.now() - 1000);
+    const reachable = await pollFn(transportUrl, pollBudget);
+    if (!reachable) throw new Error("broker did not become reachable within budget");
+
+    const remaining = Math.max(500, deadline - Date.now());
+    const clientInfo = {
+      name: "codex-pair",
+      title: `codex-pair plugin v${readPluginVersion()}`,
+      version: readPluginVersion(),
+    };
+    const { connection, initializeResult } = await initFn(transportUrl, clientInfo, {
+      handshakeTimeoutMs: remaining,
+      initializeTimeoutMs: remaining,
+    });
+
+    const descriptor = {
+      pid: child.pid,
+      transportUrl,
+      codexVersion: versionFn(),
+      codexHome: initializeResult?.codexHome ?? null,
+      protocolVersion: "v2", // matches BROKER_PROTOCOL_VERSION in broker.mjs
+      pluginVersion: readPluginVersion(),
+      startedAt: new Date().toISOString(),
+      logPath: brokerLogPath(markerDir),
+    };
+    await writeBrokerDescriptor(markerDir, descriptor);
+
+    // Close the bootstrap connection — the per-edit hook opens its own
+    // long-lived RPC connection (Milestone 4).
+    try {
+      connection.close(1000, "bootstrap done");
+    } catch {
+      // best-effort
+    }
+
+    return descriptor;
+  } catch {
+    // ADR-077 silent-on-error. Tear down the child (best-effort) and
+    // signal failure to the caller via null return.
+    if (child) {
+      try {
+        terminateProcessTree(child, "SIGTERM");
+      } catch {}
+    }
+    return null;
+  } finally {
+    releaseBrokerLock(lockPath);
+  }
+}
+
+// Test-only exports
+export const __testing__ = {
+  BROKER_LOCK_DIR,
+  BROKER_LOG_FILE,
+  BROKER_SOCKET_PREFIX,
+  BOOTSTRAP_BUDGET_MS_DEFAULT,
+};

--- a/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
+++ b/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
@@ -2269,4 +2269,183 @@ describe("scripts/codex-pair-watch.mjs — runtime behavior (no codex calls)", (
       /unsupported transport URL scheme/,
     );
   });
+
+  // Milestone 2 PR 2: broker-lifecycle (SessionStart spawn + handshake +
+  // descriptor write). End-to-end against a real `codex app-server` is
+  // Milestone 4; these tests use injectDeps to mock spawn + initialize.
+
+  it("ADR-093 lifecycle: chooseTransport returns unix:// URL with sha256-of-markerDir suffix", async () => {
+    const { chooseTransport } = await import("../../scripts/lib/broker-lifecycle.mjs");
+    const url = chooseTransport("/project");
+    expect(url).toMatch(/^unix:\/\/.+\/\.codex-pair\/state\/codex-pair-broker\.[0-9a-f]{8}\.sock$/);
+    expect(chooseTransport("/project")).toBe(url);
+    expect(chooseTransport("/project2")).not.toBe(url);
+  });
+
+  it("ADR-093 lifecycle: acquireBrokerLock is atomic (first wins, second returns null)", async () => {
+    const { acquireBrokerLock, releaseBrokerLock } = await import("../../scripts/lib/broker-lifecycle.mjs");
+    fs.mkdirSync(path.join(tempDir, ".codex-pair", "state"), { recursive: true });
+    const first = acquireBrokerLock(tempDir);
+    expect(first).not.toBeNull();
+    expect(fs.existsSync(first as string)).toBe(true);
+    expect(acquireBrokerLock(tempDir)).toBeNull();
+    releaseBrokerLock(first);
+    expect(fs.existsSync(first as string)).toBe(false);
+    const third = acquireBrokerLock(tempDir);
+    expect(third).not.toBeNull();
+    releaseBrokerLock(third);
+  });
+
+  it("ADR-093 lifecycle: writeBrokerDescriptor writes atomically via tmp+rename", async () => {
+    const { writeBrokerDescriptor } = await import("../../scripts/lib/broker-lifecycle.mjs");
+    fs.mkdirSync(path.join(tempDir, ".codex-pair", "state"), { recursive: true });
+    const descriptor = {
+      pid: 99999,
+      transportUrl: "unix:///tmp/test.sock",
+      codexVersion: "codex-cli 0.130.0",
+      protocolVersion: "v2",
+      pluginVersion: "0.7.0",
+      startedAt: "2026-05-20T00:00:00.000Z",
+      logPath: "/tmp/broker.log",
+    };
+    const finalPath = await writeBrokerDescriptor(tempDir, descriptor);
+    expect(finalPath).toBe(path.join(tempDir, ".codex-pair", "state", "broker.json"));
+    const read = JSON.parse(fs.readFileSync(finalPath, "utf-8"));
+    expect(read).toEqual(descriptor);
+    const stateDirEntries = fs.readdirSync(path.join(tempDir, ".codex-pair", "state"));
+    expect(stateDirEntries.some((e) => e.includes(".tmp."))).toBe(false);
+  });
+
+  it("ADR-093 lifecycle: bootstrapBroker happy path writes descriptor + closes init connection", async () => {
+    const { bootstrapBroker } = await import("../../scripts/lib/broker-lifecycle.mjs");
+    fs.mkdirSync(path.join(tempDir, ".codex-pair"), { recursive: true });
+    const fakeChild = { pid: 12345, kill: () => true, killed: false, exitCode: null };
+    let connectionClosed = false;
+    const result = await bootstrapBroker(tempDir, {
+      injectDeps: {
+        // biome-ignore lint/suspicious/noExplicitAny: test mock
+        spawnBroker: () => fakeChild as any,
+        pollSocketReachable: async () => true,
+        initializeBroker: async () => ({
+          connection: {
+            close: () => {
+              connectionClosed = true;
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: test mock
+          } as any,
+          // biome-ignore lint/suspicious/noExplicitAny: test mock
+          rpc: {} as any,
+          initializeResult: { codexHome: "/Users/test/.codex" },
+        }),
+        readCodexVersion: () => "codex-cli 0.130.0",
+      },
+    });
+    expect(result).not.toBeNull();
+    expect(result?.pid).toBe(12345);
+    expect(result?.codexVersion).toBe("codex-cli 0.130.0");
+    expect(result?.codexHome).toBe("/Users/test/.codex");
+    expect(result?.protocolVersion).toBe("v2");
+    expect(connectionClosed).toBe(true);
+    expect(fs.existsSync(path.join(tempDir, ".codex-pair", "state", "broker.json"))).toBe(true);
+    expect(fs.existsSync(path.join(tempDir, ".codex-pair", "state", "broker.lock"))).toBe(false);
+  });
+
+  it("ADR-093 lifecycle: bootstrapBroker returns null + terminates child on poll timeout", async () => {
+    const { bootstrapBroker } = await import("../../scripts/lib/broker-lifecycle.mjs");
+    fs.mkdirSync(path.join(tempDir, ".codex-pair"), { recursive: true });
+    let terminated = false;
+    const fakeChild = {
+      pid: 12345,
+      kill: () => {
+        terminated = true;
+        return true;
+      },
+      killed: false,
+      exitCode: null,
+    };
+    const result = await bootstrapBroker(tempDir, {
+      budgetMs: 200,
+      injectDeps: {
+        // biome-ignore lint/suspicious/noExplicitAny: test mock
+        spawnBroker: () => fakeChild as any,
+        pollSocketReachable: async () => false,
+        // biome-ignore lint/suspicious/noExplicitAny: test mock
+        initializeBroker: (async () => ({})) as any,
+        readCodexVersion: () => "x",
+      },
+    });
+    expect(result).toBeNull();
+    expect(fs.existsSync(path.join(tempDir, ".codex-pair", "state", "broker.json"))).toBe(false);
+    expect(fs.existsSync(path.join(tempDir, ".codex-pair", "state", "broker.lock"))).toBe(false);
+    expect(terminated).toBe(true);
+  });
+
+  it("ADR-093 lifecycle: bootstrapBroker returns null + cleans up on initialize rejection", async () => {
+    const { bootstrapBroker } = await import("../../scripts/lib/broker-lifecycle.mjs");
+    fs.mkdirSync(path.join(tempDir, ".codex-pair"), { recursive: true });
+    const fakeChild = { pid: 12345, kill: () => true, killed: false, exitCode: null };
+    const result = await bootstrapBroker(tempDir, {
+      injectDeps: {
+        // biome-ignore lint/suspicious/noExplicitAny: test mock
+        spawnBroker: () => fakeChild as any,
+        pollSocketReachable: async () => true,
+        initializeBroker: async () => {
+          throw new Error("initialize timeout");
+        },
+        readCodexVersion: () => "x",
+      },
+    });
+    expect(result).toBeNull();
+    expect(fs.existsSync(path.join(tempDir, ".codex-pair", "state", "broker.json"))).toBe(false);
+    expect(fs.existsSync(path.join(tempDir, ".codex-pair", "state", "broker.lock"))).toBe(false);
+  });
+
+  it("ADR-093 lifecycle: bootstrapBroker returns null when lock acquisition fails (concurrent SessionStart)", async () => {
+    const { acquireBrokerLock, bootstrapBroker } = await import("../../scripts/lib/broker-lifecycle.mjs");
+    fs.mkdirSync(path.join(tempDir, ".codex-pair", "state"), { recursive: true });
+    const firstLock = acquireBrokerLock(tempDir);
+    expect(firstLock).not.toBeNull();
+    let spawnAttempted = false;
+    const result = await bootstrapBroker(tempDir, {
+      injectDeps: {
+        spawnBroker: () => {
+          spawnAttempted = true;
+          // biome-ignore lint/suspicious/noExplicitAny: test mock
+          return {} as any;
+        },
+        pollSocketReachable: async () => true,
+        // biome-ignore lint/suspicious/noExplicitAny: test mock
+        initializeBroker: (async () => ({})) as any,
+        readCodexVersion: () => "x",
+      },
+    });
+    expect(result).toBeNull();
+    expect(spawnAttempted).toBe(false);
+    fs.rmSync(firstLock as string, { recursive: true, force: true });
+  });
+
+  it("ADR-093 lifecycle: SessionStart hook with ASK_CODEX_BROKER=1 but no marker is a silent no-op", () => {
+    const sessionScript = path.join(PLUGIN_ROOT, "scripts", "codex-pair-session.mjs");
+    const noMarkerDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-pair-no-marker-"));
+    try {
+      const result = spawnSync("node", [sessionScript], {
+        input: JSON.stringify({ hook_event_name: "SessionStart" }),
+        cwd: noMarkerDir,
+        env: { ...process.env, ASK_CODEX_BROKER: "1", HOME: noMarkerDir },
+        encoding: "utf-8",
+        timeout: 6000,
+      });
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
+    } finally {
+      fs.rmSync(noMarkerDir, { recursive: true, force: true });
+    }
+  });
+
+  it("ADR-093 structural: codex-pair-session.mjs wires bootstrapBroker from broker-lifecycle", () => {
+    const sessionScript = fs.readFileSync(path.join(PLUGIN_ROOT, "scripts", "codex-pair-session.mjs"), "utf-8");
+    expect(sessionScript).toMatch(/bootstrapBroker/);
+    expect(sessionScript).toMatch(/from\s+["']\.\/lib\/broker-lifecycle\.mjs["']/);
+    expect(sessionScript).toMatch(/findMarkerUp/);
+  });
 });


### PR DESCRIPTION
## Summary

**Tier 3 Milestone 2, PR 2 of 3.** Implements `SessionStart` broker spawn + handshake + atomic descriptor write. SessionEnd teardown stays TODO for M2 PR 3. Behind `ASK_CODEX_BROKER=1` gate so production unaffected.

Builds on M2 PR 1 (#99 — transport + JSON-RPC client, merged). When this lands, `ASK_CODEX_BROKER=1` produces a usable broker descriptor at SessionStart — the per-edit hook still ignores it until M4 wires the integration.

## New file: `scripts/lib/broker-lifecycle.mjs` (~200 lines)

| Function | Behavior |
|---|---|
| `chooseTransport(markerDir)` | POSIX → `unix://<markerDir>/.codex-pair/state/codex-pair-broker.<sha256[0:8]>.sock`. Deterministic hash suffix prevents collisions across symlinked project trees. Windows throws (deferred per brainstorm Risk #3 — port-reservation race). |
| `acquireBrokerLock/releaseBrokerLock` | Atomic via `mkdir(2)`. EEXIST → returns null (caller exits quietly). Release uses `rmSync({ recursive: true })` because `recursive: false` throws on directories even with `force: true` — bug caught by negative-assertion tests. |
| `pollSocketReachable` | Per-scheme probe with backoff. Returns boolean within caller's budget. Necessary-but-not-sufficient (caller must perform initialize). |
| `spawnBroker` | `spawn("codex", ["app-server", "--listen", transport])` with `detached:true` + stdio → `broker.log` (NOT `/dev/null` per brainstorm — diagnostic value for stale-recovery and field debugging). `child.unref()` so SessionStart exits cleanly. |
| `readCodexVersion` | Best-effort `codex --version` parse for descriptor (used by stale-recovery in M2 PR 3 / M4). |
| `writeBrokerDescriptor` | Atomic tmp+rename (ADR-086 pattern). Shape: `{ pid, transportUrl, codexVersion, codexHome, protocolVersion, pluginVersion, startedAt, logPath }`. |
| `bootstrapBroker(markerDir, options)` | Full orchestrator. Lock → spawn → poll → initialize → descriptor → close init connection. Wall-clock budget (default 5s). On ANY failure: terminates child via `terminateProcessTree`, releases lock, returns null. Caller exits 0 silently per ADR-077. |

## Updated file: `scripts/codex-pair-session.mjs`

- Wires `findMarkerUp(cwd)` + `bootstrapBroker(markerDir)` on SessionStart
- `findMarkerUp` duplicated from `codex-pair-watch.mjs` (15 LOC × 3 callers — duplication acceptable; zero-workspace-imports rules out extraction without expanding `state.mjs`'s API surface unnecessarily)
- SessionEnd branch remains TODO (M2 PR 3)
- `ASK_CODEX_BROKER=1` gate unchanged

## Bug caught + fixed during test development

`releaseBrokerLock` initially used `rmSync({ recursive: false, force: true })`. This throws on directories (force only suppresses ENOENT, not EISDIR). Negative-assertion tests (lock should NOT exist after success) caught it immediately. Fixed to `recursive: true` — lock is an empty dir so no actual recursion happens, but `rmSync` semantics require the flag.

## Tests added (9 new pins, 245 → 254)

- `chooseTransport`: unix:// URL shape, sha256 determinism, different markerDirs → different hashes
- `acquireBrokerLock`: first-wins / null on contention / re-acquire after release
- `writeBrokerDescriptor`: atomic tmp+rename, exact descriptor shape, no leftover .tmp.PID files
- `bootstrapBroker` happy path: descriptor written, lock released, init connection closed
- `bootstrapBroker` poll timeout: descriptor NOT written, lock released, child terminated
- `bootstrapBroker` initialize rejection: same cleanup invariants
- `bootstrapBroker` lock contention: returns null without attempting spawn
- SessionStart subprocess + ASK_CODEX_BROKER=1 + no marker: silent no-op (status 0, empty stderr)
- Structural pin: `codex-pair-session.mjs` imports `bootstrapBroker` from `broker-lifecycle.mjs` + uses `findMarkerUp`

All tests use the `injectDeps` escape hatch — no real `codex` spawn in this PR. End-to-end against a live `codex app-server` is Milestone 4's job.

## Out of scope

- **M2 PR 3**: SessionEnd teardown (SIGTERM → wait → SIGKILL, terminateProcessTree, unlink descriptor + socket + lock) + `clearStaleBrokerState` minimal implementation
- **Milestone 3**: `thread/start` + `turn/start` + notification listener (real `submitReview`)
- **Milestone 4**: hook integration in `codex-pair-watch.mjs` + end-to-end test with real `codex app-server`
- **Windows broker transport**: deferred per brainstorm Risk #3 (port-reservation race needs more design work)

## Test plan

- [x] Plugin tests: 245 → 254 passing
- [x] Lint clean across 6 workspaces
- [x] No production code path change — `isBrokerEnabled` still returns false; per-edit hook still uses per-edit codex spawn
- [x] Brainstorm-recommended sub-PR shape followed (lifecycle ships incrementally, not all in one diff)
- [x] All failure paths produce ADR-077 silent-on-error semantics (verified by tests)
- [ ] Integration test against real `codex app-server` deferred to M4

🤖 Generated with [Claude Code](https://claude.com/claude-code)