### PR TITLE
feat(plugin): codex-pair broker submitReview implementation (M3, ADR-093)

### DIFF
--- a/packages/claude-plugin/scripts/lib/broker-rpc.mjs
+++ b/packages/claude-plugin/scripts/lib/broker-rpc.mjs
@@ -121,6 +121,16 @@ export function createRpcClient(connection, options = {}) {
       entry.reject(err);
       pending.delete(id);
     }
+    // Multi-review M3 hotfix: also reject notification waiters — some
+    // Node transports emit "error" without a following "close", so the
+    // close-handler cleanup wouldn't run otherwise and waitFor() would
+    // hang until its own timeout. Surface the real transport error
+    // immediately for diagnostics instead of a generic timeout.
+    for (const sub of notificationSubscribers) {
+      clearTimeout(sub.timer);
+      sub.reject(err);
+    }
+    notificationSubscribers.clear();
   });
 
   return {
@@ -166,11 +176,11 @@ export function createRpcClient(connection, options = {}) {
         const sub = { method, predicate, resolve, reject, timer: null };
         sub.timer = setTimeout(() => {
           notificationSubscribers.delete(sub);
-          reject(
-            new Error(
-              `broker-rpc: waitFor(${method}) timed out after ${timeoutMs}ms`,
-            ),
-          );
+          // Multi-review M3 hotfix: attach a structured `.timeout = true`
+          // marker so callers don't have to regex-match the message.
+          const err = new Error(`broker-rpc: waitFor(${method}) timed out after ${timeoutMs}ms`);
+          err.timeout = true;
+          reject(err);
         }, timeoutMs);
         sub.timer.unref?.();
         notificationSubscribers.add(sub);

--- a/packages/claude-plugin/scripts/lib/broker-rpc.mjs
+++ b/packages/claude-plugin/scripts/lib/broker-rpc.mjs
@@ -35,6 +35,11 @@ function takeNextId() {
 export function createRpcClient(connection, options = {}) {
   const { defaultTimeoutMs = 30000, onNotification = () => {}, onProtocolError = () => {} } = options;
   const pending = new Map(); // id -> { resolve, reject, timer }
+  // Subscriber list for waitFor — each entry { method, predicate, resolve, reject, timer }.
+  // M3 needs to attach a notification listener BEFORE dispatching `turn/start`
+  // (race-safe per brainstorm Risk #1: server can emit `turn/completed` between
+  // request-send and listener-install if registered after the send).
+  const notificationSubscribers = new Set();
   let closed = false;
 
   connection.on("message", (text) => {
@@ -69,7 +74,25 @@ export function createRpcClient(connection, options = {}) {
       // Server-pushed notification (or a server-initiated request, which
       // codex-pair refuses since approvalPolicy:"never" — but pass it up
       // either way and let the caller decide).
-      onNotification({ method: env.method, params: env.params, id: env.id });
+      const notification = { method: env.method, params: env.params, id: env.id };
+      // Dispatch to waitFor subscribers first — they capture by method+predicate.
+      // Iterate a snapshot since resolved subscribers self-remove during dispatch.
+      for (const sub of [...notificationSubscribers]) {
+        if (sub.method === env.method) {
+          try {
+            if (!sub.predicate || sub.predicate(notification)) {
+              notificationSubscribers.delete(sub);
+              clearTimeout(sub.timer);
+              sub.resolve(notification);
+            }
+          } catch (err) {
+            notificationSubscribers.delete(sub);
+            clearTimeout(sub.timer);
+            sub.reject(err);
+          }
+        }
+      }
+      onNotification(notification);
       return;
     }
     onProtocolError(new Error(`broker-rpc: envelope has neither id nor method: ${text.slice(0, 120)}`));
@@ -82,6 +105,12 @@ export function createRpcClient(connection, options = {}) {
       entry.reject(new Error("broker-rpc: connection closed before response"));
       pending.delete(id);
     }
+    // Also reject any notification waiters — they'll never fire post-close.
+    for (const sub of notificationSubscribers) {
+      clearTimeout(sub.timer);
+      sub.reject(new Error("broker-rpc: connection closed before notification"));
+    }
+    notificationSubscribers.clear();
   });
 
   connection.on("error", (err) => {
@@ -120,6 +149,32 @@ export function createRpcClient(connection, options = {}) {
       // Notifications have no id and expect no response.
       if (closed) throw new Error("broker-rpc: client is closed");
       connection.sendText(JSON.stringify({ jsonrpc: "2.0", method, params }));
+    },
+    // Register a notification listener with a predicate. Returns a Promise
+    // resolving to the matched notification, OR rejecting on timeout / close.
+    // CRITICAL: call this BEFORE the request that triggers the notification
+    // (per brainstorm Risk #1 — server can emit `turn/completed` between
+    // request-send and listener-install if registered after the send).
+    //
+    // Usage in M3 submitReview:
+    //   const waiter = rpc.waitFor("turn/completed", n => n.params?.threadId === ourThreadId, timeoutMs);
+    //   await rpc.request("turn/start", { ... });
+    //   const completion = await waiter;
+    waitFor(method, predicate, timeoutMs) {
+      if (closed) return Promise.reject(new Error("broker-rpc: client is closed"));
+      return new Promise((resolve, reject) => {
+        const sub = { method, predicate, resolve, reject, timer: null };
+        sub.timer = setTimeout(() => {
+          notificationSubscribers.delete(sub);
+          reject(
+            new Error(
+              `broker-rpc: waitFor(${method}) timed out after ${timeoutMs}ms`,
+            ),
+          );
+        }, timeoutMs);
+        sub.timer.unref?.();
+        notificationSubscribers.add(sub);
+      });
     },
     get pendingCount() {
       return pending.size;

--- a/packages/claude-plugin/scripts/lib/broker.mjs
+++ b/packages/claude-plugin/scripts/lib/broker.mjs
@@ -107,13 +107,17 @@ export function buildVerdictSchema() {
               type: "string",
               description: "The concern itself — what's wrong + why it matters + how to fix.",
             },
+            title: {
+              type: "string",
+              description: "Optional short title rendered ahead of the file:line line.",
+            },
             file: {
               type: "string",
-              description: "File path (optional). When present, prepended to the rendered concern.",
+              description: "File path (optional). Prepended to the rendered concern.",
             },
-            line: {
-              type: ["integer", "string"],
-              description: "Line number (optional). Rendered as ':<line>' suffix on file.",
+            line_start: {
+              type: "integer",
+              description: "Line number (optional). Multi-review M3 hotfix: parser.mjs reads `line_start`, not `line`. Rendered as ':<n>' suffix on file.",
             },
             recommendation: {
               type: "string",
@@ -370,18 +374,29 @@ export async function submitReview(args) {
   // 4. Wire cancellation. abortSignal abort → turn/interrupt + reject.
   let abortHandler = null;
   let interruptSent = false;
+  // Multi-review M3 hotfix: track completion so a late abort (firing
+  // AFTER completion resolves but BEFORE finally cleans up) doesn't
+  // send a spurious turn/interrupt for an already-done turn.
+  let completed = false;
   const abortPromise =
     abortSignal
       ? new Promise((_, reject) => {
           abortHandler = () => {
+            // Early-return if we already got the completion. Closes the
+            // abort-after-completion race window flagged in multi-review.
+            if (completed) return;
             interruptSent = true;
             // Best-effort interrupt; don't await it on the abort path —
             // we want to reject the user-facing promise immediately.
             rpc
               .request(JSONRPC_METHODS.TURN_INTERRUPT, { threadId, turnId }, { timeoutMs: 2000 })
               .catch(() => {});
+            // Multi-review M3 hotfix: use `verdict` not `code` — the
+            // hook's verdictFromError reads err.verdict. "aborted" is
+            // not in VERDICT_PREFIXES so map to "error".
             const err = new Error("submitReview: aborted");
-            err.code = "aborted";
+            err.verdict = "error";
+            err.aborted = true; // structured marker for callers who care
             reject(err);
           };
           if (abortSignal.aborted) abortHandler();
@@ -395,15 +410,16 @@ export async function submitReview(args) {
     completion = abortPromise
       ? await Promise.race([completionPromise, abortPromise])
       : await completionPromise;
+    completed = true;
   } catch (err) {
     // On timeout (waitFor rejects), send best-effort interrupt so we
-    // don't leak a server-side turn.
-    if (!interruptSent && err && err.message && /timed out/.test(err.message)) {
-      rpc
-        .request(JSONRPC_METHODS.TURN_INTERRUPT, { threadId, turnId }, { timeoutMs: 2000 })
-        .catch(() => {});
+    // don't leak a server-side turn. Multi-review M3 hotfix: use the
+    // structured err.timeout marker from broker-rpc, not regex on message.
+    if (!interruptSent && err && err.timeout === true) {
+      rpc.request(JSONRPC_METHODS.TURN_INTERRUPT, { threadId, turnId }, { timeoutMs: 2000 }).catch(() => {});
       const wrapped = new Error("submitReview: turn timed out");
-      wrapped.code = "timeout";
+      wrapped.verdict = "timeout";
+      wrapped.timeout = true;
       throw wrapped;
     }
     throw err;
@@ -411,28 +427,33 @@ export async function submitReview(args) {
     if (abortHandler && abortSignal) {
       abortSignal.removeEventListener("abort", abortHandler);
     }
+    // If the abort handler already fired but we'd completed, it sent a
+    // spurious interrupt and rejected an unawaited promise. The flag
+    // above prevents that — abortHandler now early-returns if completed.
   }
 
   // 6. Extract the final agentMessage from `turn.items`. Brainstorm
   // confirmed multiple `agentMessage` items can appear (reasoning summaries
   // vs final answer); `findLast` picks the last/final one.
+  // `completed` is read by the abortHandler closure to detect the
+  // abort-after-completion race; biome won't strip it.
   const turn = completion?.params?.turn;
   if (!turn || !Array.isArray(turn.items)) {
     const err = new Error("submitReview: turn/completed missing turn.items");
-    err.code = "parse_failed";
+    err.verdict = "parse_failed";
     throw err;
   }
   if (turn.status === "failed" || turn.status === "interrupted") {
     const err = new Error(
       `submitReview: turn ${turn.status}${turn.error?.message ? ` — ${turn.error.message}` : ""}`,
     );
-    err.code = "error";
+    err.verdict = "error";
     throw err;
   }
   const finalMessage = turn.items.findLast?.((i) => i?.type === "agentMessage");
   if (!finalMessage || typeof finalMessage.text !== "string") {
     const err = new Error("submitReview: turn/completed has no agentMessage item");
-    err.code = "parse_failed";
+    err.verdict = "parse_failed";
     throw err;
   }
   return finalMessage.text;

--- a/packages/claude-plugin/scripts/lib/broker.mjs
+++ b/packages/claude-plugin/scripts/lib/broker.mjs
@@ -65,36 +65,60 @@ export const JSONRPC_NOTIFICATIONS = Object.freeze({
 // means we get a structured verdict back without prose-parsing (per
 // ADR-083's verdict contract). Centralized here so test fixtures and
 // production code build the same schema.
+// JSON Schema for `turn/start.outputSchema`. Harmonized in M3 to match
+// the `parseConcernsJson` contract in `lib/parser.mjs` so the broker's
+// structured output drops in to the existing per-edit hook flow without
+// translation. Brainstorm-coordinator and codex-pair both flagged the
+// prior mismatch (the original schema used `concerns: { high, med, low }`
+// while the parser expects `findings: [{ severity, ... }]`).
+//
+// Shape matches `parser.mjs::parseConcernsJson`:
+//   { verdict: "clean" } → no concerns
+//   { verdict: "concerns", findings: [{ severity, body, file?, line?, recommendation? }] }
+//
+// Severity enum mirrors `lib/parser.mjs::SEVERITY_TO_BUCKET`:
+//   "high" | "medium" | "low" (parser also accepts "med" but the codex
+//   model emits the canonical "medium" — `med` is a legacy alias).
 export function buildVerdictSchema() {
   return {
     type: "object",
-    required: ["verdict", "concerns"],
+    required: ["verdict"],
     additionalProperties: false,
     properties: {
       verdict: {
         type: "string",
-        enum: ["none", "concerns"],
-        description: "ADR-083 verdict closed set.",
+        enum: ["clean", "concerns"],
+        description: "Closed-set verdict (parser.mjs:parseConcernsJson contract).",
       },
-      concerns: {
-        type: "object",
-        required: ["high", "med", "low"],
-        additionalProperties: false,
-        properties: {
-          high: {
-            type: "array",
-            items: { type: "string" },
-            description: "HIGH-severity concerns. Surfaced via systemMessage.",
-          },
-          med: {
-            type: "array",
-            items: { type: "string" },
-            description: "MED-severity concerns. Surfaced via systemMessage.",
-          },
-          low: {
-            type: "array",
-            items: { type: "string" },
-            description: "LOW-severity concerns. Logged only (ADR-077 threshold).",
+      findings: {
+        type: "array",
+        description: "Required when verdict == 'concerns'. Empty array also accepted.",
+        items: {
+          type: "object",
+          required: ["severity", "body"],
+          additionalProperties: false,
+          properties: {
+            severity: {
+              type: "string",
+              enum: ["high", "medium", "low"],
+              description: "ADR-077 severity ladder. 'medium' (canonical) — 'med' is a legacy alias.",
+            },
+            body: {
+              type: "string",
+              description: "The concern itself — what's wrong + why it matters + how to fix.",
+            },
+            file: {
+              type: "string",
+              description: "File path (optional). When present, prepended to the rendered concern.",
+            },
+            line: {
+              type: ["integer", "string"],
+              description: "Line number (optional). Rendered as ':<line>' suffix on file.",
+            },
+            recommendation: {
+              type: "string",
+              description: "Optional fix suggestion. Appended on a new line after body.",
+            },
           },
         },
       },
@@ -257,8 +281,159 @@ export async function probeBrokerHealth(state) {
 // Returns: { agentMessage: string, tokenUsage: { ... }, durationMs: number }
 // — mirrors the shape spawnCodex currently produces so the hook's main()
 // integration is a one-line substitution.
-export async function submitReview(_args) {
-  throw new Error(
-    "Broker submitReview not implemented yet — see ADR-093 Milestone 3",
+// Tier 3 Milestone 3 implementation. Performs the JSON-RPC dance per
+// ADR-093 + brainstorm-verified protocol facts:
+//   1. `thread/start { ephemeral: true, cwd, baseInstructions, model,
+//      approvalPolicy: "never", sandbox: "read-only" }`
+//      → receives `{ thread: Thread }`. Pin `thread.id`.
+//   2. Register `turn/completed` waiter BEFORE turn/start (race-safe).
+//   3. `turn/start { threadId, input: [{type:"text", text: prompt}],
+//      outputSchema: buildVerdictSchema(), effort: "high",
+//      sandboxPolicy: { type: "readOnly", networkAccess: false } }`
+//      → receives `{ turn: Turn }`. Pin `turn.id`.
+//   4. Await `turn/completed` notification matching our threadId. Extract
+//      the final agentMessage text via `turn.items.findLast(i =>
+//      i.type === "agentMessage")?.text`.
+//   5. On abort: send `turn/interrupt { threadId, turnId }` best-effort.
+//   6. Return STRING (matches spawnCodex's return so the hook flow doesn't
+//      need a translation layer).
+//
+// `args` shape (refined from ADR-090's `(state, prompt, options)`):
+//   { connection, rpc, cwd, baseInstructions, prompt, model, timeoutMs,
+//     abortSignal }
+//
+// Caller owns connection + rpc lifetime; submitReview does NOT close them.
+// Failures map to thrown errors with `.code` matching the existing
+// taggedError verdict set in codex-pair-watch.mjs (timeout, error,
+// parse_failed) so the surrounding hook flow handles them uniformly.
+export async function submitReview(args) {
+  const { rpc, connection, cwd, baseInstructions, prompt, model, timeoutMs = 60_000, abortSignal } = args;
+  if (!rpc) throw new Error("submitReview: rpc client required");
+  if (!connection) throw new Error("submitReview: connection required");
+  if (typeof prompt !== "string" || prompt.length === 0) {
+    throw new Error("submitReview: prompt required");
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  const remaining = () => Math.max(0, deadline - Date.now());
+
+  // 1. thread/start (ephemeral — codex auto-discards after the turn).
+  // approvalPolicy: "never" is mandatory for the hook context (no user
+  // available to approve interactive prompts). sandbox: "read-only" denies
+  // file writes from the reviewer.
+  const threadResp = await rpc.request(
+    JSONRPC_METHODS.THREAD_START,
+    {
+      ephemeral: true,
+      cwd,
+      baseInstructions,
+      model,
+      approvalPolicy: "never",
+      sandbox: "read-only",
+    },
+    { timeoutMs: remaining() },
   );
+  const threadId = threadResp?.thread?.id;
+  if (typeof threadId !== "string") {
+    throw new Error("submitReview: thread/start returned no thread.id");
+  }
+
+  // 2. Register the turn/completed waiter BEFORE turn/start. Codex can
+  // emit turn/completed between the turn/start dispatch and the listener
+  // registration if we order them the other way around (brainstorm
+  // Risk #1).
+  const completionPromise = rpc.waitFor(
+    JSONRPC_NOTIFICATIONS.TURN_COMPLETED,
+    (n) => n.params?.threadId === threadId,
+    remaining(),
+  );
+
+  // 3. turn/start. outputSchema constrains the agent's final message to
+  // the parser-compatible shape (parser.mjs::parseConcernsJson).
+  const turnResp = await rpc.request(
+    JSONRPC_METHODS.TURN_START,
+    {
+      threadId,
+      input: [{ type: "text", text: prompt }],
+      outputSchema: buildVerdictSchema(),
+      effort: "high",
+      // Belt-and-suspenders: also pin turn-level sandbox + deny network.
+      sandboxPolicy: { type: "readOnly", networkAccess: false },
+    },
+    { timeoutMs: remaining() },
+  );
+  const turnId = turnResp?.turn?.id;
+  if (typeof turnId !== "string") {
+    throw new Error("submitReview: turn/start returned no turn.id");
+  }
+
+  // 4. Wire cancellation. abortSignal abort → turn/interrupt + reject.
+  let abortHandler = null;
+  let interruptSent = false;
+  const abortPromise =
+    abortSignal
+      ? new Promise((_, reject) => {
+          abortHandler = () => {
+            interruptSent = true;
+            // Best-effort interrupt; don't await it on the abort path —
+            // we want to reject the user-facing promise immediately.
+            rpc
+              .request(JSONRPC_METHODS.TURN_INTERRUPT, { threadId, turnId }, { timeoutMs: 2000 })
+              .catch(() => {});
+            const err = new Error("submitReview: aborted");
+            err.code = "aborted";
+            reject(err);
+          };
+          if (abortSignal.aborted) abortHandler();
+          else abortSignal.addEventListener("abort", abortHandler);
+        })
+      : null;
+
+  // 5. Race the completion against the abort.
+  let completion;
+  try {
+    completion = abortPromise
+      ? await Promise.race([completionPromise, abortPromise])
+      : await completionPromise;
+  } catch (err) {
+    // On timeout (waitFor rejects), send best-effort interrupt so we
+    // don't leak a server-side turn.
+    if (!interruptSent && err && err.message && /timed out/.test(err.message)) {
+      rpc
+        .request(JSONRPC_METHODS.TURN_INTERRUPT, { threadId, turnId }, { timeoutMs: 2000 })
+        .catch(() => {});
+      const wrapped = new Error("submitReview: turn timed out");
+      wrapped.code = "timeout";
+      throw wrapped;
+    }
+    throw err;
+  } finally {
+    if (abortHandler && abortSignal) {
+      abortSignal.removeEventListener("abort", abortHandler);
+    }
+  }
+
+  // 6. Extract the final agentMessage from `turn.items`. Brainstorm
+  // confirmed multiple `agentMessage` items can appear (reasoning summaries
+  // vs final answer); `findLast` picks the last/final one.
+  const turn = completion?.params?.turn;
+  if (!turn || !Array.isArray(turn.items)) {
+    const err = new Error("submitReview: turn/completed missing turn.items");
+    err.code = "parse_failed";
+    throw err;
+  }
+  if (turn.status === "failed" || turn.status === "interrupted") {
+    const err = new Error(
+      `submitReview: turn ${turn.status}${turn.error?.message ? ` — ${turn.error.message}` : ""}`,
+    );
+    err.code = "error";
+    throw err;
+  }
+  const finalMessage = turn.items.findLast?.((i) => i?.type === "agentMessage");
+  if (!finalMessage || typeof finalMessage.text !== "string") {
+    const err = new Error("submitReview: turn/completed has no agentMessage item");
+    err.code = "parse_failed";
+    throw err;
+  }
+  return finalMessage.text;
 }

--- a/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
+++ b/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
@@ -2921,7 +2921,13 @@ describe("scripts/codex-pair-watch.mjs — runtime behavior (no codex calls)", (
         return {};
       },
       waitFor: async () => {
-        throw new Error("broker-rpc: waitFor(turn/completed) timed out after 50ms");
+        // Multi-review M3 hotfix: timeout is detected via structured
+        // err.timeout marker, not regex on message. Mock fakes the
+        // marker that the real waitFor attaches.
+        const e = new Error("broker-rpc: waitFor(turn/completed) timed out after 50ms");
+        // biome-ignore lint/suspicious/noExplicitAny: structured marker
+        (e as any).timeout = true;
+        throw e;
       },
     };
     // biome-ignore lint/suspicious/noExplicitAny: test mock
@@ -2941,7 +2947,7 @@ describe("scripts/codex-pair-watch.mjs — runtime behavior (no codex calls)", (
       caught = err as Error;
     }
     // biome-ignore lint/suspicious/noExplicitAny: test mock
-    expect((caught as any)?.code).toBe("timeout");
+    expect((caught as any)?.verdict).toBe("timeout");
     expect(interruptCalls).toHaveLength(1);
     expect((interruptCalls[0].params as { threadId: string; turnId: string }).threadId).toBe("T1");
     expect((interruptCalls[0].params as { threadId: string; turnId: string }).turnId).toBe("U1");
@@ -2980,7 +2986,7 @@ describe("scripts/codex-pair-watch.mjs — runtime behavior (no codex calls)", (
       caught = err as Error;
     }
     // biome-ignore lint/suspicious/noExplicitAny: test mock
-    expect((caught as any)?.code).toBe("error");
+    expect((caught as any)?.verdict).toBe("error");
     expect(caught?.message).toMatch(/quota/);
   });
 
@@ -3021,5 +3027,104 @@ describe("scripts/codex-pair-watch.mjs — runtime behavior (no codex calls)", (
     expect(p.baseInstructions).toBe("be strict");
     expect(p.approvalPolicy).toBe("never");
     expect(p.sandbox).toBe("read-only");
+  });
+
+  // Multi-review M3 HOTFIX regression tests.
+
+  it("M3 hotfix: submitReview errors set err.verdict (hook reads .verdict, not .code)", async () => {
+    const { submitReview } = await import("../../scripts/lib/broker.mjs");
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const mockRpc: any = {
+      request: async (method: string) => {
+        if (method === "thread/start") return { thread: { id: "T1" } };
+        if (method === "turn/start") return { turn: { id: "U1" } };
+        return {};
+      },
+      waitFor: async () => ({
+        method: "turn/completed",
+        params: { threadId: "T1", turn: { id: "U1", status: "completed", items: [] } },
+      }),
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const mockConn: any = { close: () => {}, on: () => {}, destroyed: false };
+    let caught: Error | null = null;
+    try {
+      await submitReview({
+        rpc: mockRpc,
+        connection: mockConn,
+        cwd: "/tmp",
+        baseInstructions: "ctx",
+        prompt: "x",
+        model: "gpt-5.5",
+      });
+    } catch (err) {
+      caught = err as Error;
+    }
+    // biome-ignore lint/suspicious/noExplicitAny: structured marker
+    expect((caught as any)?.verdict).toBe("parse_failed");
+    // The legacy `code` field is NOT set (hook reads .verdict only)
+    // biome-ignore lint/suspicious/noExplicitAny: structured marker
+    expect((caught as any)?.code).toBeUndefined();
+  });
+
+  it("M3 hotfix: buildVerdictSchema uses line_start (matches parser.mjs::formatFindingBody)", async () => {
+    const { buildVerdictSchema } = await import("../../scripts/lib/broker.mjs");
+    const schema = buildVerdictSchema();
+    const findingProps = schema.properties.findings.items.properties;
+    expect(findingProps.line_start).toBeDefined();
+    expect(findingProps.line_start.type).toBe("integer");
+    expect(findingProps.line).toBeUndefined();
+  });
+
+  it("M3 hotfix: buildVerdictSchema includes optional title (parser renders it)", async () => {
+    const { buildVerdictSchema } = await import("../../scripts/lib/broker.mjs");
+    const schema = buildVerdictSchema();
+    const findingProps = schema.properties.findings.items.properties;
+    expect(findingProps.title).toBeDefined();
+    expect(findingProps.title.type).toBe("string");
+  });
+
+  it("M3 hotfix: rpc.waitFor timeout attaches err.timeout = true (structured marker)", async () => {
+    const { createRpcClient, __testing__ } = await import("../../scripts/lib/broker-rpc.mjs");
+    __testing__.resetIdCounter();
+    const listeners: Record<string, Array<(arg?: unknown) => void>> = { message: [], close: [], error: [] };
+    const mock = {
+      sendText: () => {},
+      close: () => {},
+      on: (event: string, cb: (arg?: unknown) => void) => listeners[event]?.push(cb),
+      get destroyed() {
+        return false;
+      },
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: mock
+    const rpc = createRpcClient(mock as any, { defaultTimeoutMs: 5000 });
+    let caught: Error | null = null;
+    try {
+      await rpc.waitFor("turn/completed", null, 50);
+    } catch (err) {
+      caught = err as Error;
+    }
+    // biome-ignore lint/suspicious/noExplicitAny: structured marker
+    expect((caught as any)?.timeout).toBe(true);
+  });
+
+  it("M3 hotfix: rpc connection.error rejects pending notification subscribers", async () => {
+    const { createRpcClient } = await import("../../scripts/lib/broker-rpc.mjs");
+    const listeners: Record<string, Array<(arg?: unknown) => void>> = { message: [], close: [], error: [] };
+    const mock = {
+      sendText: () => {},
+      close: () => {},
+      on: (event: string, cb: (arg?: unknown) => void) => listeners[event]?.push(cb),
+      get destroyed() {
+        return false;
+      },
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: mock
+    const rpc = createRpcClient(mock as any, { defaultTimeoutMs: 5000 });
+    const p = rpc.waitFor("turn/completed", null, 10000);
+    // Simulate transport error WITHOUT a subsequent close
+    const transportErr = new Error("ECONNRESET");
+    for (const cb of listeners.error) cb(transportErr);
+    await expect(p).rejects.toThrow(/ECONNRESET/);
   });
 });

--- a/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
+++ b/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
@@ -1944,16 +1944,13 @@ describe("scripts/codex-pair-watch.mjs — runtime behavior (no codex calls)", (
     expect(p).toContain(BROKER_STATE_FILE);
   });
 
-  it("ADR-093: submitReview throws until implementation lands (single-args shape per ADR-093)", async () => {
+  it("ADR-093 M3: submitReview rejects when required args missing (signature contract)", async () => {
     const { submitReview } = await import("../../scripts/lib/broker.mjs");
-    await expect(
-      submitReview({
-        state: {},
-        baseInstructions: "ctx",
-        prompt: "review",
-        model: "gpt-5.5",
-      }),
-    ).rejects.toThrow(/not implemented yet/);
+    // Empty args → no rpc/connection/prompt — must reject with a clear message.
+    // Implementation landed in M3; the stub-throws test from M2 PR 1 is now
+    // obsolete and replaced by argument-validation pins.
+    // biome-ignore lint/suspicious/noExplicitAny: explicit empty-args test
+    await expect(submitReview({} as any)).rejects.toThrow(/rpc client required/);
   });
 
   it("ADR-090: hooks.json registers SessionStart and SessionEnd dispatchers", () => {
@@ -1999,23 +1996,10 @@ describe("scripts/codex-pair-watch.mjs — runtime behavior (no codex calls)", (
     expect(Object.isFrozen(JSONRPC_NOTIFICATIONS)).toBe(true);
   });
 
-  it("ADR-093: buildVerdictSchema returns ADR-083-compliant verdict shape", async () => {
-    const { buildVerdictSchema } = await import("../../scripts/lib/broker.mjs");
-    const schema = buildVerdictSchema();
-    expect(schema.type).toBe("object");
-    expect(schema.required).toContain("verdict");
-    expect(schema.required).toContain("concerns");
-    expect(schema.additionalProperties).toBe(false);
-    // verdict closed set per ADR-083
-    expect(schema.properties.verdict.enum).toEqual(["none", "concerns"]);
-    // concerns shape pins HIGH/MED/LOW arrays of strings (ADR-077 grading)
-    const concernsProps = schema.properties.concerns.properties;
-    expect(concernsProps.high.type).toBe("array");
-    expect(concernsProps.high.items.type).toBe("string");
-    expect(concernsProps.med.items.type).toBe("string");
-    expect(concernsProps.low.items.type).toBe("string");
-    expect(schema.properties.concerns.required).toEqual(["high", "med", "low"]);
-  });
+  // The original "concerns: { high, med, low }" schema-shape test from M2
+  // PR 1 was REPLACED in M3 by the parser-harmonized shape. See the M3
+  // schema test below ("ADR-093 M3 schema: buildVerdictSchema matches
+  // parser.mjs::parseConcernsJson contract") for the current contract.
 
   it("ADR-093: broker.mjs documents the protocol-mapping in its module docstring", () => {
     // Structural pin: future readers must be able to find the protocol
@@ -2833,5 +2817,209 @@ describe("scripts/codex-pair-watch.mjs — runtime behavior (no codex calls)", (
     // unhandled and can crash the process. Fix uses `.on("error")`.
     expect(transport).toMatch(/socket\.on\("error"/);
     // The pre-upgrade reject() is idempotent so multiple invocations are safe.
+  });
+  // Milestone 3: submitReview body + rpc.waitFor + harmonized output schema.
+
+  it("ADR-093 M3 schema: buildVerdictSchema matches parser.mjs::parseConcernsJson contract", async () => {
+    const { buildVerdictSchema } = await import("../../scripts/lib/broker.mjs");
+    const schema = buildVerdictSchema();
+    expect(schema.required).toEqual(["verdict"]);
+    expect(schema.properties.verdict.enum).toEqual(["clean", "concerns"]);
+    expect(schema.properties.findings.type).toBe("array");
+    expect(schema.properties.findings.items.required).toEqual(["severity", "body"]);
+    expect(schema.properties.findings.items.properties.severity.enum).toEqual(["high", "medium", "low"]);
+  });
+
+  it("ADR-093 M3 rpc: waitFor resolves when matching notification arrives", async () => {
+    const { createRpcClient, __testing__ } = await import("../../scripts/lib/broker-rpc.mjs");
+    __testing__.resetIdCounter();
+    const listeners: Record<string, Array<(arg?: unknown) => void>> = { message: [], close: [], error: [] };
+    const mock = {
+      sendText: () => {},
+      close: () => {},
+      on: (event: string, cb: (arg?: unknown) => void) => listeners[event]?.push(cb),
+      get destroyed() {
+        return false;
+      },
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: mock connection shape
+    const rpc = createRpcClient(mock as any, { defaultTimeoutMs: 1000 });
+    const waiter = rpc.waitFor("turn/completed", (n) => (n.params as { threadId?: string })?.threadId === "T1", 1000);
+    for (const cb of listeners.message)
+      cb(JSON.stringify({ method: "turn/completed", params: { threadId: "T1", turn: { id: "U1", items: [] } } }));
+    const result = await waiter;
+    expect((result.params as { threadId?: string }).threadId).toBe("T1");
+  });
+
+  it("ADR-093 M3 rpc: waitFor rejects on timeout", async () => {
+    const { createRpcClient, __testing__ } = await import("../../scripts/lib/broker-rpc.mjs");
+    __testing__.resetIdCounter();
+    const listeners: Record<string, Array<(arg?: unknown) => void>> = { message: [], close: [], error: [] };
+    const mock = {
+      sendText: () => {},
+      close: () => {},
+      on: (event: string, cb: (arg?: unknown) => void) => listeners[event]?.push(cb),
+      get destroyed() {
+        return false;
+      },
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: mock connection shape
+    const rpc = createRpcClient(mock as any, { defaultTimeoutMs: 5000 });
+    await expect(rpc.waitFor("turn/completed", null, 50)).rejects.toThrow(/waitFor.*timed out/);
+  });
+
+  it("ADR-093 M3 submitReview: happy path returns final agentMessage text", async () => {
+    const { submitReview } = await import("../../scripts/lib/broker.mjs");
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const mockRpc: any = {
+      request: async (method: string) => {
+        if (method === "thread/start") return { thread: { id: "T1" } };
+        if (method === "turn/start") return { turn: { id: "U1" } };
+        throw new Error("unexpected method");
+      },
+      waitFor: async () => ({
+        method: "turn/completed",
+        params: {
+          threadId: "T1",
+          turn: {
+            id: "U1",
+            status: "completed",
+            items: [
+              { type: "reasoning", text: "x" },
+              { type: "agentMessage", text: '{"verdict":"clean"}' },
+            ],
+          },
+        },
+      }),
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const mockConn: any = { close: () => {}, on: () => {}, destroyed: false };
+    const result = await submitReview({
+      rpc: mockRpc,
+      connection: mockConn,
+      cwd: "/tmp",
+      baseInstructions: "ctx",
+      prompt: "x",
+      model: "gpt-5.5",
+      timeoutMs: 5000,
+    });
+    expect(result).toBe('{"verdict":"clean"}');
+  });
+
+  it("ADR-093 M3 submitReview: throws code=timeout + sends turn/interrupt on waitFor timeout", async () => {
+    const { submitReview } = await import("../../scripts/lib/broker.mjs");
+    const interruptCalls: Array<{ method: string; params: unknown }> = [];
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const mockRpc: any = {
+      request: async (method: string, params: unknown) => {
+        if (method === "thread/start") return { thread: { id: "T1" } };
+        if (method === "turn/start") return { turn: { id: "U1" } };
+        if (method === "turn/interrupt") {
+          interruptCalls.push({ method, params });
+          return {};
+        }
+        return {};
+      },
+      waitFor: async () => {
+        throw new Error("broker-rpc: waitFor(turn/completed) timed out after 50ms");
+      },
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const mockConn: any = { close: () => {}, on: () => {}, destroyed: false };
+    let caught: Error | null = null;
+    try {
+      await submitReview({
+        rpc: mockRpc,
+        connection: mockConn,
+        cwd: "/tmp",
+        baseInstructions: "ctx",
+        prompt: "x",
+        model: "gpt-5.5",
+        timeoutMs: 100,
+      });
+    } catch (err) {
+      caught = err as Error;
+    }
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    expect((caught as any)?.code).toBe("timeout");
+    expect(interruptCalls).toHaveLength(1);
+    expect((interruptCalls[0].params as { threadId: string; turnId: string }).threadId).toBe("T1");
+    expect((interruptCalls[0].params as { threadId: string; turnId: string }).turnId).toBe("U1");
+  });
+
+  it("ADR-093 M3 submitReview: throws code=error when turn.status is failed", async () => {
+    const { submitReview } = await import("../../scripts/lib/broker.mjs");
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const mockRpc: any = {
+      request: async (method: string) => {
+        if (method === "thread/start") return { thread: { id: "T1" } };
+        if (method === "turn/start") return { turn: { id: "U1" } };
+        return {};
+      },
+      waitFor: async () => ({
+        method: "turn/completed",
+        params: {
+          threadId: "T1",
+          turn: { id: "U1", status: "failed", error: { message: "quota exhausted" }, items: [] },
+        },
+      }),
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const mockConn: any = { close: () => {}, on: () => {}, destroyed: false };
+    let caught: Error | null = null;
+    try {
+      await submitReview({
+        rpc: mockRpc,
+        connection: mockConn,
+        cwd: "/tmp",
+        baseInstructions: "ctx",
+        prompt: "x",
+        model: "gpt-5.5",
+      });
+    } catch (err) {
+      caught = err as Error;
+    }
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    expect((caught as any)?.code).toBe("error");
+    expect(caught?.message).toMatch(/quota/);
+  });
+
+  it("ADR-093 M3 submitReview: thread/start params include ephemeral + approvalPolicy:'never' + sandbox:'read-only'", async () => {
+    const { submitReview } = await import("../../scripts/lib/broker.mjs");
+    let threadStartParams: unknown;
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const mockRpc: any = {
+      request: async (method: string, params: unknown) => {
+        if (method === "thread/start") {
+          threadStartParams = params;
+          return { thread: { id: "T1" } };
+        }
+        if (method === "turn/start") return { turn: { id: "U1" } };
+        return {};
+      },
+      waitFor: async () => ({
+        method: "turn/completed",
+        params: {
+          threadId: "T1",
+          turn: { id: "U1", status: "completed", items: [{ type: "agentMessage", text: '{"verdict":"clean"}' }] },
+        },
+      }),
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const mockConn: any = { close: () => {}, on: () => {}, destroyed: false };
+    await submitReview({
+      rpc: mockRpc,
+      connection: mockConn,
+      cwd: "/proj",
+      baseInstructions: "be strict",
+      prompt: "x",
+      model: "gpt-5.5",
+    });
+    const p = threadStartParams as Record<string, unknown>;
+    expect(p.ephemeral).toBe(true);
+    expect(p.cwd).toBe("/proj");
+    expect(p.baseInstructions).toBe("be strict");
+    expect(p.approvalPolicy).toBe("never");
+    expect(p.sandbox).toBe("read-only");
   });
 });


### PR DESCRIPTION
## Summary

**Tier 3 Milestone 3 — the heart of the broker.** Implements the 3-step JSON-RPC dance (`thread/start` ephemeral → `turn/start` → wait for `turn/completed`) per ADR-093 brainstorm-verified protocol facts. Behind `ASK_CODEX_BROKER=1` — production behavior byte-identical; `isBrokerEnabled` still returns false until M4 wires the hook.

## Protocol findings from the brainstorm (verified against codex-cli 0.130.0 schema)

The brainstorm probed `codex app-server generate-json-schema` and corrected several prompt assumptions:

| Claim verified | Implication |
|---|---|
| `TurnStartResponse` is `{ turn: Turn }` NOT `{ turn: { id } }` | Pin `turn.id` from `response.turn.id` |
| `turn/completed` payload is `{ threadId, turn: Turn }` | Extract via `turn.items.findLast(i => i.type === "agentMessage")?.text` (multiple agentMessage items possible) |
| `turn/interrupt` requires BOTH `threadId` AND `turnId` | Track both across the request lifecycle |
| Sandbox enum: kebab-case `"read-only"`; approvalPolicy enum `"never"` | Pin in submitReview params |
| codex responses lack `jsonrpc:"2.0"` discriminator | Already handled by M2's tolerant parser |

## Files changed

### `scripts/lib/broker.mjs`

- **`submitReview` body** (replaces M2 throwing stub):
  1. `thread/start { ephemeral: true, cwd, baseInstructions, model, approvalPolicy: "never", sandbox: "read-only" }`
  2. Register `turn/completed` waiter BEFORE `turn/start` (race-safe per brainstorm Risk #1)
  3. `turn/start { threadId, input, outputSchema, effort: "high", sandboxPolicy: { type: "readOnly", networkAccess: false } }`
  4. Race completion against abortSignal
  5. Extract `turn.items.findLast(agentMessage).text` → return STRING (matches `spawnCodex` for drop-in compatibility)
- **Error mapping**: `code="timeout"` (with best-effort `turn/interrupt`), `code="error"` (turn failed/interrupted), `code="parse_failed"` (missing agentMessage), `code="aborted"` (external abort).
- **`buildVerdictSchema` harmonized** to match `parser.mjs::parseConcernsJson` contract: `{ verdict: "clean" | "concerns", findings: [{severity, body, file?, line?, recommendation?}] }`. Drops in without a translation layer.

### `scripts/lib/broker-rpc.mjs`

- **New `rpc.waitFor(method, predicate, timeoutMs)`**: Promise that resolves when a matching notification arrives. **Critical**: callers must register BEFORE the triggering request (race-safe). Connection close rejects pending waiters.

## Tests added (6 new pins, 278 → 284)

- M3 schema matches `parseConcernsJson` contract
- `rpc.waitFor` resolves on matching notification + rejects on timeout
- `submitReview` happy path returns final agentMessage text
- `submitReview` throws `code=timeout` + sends `turn/interrupt` on waitFor timeout
- `submitReview` throws `code=error` when `turn.status === "failed"`
- `submitReview` `thread/start` params pin `ephemeral` + `approvalPolicy:"never"` + `sandbox:"read-only"`

Updated obsolete M2 PR 1 tests:
- "submitReview throws until implementation lands" → rewritten to validate M3 arg-validation
- "buildVerdictSchema returns concerns: {high,med,low}" → removed (replaced by parser-harmonized schema test)

## Out of scope for M3 (Milestone 4)

- Flip `isBrokerEnabled` to return true when descriptor exists + protocol/version match
- Wire `codex-pair-watch.mjs`'s main() to call `submitReview` when broker enabled
- End-to-end test against a real `codex app-server` (brainstorm recommended deferring; M4 owns live integration smoke)

## Diff

```
 packages/claude-plugin/scripts/lib/broker-rpc.mjs  |  57 ++++-
 packages/claude-plugin/scripts/lib/broker.mjs      | 225 ++++++++++++++++---
 .../src/__tests__/codex-pair-watch.test.ts         | 240 ++++++++++++++++---
 3 files changed, 470 insertions(+), 52 deletions(-)
```

## Test plan

- [x] Plugin tests: 278 → 284 passing
- [x] Lint clean across 6 workspaces
- [x] No production code path change — `isBrokerEnabled` still returns false; hook still uses per-edit codex spawn
- [x] Protocol shape verified against codex-cli 0.130.0 generated schema
- [x] Cancellation contract: `turn/interrupt` sent on timeout AND on abort
- [ ] /multi-review on this diff (per goal-directive)
- [ ] End-to-end against real `codex app-server` (M4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)