### PR TITLE
fix(plugin): broker hotfix — multi-review findings on M2 (CRITICAL: upgrade-send missing, ESM require bug)

### DIFF
--- a/packages/claude-plugin/scripts/lib/broker-lifecycle.mjs
+++ b/packages/claude-plugin/scripts/lib/broker-lifecycle.mjs
@@ -17,14 +17,13 @@
 
 import { spawn, execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, openSync, rmSync, statSync } from "node:fs";
+import { mkdirSync, openSync, readFileSync, rmSync, statSync, unlinkSync } from "node:fs";
 import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
 import { connect as netConnect } from "node:net";
 import { platform } from "node:process";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import { BROKER_PROTOCOL_VERSION, initializeBroker } from "./broker.mjs";
-import { unlinkSync as unlinkSyncFs, statSync as statSyncFs } from "node:fs";
 import { terminateProcessTree, IS_WINDOWS } from "./process.mjs";
 import { stateRoot } from "./state.mjs";
 
@@ -209,10 +208,13 @@ export function readPluginVersion() {
     const here = dirname(fileURLToPath(import.meta.url));
     // scripts/lib/*.mjs → packages/claude-plugin/package.json
     const manifest = join(here, "..", "..", "package.json");
-    // Synchronous read because this is a one-shot startup cost.
-    // biome-ignore lint/style/useNodejsImportProtocol: ESM dynamic
-    const fs = require("node:fs");
-    const text = fs.readFileSync(manifest, "utf-8");
+    // Use the static ESM import — the original M2 PR 2 code used
+    // `require("node:fs")` which is undefined in ESM (.mjs files), so
+    // every call to this function threw ReferenceError silently and
+    // permanently returned "unknown". Multi-review caught it; the
+    // bootstrap-descriptor test now asserts pluginVersion is not
+    // "unknown" so this regression can't sneak in again.
+    const text = readFileSync(manifest, "utf-8");
     cachedPluginVersion = (JSON.parse(text)?.version || "unknown").trim();
   } catch {
     cachedPluginVersion = "unknown";
@@ -304,11 +306,10 @@ export async function bootstrapBroker(markerDir, options = {}) {
 // Read the broker descriptor synchronously. Returns the parsed object
 // or null on any error (missing, malformed, unreadable). Used by
 // teardownBroker AND by the per-edit hook's readBrokerState lookup.
-import { readFileSync as readFileSyncFs } from "node:fs";
 export function readBrokerDescriptorSync(markerDir) {
   const descPath = join(stateRoot(markerDir), "broker.json");
   try {
-    const text = readFileSyncFs(descPath, "utf-8");
+    const text = readFileSync(descPath, "utf-8");
     const parsed = JSON.parse(text);
     if (!parsed || typeof parsed !== "object") return null;
     if (typeof parsed.pid !== "number" || typeof parsed.transportUrl !== "string") return null;
@@ -379,12 +380,15 @@ async function killPidGracefully(pid, graceMs) {
 }
 
 // Unlink the unix socket file alongside descriptor + lock. Only meaningful
-// on POSIX; on Windows the WS transport doesn't leave a file.
-async function unlinkTransportArtifact(transportUrl) {
-  if (!transportUrl || !transportUrl.startsWith("unix://")) return;
-  const sockPath = transportUrl.slice("unix://".length);
+// on POSIX; on Windows the WS transport doesn't leave a file. Caller
+// must supply markerDir so we can validate the socket path is rooted
+// under the marker's state directory (defense against a tampered
+// descriptor.json pointing the unlink at an arbitrary path).
+async function unlinkTransportArtifact(transportUrl, markerDir) {
+  const safePath = extractSafeSocketPath(transportUrl, markerDir);
+  if (safePath === null) return;
   try {
-    await unlink(sockPath);
+    await unlink(safePath);
   } catch {
     // already gone — fine
   }
@@ -402,10 +406,10 @@ export function clearStaleBrokerState(markerDir) {
   const alive = isPidAlive(descriptor.pid);
   const protoOk = descriptor.protocolVersion === BROKER_PROTOCOL_VERSION;
   let socketOk = true;
-  if (typeof descriptor.transportUrl === "string" && descriptor.transportUrl.startsWith("unix://")) {
-    const sockPath = descriptor.transportUrl.slice("unix://".length);
+  const sockPath = extractSafeSocketPath(descriptor.transportUrl, markerDir);
+  if (sockPath !== null) {
     try {
-      statSyncFs(sockPath);
+      statSync(sockPath);
     } catch {
       socketOk = false;
     }
@@ -413,14 +417,36 @@ export function clearStaleBrokerState(markerDir) {
   if (alive && protoOk && socketOk) return "live";
   // Stale — clean up. Best-effort; failures are silent per ADR-077.
   try {
-    unlinkSyncFs(join(stateRoot(markerDir), "broker.json"));
+    unlinkSync(join(stateRoot(markerDir), "broker.json"));
   } catch {}
-  if (typeof descriptor.transportUrl === "string" && descriptor.transportUrl.startsWith("unix://")) {
+  if (sockPath !== null) {
     try {
-      unlinkSyncFs(descriptor.transportUrl.slice("unix://".length));
+      unlinkSync(sockPath);
     } catch {}
   }
   return "stale";
+}
+
+// Path-safety: validate that a unix:// socket path resolves under the
+// markerDir's state root before we agree to stat or unlink it. Per the
+// multi-review (Gemini Finding #4), a hostile or stale broker.json could
+// otherwise direct us to unlink arbitrary paths the user has write
+// permission to. Returns the safe socket path or null if invalid /
+// non-unix / outside-bounds.
+function extractSafeSocketPath(transportUrl, markerDir) {
+  if (typeof transportUrl !== "string" || !transportUrl.startsWith("unix://")) {
+    return null;
+  }
+  const sockPath = transportUrl.slice("unix://".length);
+  if (!sockPath) return null;
+  const resolvedSock = resolvePath(sockPath);
+  const resolvedRoot = resolvePath(stateRoot(markerDir));
+  // Path must be exactly the state root or strictly nested under it.
+  // The boundary check guards against `/foo/bar/state-evil/x` matching
+  // `/foo/bar/state` via a substring prefix.
+  if (resolvedSock === resolvedRoot) return null; // can't unlink the root itself
+  if (resolvedSock.startsWith(`${resolvedRoot}/`)) return resolvedSock;
+  return null;
 }
 
 // SessionEnd orchestrator. Reads the descriptor, signals the broker pid
@@ -449,7 +475,7 @@ export async function teardownBroker(markerDir, options = {}) {
     // best-effort
   }
   try {
-    await unlinkSockFn(descriptor.transportUrl);
+    await unlinkSockFn(descriptor.transportUrl, markerDir);
   } catch {
     // best-effort
   }

--- a/packages/claude-plugin/scripts/lib/broker-transport.mjs
+++ b/packages/claude-plugin/scripts/lib/broker-transport.mjs
@@ -139,41 +139,60 @@ function encodeTextFrame(text) {
   ]);
 }
 
+// Maximum control-frame payload per RFC 6455 §5.5 ("All control frames
+// MUST have a payload length of 125 bytes or less"). The 7-bit length
+// field in byte[1] would otherwise overflow into the extended-length
+// encoding flags (126, 127). Both encoders below truncate to this cap
+// to guarantee on-wire correctness.
+const MAX_CONTROL_FRAME_PAYLOAD = 125;
+
 // Encode a CLOSE frame with optional status code + reason. Client-masked.
+// Reason is truncated as needed to keep total payload ≤ 125 bytes per
+// RFC 6455 §5.5 (multi-review Finding #3 — previously silently corrupted
+// frames if reason was ≥ 124 bytes).
 function encodeCloseFrame(code = 1000, reason = "") {
-  const reasonBuf = Buffer.from(reason, "utf-8");
+  let reasonBuf = Buffer.from(reason, "utf-8");
+  // 2 bytes for the status code + reason. Truncate reason if combined
+  // would exceed the control-frame cap.
+  if (2 + reasonBuf.length > MAX_CONTROL_FRAME_PAYLOAD) {
+    reasonBuf = reasonBuf.slice(0, MAX_CONTROL_FRAME_PAYLOAD - 2);
+  }
   const payload = Buffer.allocUnsafe(2 + reasonBuf.length);
   payload.writeUInt16BE(code, 0);
   reasonBuf.copy(payload, 2);
   const mask = randomBytes(4);
   const masked = Buffer.allocUnsafe(payload.length);
   for (let i = 0; i < payload.length; i++) masked[i] = payload[i] ^ mask[i % 4];
-  return Buffer.concat([
-    Buffer.from([0x80 | OPCODE_CLOSE, 0x80 | payload.length]),
-    mask,
-    masked,
-  ]);
+  return Buffer.concat([Buffer.from([0x80 | OPCODE_CLOSE, 0x80 | payload.length]), mask, masked]);
 }
 
 // Encode a PONG frame echoing the server's PING payload. Client-masked.
+// PING payload is truncated to 125 bytes (RFC 6455 §5.5) — a hostile or
+// buggy server sending a > 125-byte PING would otherwise scramble our
+// outgoing frame.
 function encodePongFrame(payload) {
+  const capped = payload.length > MAX_CONTROL_FRAME_PAYLOAD ? payload.slice(0, MAX_CONTROL_FRAME_PAYLOAD) : payload;
   const mask = randomBytes(4);
-  const masked = Buffer.allocUnsafe(payload.length);
-  for (let i = 0; i < payload.length; i++) masked[i] = payload[i] ^ mask[i % 4];
-  // Control frames have payload < 126 (RFC 6455 §5.5).
-  return Buffer.concat([
-    Buffer.from([0x80 | OPCODE_PONG, 0x80 | payload.length]),
-    mask,
-    masked,
-  ]);
+  const masked = Buffer.allocUnsafe(capped.length);
+  for (let i = 0; i < capped.length; i++) masked[i] = capped[i] ^ mask[i % 4];
+  return Buffer.concat([Buffer.from([0x80 | OPCODE_PONG, 0x80 | capped.length]), mask, masked]);
 }
 
 // Stateful frame parser. Accumulates incoming bytes and emits whole frames
 // via `onFrame({ opcode, payload })`. Caller drains via `feed(chunk)`.
-// Server→client frames are NOT masked, so we ignore the MASK bit on parse.
+// Server→client frames are NOT masked per RFC 6455 §5.3, so we ignore
+// the MASK bit on parse. On fatal protocol violations (fragmentation we
+// don't support, illegal frame shapes) the parser flips into a "corrupted"
+// state — no further frames are emitted, and onError is called once.
+// The caller (connectWebSocket) destroys the socket so pending RPC
+// requests reject via the close handler. This was a multi-review finding
+// — the previous code did `continue` after fragmentation and the buffer
+// state corrupted forever.
 function createFrameParser(onFrame, onError) {
   let buf = Buffer.alloc(0);
+  let corrupted = false;
   return (chunk) => {
+    if (corrupted) return; // already reported fatal — discard further bytes
     buf = Buffer.concat([buf, chunk]);
     while (buf.length >= 2) {
       const first = buf[0];
@@ -200,14 +219,20 @@ function createFrameParser(onFrame, onError) {
       const maskBit = (second & 0x80) !== 0;
       if (maskBit) offset += 4;
       if (buf.length < offset + len) return; // need more
+      if (!fin && opcode !== OPCODE_CONTINUATION) {
+        // Fragmentation is not supported. Marking corrupted so subsequent
+        // bytes are ignored; the connect handler destroys the socket.
+        // codex doesn't fragment JSON-RPC frames in practice, so this
+        // path is defensive against a buggy or hostile server.
+        corrupted = true;
+        buf = Buffer.alloc(0);
+        onError(
+          new Error(`broker-transport: fragmentation not supported (opcode=${opcode}) — connection terminating`),
+        );
+        return;
+      }
       const payload = buf.slice(offset, offset + len);
       buf = buf.slice(offset + len);
-      if (!fin && opcode !== OPCODE_CONTINUATION) {
-        // We don't support fragmentation. Codex doesn't fragment small
-        // JSON-RPC frames. Emit an error and move on.
-        onError(new Error(`broker-transport: fragmentation not supported (opcode=${opcode})`));
-        continue;
-      }
       onFrame({ opcode, payload });
     }
   };
@@ -249,6 +274,23 @@ export async function connectWebSocket(transportUrl, options = {}) {
         reject(err);
       } else {
         for (const cb of listeners.error) cb(err);
+      }
+    });
+
+    // Send the HTTP/1.1 upgrade request once the TCP/UDS connection is
+    // established. This was missing in the original M2 PR 1 implementation
+    // — flagged by the multi-review (both Codex + Gemini caught it). Unit
+    // tests mocked around connectWebSocket so the missing write was
+    // invisible. The fixture-server test added in this hotfix exercises
+    // the real upgrade path so this class of bug can't recur silently.
+    socket.once("connect", () => {
+      try {
+        socket.write(buildUpgradeRequest(host, secKey));
+      } catch (err) {
+        if (!upgraded) {
+          clearTimeout(timer);
+          reject(err);
+        }
       }
     });
 
@@ -301,6 +343,16 @@ export async function connectWebSocket(transportUrl, options = {}) {
         },
         (err) => {
           for (const cb of listeners.error) cb(err);
+          // Parser-level errors signal unrecoverable protocol corruption
+          // (fragmentation, malformed framing). Destroy the socket so
+          // pending RPC requests reject via the close handler. Multi-
+          // review finding #4: previously the parser silently corrupted
+          // its buffer state and kept "running" against garbage.
+          try {
+            socket.destroy();
+          } catch {
+            // best-effort
+          }
         },
       );
 

--- a/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
+++ b/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
@@ -2602,4 +2602,166 @@ describe("scripts/codex-pair-watch.mjs — runtime behavior (no codex calls)", (
     expect(sessionScript).toMatch(/clearStaleBrokerState/);
     expect(sessionScript).toMatch(/handleSessionEnd/);
   });
+
+  it("ADR-093 transport hotfix: connectWebSocket performs a real RFC 6455 upgrade end-to-end", async () => {
+    const { createServer } = await import("node:net");
+    const { createHash } = await import("node:crypto");
+    const { connectWebSocket } = await import("../../scripts/lib/broker-transport.mjs");
+    const server: import("node:net").Server = createServer((sock) => {
+      let buf = Buffer.alloc(0);
+      let upgraded = false;
+      sock.on("data", (chunk) => {
+        // Always append; the upgrade-vs-frame state machine routes from buf.
+        // Previous test had an order-dependent bug where buf only grew during
+        // the upgrade phase, so a frame arriving in a separate TCP packet
+        // would never be seen by the frame-processing branch.
+        buf = Buffer.concat([buf, chunk]);
+        if (!upgraded) {
+          const end = buf.indexOf("\r\n\r\n");
+          if (end === -1) return;
+          const header = buf.slice(0, end).toString("utf-8");
+          const keyMatch = header.match(/Sec-WebSocket-Key:\s*(.+)/i);
+          if (!keyMatch) {
+            sock.destroy();
+            return;
+          }
+          const key = keyMatch[1].trim();
+          const accept = createHash("sha1").update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`).digest("base64");
+          sock.write(
+            [
+              "HTTP/1.1 101 Switching Protocols",
+              "Upgrade: websocket",
+              "Connection: Upgrade",
+              `Sec-WebSocket-Accept: ${accept}`,
+              "",
+              "",
+            ].join("\r\n"),
+          );
+          upgraded = true;
+          buf = buf.slice(end + 4);
+        }
+        // Drain any complete frames from buf.
+        while (upgraded && buf.length >= 2) {
+          const opcode = buf[0] & 0x0f;
+          if (opcode !== 0x1) break;
+          const lenByte = buf[1] & 0x7f;
+          const masked = (buf[1] & 0x80) !== 0;
+          const headerSize = 2 + (masked ? 4 : 0);
+          if (buf.length < headerSize + lenByte) break;
+          const mask = masked ? buf.slice(2, 6) : null;
+          const start = headerSize;
+          const payload = Buffer.allocUnsafe(lenByte);
+          for (let i = 0; i < lenByte; i++) {
+            payload[i] = mask ? buf[start + i] ^ mask[i % 4] : buf[start + i];
+          }
+          sock.write(Buffer.concat([Buffer.from([0x81, payload.length]), payload]));
+          buf = buf.slice(start + lenByte);
+        }
+      });
+    });
+    await new Promise<void>((resolveFn) => server.listen(0, "127.0.0.1", () => resolveFn()));
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("server.address() returned unexpected shape");
+    const port = addr.port;
+    try {
+      const conn = await connectWebSocket(`ws://127.0.0.1:${port}`, { handshakeTimeoutMs: 3000 });
+      const echoed = await new Promise<string>((resolveFn, reject) => {
+        const t = setTimeout(() => reject(new Error("echo timeout")), 2000);
+        conn.on("message", (text: string) => {
+          clearTimeout(t);
+          resolveFn(text);
+        });
+        conn.sendText("hello");
+      });
+      expect(echoed).toBe("hello");
+      conn.close(1000, "test done");
+    } finally {
+      await new Promise<void>((resolveFn) => server.close(() => resolveFn()));
+    }
+  });
+
+  it("ADR-093 transport hotfix: encodeCloseFrame truncates reason ≥ 124 bytes (RFC 6455 §5.5)", async () => {
+    const { __testing__ } = await import("../../scripts/lib/broker-transport.mjs");
+    const longReason = "x".repeat(200);
+    const frame = __testing__.encodeCloseFrame(1000, longReason);
+    const lengthBits = frame[1] & 0x7f;
+    expect(lengthBits).toBeLessThanOrEqual(125);
+    expect(lengthBits).not.toBe(126);
+    expect(lengthBits).not.toBe(127);
+  });
+
+  it("ADR-093 transport hotfix: encodePongFrame truncates payload > 125 bytes (RFC 6455 §5.5)", async () => {
+    const { __testing__ } = await import("../../scripts/lib/broker-transport.mjs");
+    const oversizedPing = Buffer.alloc(200, "z");
+    const frame = __testing__.encodePongFrame(oversizedPing);
+    const lengthBits = frame[1] & 0x7f;
+    expect(lengthBits).toBe(125);
+  });
+
+  it("ADR-093 transport hotfix: fragmented frame triggers fatal error + halts further frame emission", async () => {
+    const { __testing__ } = await import("../../scripts/lib/broker-transport.mjs");
+    const frames: Array<{ opcode: number }> = [];
+    const errors: Error[] = [];
+    const parser = __testing__.createFrameParser(
+      (f: { opcode: number; payload: Buffer }) => frames.push(f),
+      (err: Error) => errors.push(err),
+    );
+    parser(Buffer.from([0x01, 0x02, 0x68, 0x69]));
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toMatch(/fragmentation not supported/);
+    expect(frames).toHaveLength(0);
+    parser(Buffer.from([0x81, 0x02, 0x68, 0x69]));
+    expect(frames).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+  });
+
+  it("ADR-093 lifecycle hotfix: readPluginVersion returns non-'unknown' semver (regression for ESM require bug)", async () => {
+    const { readPluginVersion } = await import("../../scripts/lib/broker-lifecycle.mjs");
+    const v = readPluginVersion();
+    expect(v).not.toBe("unknown");
+    expect(v).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("ADR-093 lifecycle hotfix: clearStaleBrokerState refuses to unlink sockets outside markerDir/state", async () => {
+    const { clearStaleBrokerState } = await import("../../scripts/lib/broker-lifecycle.mjs");
+    fs.mkdirSync(path.join(tempDir, ".codex-pair", "state"), { recursive: true });
+    const victimDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-pair-victim-"));
+    const victimPath = path.join(victimDir, "do-not-delete.txt");
+    fs.writeFileSync(victimPath, "I must survive");
+    try {
+      fs.writeFileSync(
+        path.join(tempDir, ".codex-pair", "state", "broker.json"),
+        JSON.stringify({ pid: 999999, transportUrl: `unix://${victimPath}`, protocolVersion: "v2" }),
+      );
+      expect(clearStaleBrokerState(tempDir)).toBe("stale");
+      expect(fs.existsSync(path.join(tempDir, ".codex-pair", "state", "broker.json"))).toBe(false);
+      expect(fs.existsSync(victimPath)).toBe(true);
+      expect(fs.readFileSync(victimPath, "utf-8")).toBe("I must survive");
+    } finally {
+      fs.rmSync(victimDir, { recursive: true, force: true });
+    }
+  });
+
+  it("ADR-093 lifecycle hotfix: bootstrapBroker descriptor records non-'unknown' pluginVersion", async () => {
+    const { bootstrapBroker } = await import("../../scripts/lib/broker-lifecycle.mjs");
+    fs.mkdirSync(path.join(tempDir, ".codex-pair"), { recursive: true });
+    const fakeChild = { pid: 12345, kill: () => true, killed: false, exitCode: null };
+    const result = await bootstrapBroker(tempDir, {
+      injectDeps: {
+        // biome-ignore lint/suspicious/noExplicitAny: test mock
+        spawnBroker: () => fakeChild as any,
+        pollSocketReachable: async () => true,
+        initializeBroker: async () => ({
+          // biome-ignore lint/suspicious/noExplicitAny: test mock
+          connection: { close: () => {} } as any,
+          // biome-ignore lint/suspicious/noExplicitAny: test mock
+          rpc: {} as any,
+          initializeResult: {},
+        }),
+        readCodexVersion: () => "codex-cli 0.130.0",
+      },
+    });
+    expect(result?.pluginVersion).not.toBe("unknown");
+    expect(result?.pluginVersion).toMatch(/^\d+\.\d+\.\d+/);
+  });
 });


### PR DESCRIPTION
## Summary

Hotfix addressing 6 high-confidence findings from `/multi-review` on the cumulative Milestone 2 diff (Codex + Claude verified; Gemini quota-exhausted this round). **Two findings were BLOCKING and made M2 non-functional in production** despite passing 264/264 unit tests.

This PR is the multi-review-driven sanity check the goal-directive prescribes after each milestone. Without these fixes, Milestone 3 would have built atop a transport that can't actually communicate with `codex app-server`.

## CRITICAL findings (both reviewers independently caught)

### 1. `connectWebSocket` never sent the upgrade request (Codex confidence 99, Gemini confidence equivalent)

`buildUpgradeRequest` was defined and exported in `__testing__` but never invoked at runtime. Every real connection attempt would hang until handshake timeout. Unit tests passed because they mocked around `connectWebSocket` entirely.

**Fix:** Add `socket.once("connect", () => socket.write(buildUpgradeRequest(host, secKey)))` so the upgrade actually goes out once TCP/UDS connect completes. New end-to-end test against an inline Node fixture WebSocket server catches this class of bug — sends a real `"hello"` and asserts the echo round-trips.

### 2. `require("node:fs")` inside an ESM `.mjs` module (Codex 99, Gemini 98)

`readPluginVersion` used `require("node:fs")` — `require` is undefined in ESM, so the call threw ReferenceError, was caught by the surrounding try/catch, silently returning `"unknown"` forever. Every broker descriptor recorded `pluginVersion: "unknown"` and `clientInfo.title: "codex-pair plugin vunknown"`, defeating version-skew detection.

**Fix:** Use the static `readFileSync` ESM import. Two new tests catch regressions: direct `readPluginVersion()` semver assertion + `bootstrapBroker` descriptor `pluginVersion` assertion.

## RFC 6455 hardening (Codex Findings #3 + #4)

### 3. Control-frame encoders silently corrupted frames ≥ 126 bytes (Codex 85, Gemini 92)

`encodeCloseFrame` and `encodePongFrame` used the 7-bit length byte unconditionally. RFC 6455 §5.5 caps control frames at 125 bytes; >= 126 overflows into the extended-length encoding flags (126/127), scrambling the wire.

**Fix:** `MAX_CONTROL_FRAME_PAYLOAD = 125`; truncate reason/payload before encoding. Two new pin tests verify lengthBits stays ≤ 125 even on 200-byte inputs.

### 4. Fragmentation handling corrupted buffer state (Codex 80)

`createFrameParser` did `continue` on fragmentation, leaving the buffer state inconsistent for subsequent frames.

**Fix:** Parser marks itself `corrupted`, clears buffer, calls onError once. Connect handler now destroys the socket on parser-level errors so pending RPC requests reject via the close handler. New test verifies the parser halts further frame emission after a fragmented input.

## Defense-in-depth (Gemini Finding #4)

### 5. `clearStaleBrokerState` would unlink arbitrary paths from a tampered descriptor (Gemini 82)

`descriptor.transportUrl` was used verbatim as an unlink target. A hostile or stale `broker.json` could point the unlink at any file the user has perms for.

**Fix:** New `extractSafeSocketPath` helper validates the resolved socket path lives strictly under `stateRoot(markerDir)` before stat/unlink. New test asserts that a broker.json pointing at a victim file outside markerDir is NOT unlinked even when the descriptor is otherwise treated as stale.

## Code hygiene

- Consolidated three duplicate `node:fs` imports into one (mid-file imports were a smell flagged during multi-review writeup)
- Use canonical `readFileSync`/`statSync`/`unlinkSync` names instead of the temporary `*Fs` aliases

## Out of scope (deferred to follow-ons)

- **Gemini Finding #3** (SessionEnd lock-stomp race against concurrent SessionStart): real but only meaningfully triggerable across multiple Claude Code instances. Documenting in ROADMAP as a known limitation.
- **Codex Finding #5** (PID-reuse hazard on long-lived stale descriptors): real but low-frequency. Addressing via fingerprint-beyond-pid (broker `starttime` or UUID) is a focused follow-on.

## Diff

```
 .../claude-plugin/scripts/lib/broker-lifecycle.mjs |  68 ++++++---
 .../claude-plugin/scripts/lib/broker-transport.mjs |  94 +++++++++---
 .../src/__tests__/codex-pair-watch.test.ts         | 162 +++++++++++++++++++++
 3 files changed, 282 insertions(+), 42 deletions(-)
```

## Test plan

- [x] Plugin tests: 264 → 271 passing (+7 hotfix pins)
- [x] Lint clean across 6 workspaces
- [x] End-to-end fixture-server test exercises the REAL upgrade path (not just mocks). Sends "hello" → server echoes → client receives. Would have caught Finding #1 at PR-99 review time.
- [x] `readPluginVersion` test asserts a real semver (not "unknown") — catches regression of the ESM `require` bug
- [x] Control-frame encoder tests verify the 7-bit length is capped at 125
- [x] Path-validation test verifies a hostile descriptor doesn't unlink arbitrary files
- [x] No behavior change for production (ASK_CODEX_BROKER unset) — `isBrokerEnabled` still returns false

🤖 Generated with [Claude Code](https://claude.com/claude-code)