### PR TITLE
feat(plugin): codex-pair broker hook integration (M4, ADR-093) — TIER 3 COMPLETE

### DIFF
--- a/packages/claude-plugin/scripts/codex-pair-watch.mjs
+++ b/packages/claude-plugin/scripts/codex-pair-watch.mjs
@@ -40,8 +40,6 @@ import { IS_WINDOWS, terminateProcessTree } from "./lib/process.mjs";
 // fire, but isBrokerEnabled returns false fast when ASK_CODEX_BROKER
 // isn't set, so the per-edit fast path is unaffected.
 import { initializeBroker, isBrokerEnabled, readBrokerState, submitReview } from "./lib/broker.mjs";
-import { connectWebSocket } from "./lib/broker-transport.mjs";
-import { createRpcClient } from "./lib/broker-rpc.mjs";
 import { buildReviewPrompt } from "./lib/prompt.mjs";
 import {
   buildVerdictMessage,
@@ -980,43 +978,21 @@ async function main() {
   let response;
   let fellBack = false;
   try {
-    if (isBrokerEnabled(markerDir)) {
-      const state = readBrokerState(markerDir);
-      const connection = await connectWebSocket(state.transportUrl, { timeoutMs: 5000 });
-      let rpc;
-      try {
-        rpc = createRpcClient(connection);
-        const brokerPrompt = buildPrompt({
-          filePath,
-          fileContent: promptContent,
-          toolName,
-          projectContext: "", // Sent via baseInstructions instead
-          partialView,
-        });
-        response = await submitReview({
-          connection,
-          rpc,
-          cwd: markerDir,
-          baseInstructions: projectContext,
-          prompt: brokerPrompt,
-          model: config.model,
-          timeoutMs: config.timeoutMs,
-        });
-      } finally {
-        connection.on("error", () => {}); // Handle any unhandled errors on close
-        connection.close();
-      }
-    } else {
-      const result = await runCodexWithFallback({
-        prompt,
-        timeoutMs: config.timeoutMs,
-        model: config.model,
-        fallbackModel: config.fallbackModel,
-        markerDir,
-      });
-      response = result.response;
-      fellBack = result.fellBack;
-    }
+    // M4 multi-review hotfix: dispatch unified through runCodexWithFallback
+    // for BOTH broker and spawn modes. Previous duplicate inline branch
+    // bypassed runWithBroker's brokerFailure-fallback semantics + missed
+    // initialize handshake + missed quota fallback. Both /multi-review
+    // reviewers (Codex 98% + Claude 98%) caught this independently —
+    // a duplicate dispatch path I auto-completed without realizing.
+    const result = await runCodexWithFallback({
+      prompt,
+      timeoutMs: config.timeoutMs,
+      model: config.model,
+      fallbackModel: config.fallbackModel,
+      markerDir,
+    });
+    response = result.response;
+    fellBack = result.fellBack;
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     const verdict = verdictFromError(err);

--- a/packages/claude-plugin/scripts/codex-pair-watch.mjs
+++ b/packages/claude-plugin/scripts/codex-pair-watch.mjs
@@ -34,6 +34,14 @@ import { dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { IS_WINDOWS, terminateProcessTree } from "./lib/process.mjs";
+// M4: broker integration. Importing initializeBroker + isBrokerEnabled +
+// submitReview from broker.mjs transitively pulls in broker-transport,
+// broker-rpc, broker-lifecycle. ESM-static cost is paid on every hook
+// fire, but isBrokerEnabled returns false fast when ASK_CODEX_BROKER
+// isn't set, so the per-edit fast path is unaffected.
+import { initializeBroker, isBrokerEnabled, readBrokerState, submitReview } from "./lib/broker.mjs";
+import { connectWebSocket } from "./lib/broker-transport.mjs";
+import { createRpcClient } from "./lib/broker-rpc.mjs";
 import { buildReviewPrompt } from "./lib/prompt.mjs";
 import {
   buildVerdictMessage,
@@ -648,7 +656,108 @@ async function spawnCodexWithRetry({ prompt, model, timeoutMs, markerDir }) {
   }
 }
 
+// M4: cached plugin clientInfo for broker handshake. Built once per
+// process (per ADR-095, plugin version detection used to silently always
+// return "unknown" before the ESM fix).
+let _cachedBrokerClientInfo = null;
+function brokerClientInfo() {
+  if (_cachedBrokerClientInfo) return _cachedBrokerClientInfo;
+  let v = "unknown";
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const manifest = JSON.parse(readFileSync(join(here, "..", "package.json"), "utf-8"));
+    v = manifest?.version || "unknown";
+  } catch {
+    // best-effort
+  }
+  _cachedBrokerClientInfo = { name: "codex-pair", title: `codex-pair plugin v${v}`, version: v };
+  return _cachedBrokerClientInfo;
+}
+
+// M4: broker-path wrapper. Opens an RPC connection to the running
+// `codex app-server`, calls submitReview, closes the connection.
+// Connect/initialize failures get tagged with `err.brokerFailure = true`
+// so runCodexWithFallback falls back to spawnCodex silently (ADR-077).
+// Wall-clock budget is the same as spawnCodex's `timeoutMs`.
+async function runWithBroker({ prompt, timeoutMs, model, markerDir }) {
+  const state = readBrokerState(markerDir);
+  if (!state) {
+    const err = new Error("runWithBroker: no broker descriptor");
+    err.brokerFailure = true;
+    err.brokerPhase = "connect";
+    throw err;
+  }
+  let connection = null;
+  let rpc = null;
+  try {
+    // Tight handshake budget — broker should be already running; if it
+    // takes more than 2s to handshake, treat as broken and fall back
+    // rather than blocking the hook (M4 brainstorm Risk #3).
+    const init = await initializeBroker(state.transportUrl, brokerClientInfo(), {
+      handshakeTimeoutMs: 2000,
+      initializeTimeoutMs: 2000,
+    });
+    connection = init.connection;
+    rpc = init.rpc;
+  } catch (err) {
+    if (err && typeof err === "object") {
+      err.brokerFailure = true;
+      err.brokerPhase = err.brokerPhase || "connect";
+    }
+    throw err;
+  }
+  try {
+    return await submitReview({
+      connection,
+      rpc,
+      cwd: markerDir,
+      // baseInstructions is folded into `prompt` by buildReviewPrompt
+      // already; passing empty string keeps the codex API happy.
+      baseInstructions: "",
+      prompt,
+      model,
+      timeoutMs,
+    });
+  } finally {
+    if (connection) {
+      try {
+        connection.close(1000, "review done");
+      } catch {
+        // best-effort
+      }
+    }
+  }
+}
+
 async function runCodexWithFallback({ prompt, timeoutMs, model, fallbackModel, markerDir }) {
+  // M4: try the broker first if enabled. On err.brokerFailure (transport,
+  // handshake, parse-layer failure) fall through to per-edit spawnCodex
+  // silently per ADR-077. On other errors (verdict:"error" from a real
+  // codex result, verdict:"timeout") propagate as-is — retrying via
+  // spawnCodex would double the spend on cases where the model
+  // legitimately couldn't produce a verdict.
+  if (isBrokerEnabled(markerDir)) {
+    try {
+      return {
+        response: await runWithBroker({ prompt, model, timeoutMs, markerDir }),
+        fellBack: false,
+        viaBroker: true,
+      };
+    } catch (err) {
+      if (!err?.brokerFailure) throw err;
+      // brokerFailure → silent fall-through to spawnCodex path below.
+      // Append a log entry so dogfooders can audit broker-mode regressions.
+      try {
+        await appendLog(markerDir, {
+          timestamp: new Date().toISOString(),
+          verdict: "broker_fallback",
+          reason: `${err.brokerPhase || "unknown"}: ${err.message ?? String(err)}`,
+        });
+      } catch {
+        // best-effort; logging failure must never break the hook
+      }
+    }
+  }
   try {
     return {
       response: await spawnCodexWithRetry({ prompt, model, timeoutMs, markerDir }),
@@ -871,15 +980,43 @@ async function main() {
   let response;
   let fellBack = false;
   try {
-    const result = await runCodexWithFallback({
-      prompt,
-      timeoutMs: config.timeoutMs,
-      model: config.model,
-      fallbackModel: config.fallbackModel,
-      markerDir,
-    });
-    response = result.response;
-    fellBack = result.fellBack;
+    if (isBrokerEnabled(markerDir)) {
+      const state = readBrokerState(markerDir);
+      const connection = await connectWebSocket(state.transportUrl, { timeoutMs: 5000 });
+      let rpc;
+      try {
+        rpc = createRpcClient(connection);
+        const brokerPrompt = buildPrompt({
+          filePath,
+          fileContent: promptContent,
+          toolName,
+          projectContext: "", // Sent via baseInstructions instead
+          partialView,
+        });
+        response = await submitReview({
+          connection,
+          rpc,
+          cwd: markerDir,
+          baseInstructions: projectContext,
+          prompt: brokerPrompt,
+          model: config.model,
+          timeoutMs: config.timeoutMs,
+        });
+      } finally {
+        connection.on("error", () => {}); // Handle any unhandled errors on close
+        connection.close();
+      }
+    } else {
+      const result = await runCodexWithFallback({
+        prompt,
+        timeoutMs: config.timeoutMs,
+        model: config.model,
+        fallbackModel: config.fallbackModel,
+        markerDir,
+      });
+      response = result.response;
+      fellBack = result.fellBack;
+    }
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     const verdict = verdictFromError(err);

--- a/packages/claude-plugin/scripts/lib/broker.mjs
+++ b/packages/claude-plugin/scripts/lib/broker.mjs
@@ -140,8 +140,14 @@ export function buildVerdictSchema() {
 // The implementation is intentionally stubbed for v0.7.x Milestone 1.
 // Returning null here causes every hook invocation to fall through to the
 // existing per-edit spawn path — byte-identical behavior to pre-broker.
-export function readBrokerState(_markerDir) {
-  return null;
+// M4: delegate to the lifecycle module's descriptor reader. The function
+// signature is preserved for the stable contract; the body now returns
+// a real descriptor when one exists (vs the M2 stub returning null
+// unconditionally). isBrokerEnabled uses lifecycleReadBrokerDescriptor
+// directly for the same purpose; this exported form is the public API
+// per ADR-090.
+export function readBrokerState(markerDir) {
+  return lifecycleReadBrokerDescriptor(markerDir);
 }
 
 // Stable predicate the hook can call without knowing the broker mechanics.
@@ -149,11 +155,25 @@ export function readBrokerState(_markerDir) {
 // returns a non-null descriptor, (c) the broker process is alive AND
 // answered a health probe within BROKER_HEALTH_TIMEOUT_MS. Today (b) is
 // stubbed to null, so this is always false.
+// Tier 3 Milestone 4: implementation flipped from "always false" to a
+// real check. Returns true iff:
+//   1. ASK_CODEX_BROKER=1 in env (master switch — default off)
+//   2. A valid descriptor exists at <markerDir>/.codex-pair/state/broker.json
+//   3. The descriptor's protocolVersion matches BROKER_PROTOCOL_VERSION
+//   4. The recorded pid is still alive (cheap process.kill(pid, 0))
+//
+// Per ADR-077 silent-on-error: any check that fails returns false; caller
+// falls through to the existing per-edit spawn path. clearStaleBrokerState
+// (called by SessionStart per ADR-090) keeps the descriptor honest between
+// sessions; this check is the per-edit-hook's defense for the case where
+// the broker died MID-SESSION.
 export function isBrokerEnabled(markerDir) {
   if (process.env.ASK_CODEX_BROKER !== "1") return false;
-  const state = readBrokerState(markerDir);
+  const state = lifecycleReadBrokerDescriptor(markerDir);
   if (!state) return false;
-  return false; // implementation deferred — see ADR-093 Milestone 3
+  if (state.protocolVersion !== BROKER_PROTOCOL_VERSION) return false;
+  if (!lifecycleIsPidAlive(state.pid)) return false;
+  return true;
 }
 
 // Path resolver for the per-marker-dir broker state file. Used by the
@@ -179,6 +199,14 @@ export function brokerStatePath(markerDir, stateDir) {
 // adding BROKER_PROTOCOL_VERSION to that import doesn't introduce a new
 // cycle.
 export { clearStaleBrokerState } from "./broker-lifecycle.mjs";
+
+// M4: import the descriptor reader + pid-liveness helper into this module
+// for isBrokerEnabled's per-edit-hook gating check. The one-way dep from
+// broker.mjs → broker-lifecycle.mjs is fine: broker-lifecycle imports
+// BROKER_PROTOCOL_VERSION + initializeBroker from this file, but only
+// uses them inside function bodies (called after module init finishes),
+// so the static-evaluation order is acyclic at the value-of-import level.
+import { isPidAlive as lifecycleIsPidAlive, readBrokerDescriptorSync as lifecycleReadBrokerDescriptor } from "./broker-lifecycle.mjs";
 
 // Open a transport connection to a running broker, perform the JSON-RPC
 // `initialize` handshake, and return `{ connection, rpc, initializeResult }`.
@@ -339,7 +367,13 @@ export async function submitReview(args) {
   );
   const threadId = threadResp?.thread?.id;
   if (typeof threadId !== "string") {
-    throw new Error("submitReview: thread/start returned no thread.id");
+    // M4 brokerFailure discriminator: thread_start failures indicate the
+    // broker is broken at the protocol layer. Hook falls back to spawnCodex.
+    const err = new Error("submitReview: thread/start returned no thread.id");
+    err.verdict = "error";
+    err.brokerFailure = true;
+    err.brokerPhase = "thread_start";
+    throw err;
   }
 
   // 2. Register the turn/completed waiter BEFORE turn/start. Codex can
@@ -368,7 +402,13 @@ export async function submitReview(args) {
   );
   const turnId = turnResp?.turn?.id;
   if (typeof turnId !== "string") {
-    throw new Error("submitReview: turn/start returned no turn.id");
+    // M4 brokerFailure discriminator: turn_start failures = broker protocol
+    // is broken. Hook falls back to spawnCodex.
+    const err = new Error("submitReview: turn/start returned no turn.id");
+    err.verdict = "error";
+    err.brokerFailure = true;
+    err.brokerPhase = "turn_start";
+    throw err;
   }
 
   // 4. Wire cancellation. abortSignal abort → turn/interrupt + reject.
@@ -439,8 +479,11 @@ export async function submitReview(args) {
   // abort-after-completion race; biome won't strip it.
   const turn = completion?.params?.turn;
   if (!turn || !Array.isArray(turn.items)) {
+    // M4: protocol-layer failure → brokerFailure → hook falls back.
     const err = new Error("submitReview: turn/completed missing turn.items");
     err.verdict = "parse_failed";
+    err.brokerFailure = true;
+    err.brokerPhase = "protocol";
     throw err;
   }
   if (turn.status === "failed" || turn.status === "interrupted") {
@@ -452,8 +495,13 @@ export async function submitReview(args) {
   }
   const finalMessage = turn.items.findLast?.((i) => i?.type === "agentMessage");
   if (!finalMessage || typeof finalMessage.text !== "string") {
+    // M4: protocol-layer failure (broker spoke turn/completed but with no
+    // agentMessage). Mark brokerFailure so hook falls back to spawnCodex —
+    // this is a broker-broken state, not a real codex result.
     const err = new Error("submitReview: turn/completed has no agentMessage item");
     err.verdict = "parse_failed";
+    err.brokerFailure = true;
+    err.brokerPhase = "protocol";
     throw err;
   }
   return finalMessage.text;

--- a/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
+++ b/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
@@ -3130,14 +3130,23 @@ describe("scripts/codex-pair-watch.mjs — runtime behavior (no codex calls)", (
 
   // Tier 3 Milestone 4 (M4) Integration Tests
 
-  it("M4 integration: codex-pair-watch.mjs connects to broker when isBrokerEnabled is true", () => {
+  it("M4 integration: codex-pair-watch.mjs dispatches broker via runCodexWithFallback (single path)", () => {
     const hookSource = fs.readFileSync(path.join(PLUGIN_ROOT, "scripts", "codex-pair-watch.mjs"), "utf-8");
+    // Broker dispatch unified through runCodexWithFallback per /multi-review
+    // hotfix — both reviewers independently caught the duplicate inline
+    // branch in main() that bypassed fallback semantics + initialize handshake.
     expect(hookSource).toMatch(/if\s*\(isBrokerEnabled\(markerDir\)\)/);
-    expect(hookSource).toMatch(/readBrokerState\(markerDir\)/);
-    expect(hookSource).toMatch(/connectWebSocket/);
-    expect(hookSource).toMatch(/createRpcClient/);
+    expect(hookSource).toMatch(/runWithBroker/);
     expect(hookSource).toMatch(/submitReview/);
-    expect(hookSource).toMatch(/connection\.close\(\)/);
+    // main() must call runCodexWithFallback (not a duplicate inline branch).
+    // Pin that runCodexWithFallback is invoked from main()'s try block.
+    expect(hookSource).toMatch(/await runCodexWithFallback\(\{[\s\S]+?fallbackModel/);
+    // Explicit anti-regression on the duplicate-inline-dispatch bug:
+    // main() must NOT directly call connectWebSocket or createRpcClient.
+    // Those calls only live inside runWithBroker (called via runCodexWithFallback).
+    const mainBody = hookSource.match(/async function main\(\)[\s\S]+?\n\}/)?.[0] ?? "";
+    expect(mainBody).not.toMatch(/connectWebSocket\(/);
+    expect(mainBody).not.toMatch(/createRpcClient\(/);
   });
 
   // ─────────────────────────────────────────────────────────────────────

--- a/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
+++ b/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
@@ -3127,4 +3127,230 @@ describe("scripts/codex-pair-watch.mjs — runtime behavior (no codex calls)", (
     for (const cb of listeners.error) cb(transportErr);
     await expect(p).rejects.toThrow(/ECONNRESET/);
   });
+
+  // Tier 3 Milestone 4 (M4) Integration Tests
+
+  it("M4 integration: codex-pair-watch.mjs connects to broker when isBrokerEnabled is true", () => {
+    const hookSource = fs.readFileSync(path.join(PLUGIN_ROOT, "scripts", "codex-pair-watch.mjs"), "utf-8");
+    expect(hookSource).toMatch(/if\s*\(isBrokerEnabled\(markerDir\)\)/);
+    expect(hookSource).toMatch(/readBrokerState\(markerDir\)/);
+    expect(hookSource).toMatch(/connectWebSocket/);
+    expect(hookSource).toMatch(/createRpcClient/);
+    expect(hookSource).toMatch(/submitReview/);
+    expect(hookSource).toMatch(/connection\.close\(\)/);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Milestone 4: hook integration + isBrokerEnabled real check + broker-
+  // failure-vs-real-error discriminator.
+  // ─────────────────────────────────────────────────────────────────────
+
+  it("M4: isBrokerEnabled returns false when ASK_CODEX_BROKER is unset (master switch off)", async () => {
+    const { isBrokerEnabled } = await import("../../scripts/lib/broker.mjs");
+    const orig = process.env.ASK_CODEX_BROKER;
+    try {
+      delete process.env.ASK_CODEX_BROKER;
+      expect(isBrokerEnabled(tempDir)).toBe(false);
+    } finally {
+      if (orig === undefined) delete process.env.ASK_CODEX_BROKER;
+      else process.env.ASK_CODEX_BROKER = orig;
+    }
+  });
+
+  it("M4: isBrokerEnabled returns false when ASK_CODEX_BROKER=1 but no descriptor exists", async () => {
+    const { isBrokerEnabled } = await import("../../scripts/lib/broker.mjs");
+    fs.mkdirSync(path.join(tempDir, ".codex-pair", "state"), { recursive: true });
+    const orig = process.env.ASK_CODEX_BROKER;
+    try {
+      process.env.ASK_CODEX_BROKER = "1";
+      expect(isBrokerEnabled(tempDir)).toBe(false);
+    } finally {
+      if (orig === undefined) delete process.env.ASK_CODEX_BROKER;
+      else process.env.ASK_CODEX_BROKER = orig;
+    }
+  });
+
+  it("M4: isBrokerEnabled returns false when descriptor has wrong protocolVersion", async () => {
+    const { isBrokerEnabled } = await import("../../scripts/lib/broker.mjs");
+    fs.mkdirSync(path.join(tempDir, ".codex-pair", "state"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempDir, ".codex-pair", "state", "broker.json"),
+      JSON.stringify({ pid: process.pid, transportUrl: "unix:///tmp/x.sock", protocolVersion: "vWRONG" }),
+    );
+    const orig = process.env.ASK_CODEX_BROKER;
+    try {
+      process.env.ASK_CODEX_BROKER = "1";
+      expect(isBrokerEnabled(tempDir)).toBe(false);
+    } finally {
+      if (orig === undefined) delete process.env.ASK_CODEX_BROKER;
+      else process.env.ASK_CODEX_BROKER = orig;
+    }
+  });
+
+  it("M4: isBrokerEnabled returns false when descriptor pid is dead", async () => {
+    const { isBrokerEnabled } = await import("../../scripts/lib/broker.mjs");
+    fs.mkdirSync(path.join(tempDir, ".codex-pair", "state"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempDir, ".codex-pair", "state", "broker.json"),
+      // pid 999999 — overwhelmingly unlikely to be alive
+      JSON.stringify({ pid: 999999, transportUrl: "unix:///tmp/x.sock", protocolVersion: "v2" }),
+    );
+    const orig = process.env.ASK_CODEX_BROKER;
+    try {
+      process.env.ASK_CODEX_BROKER = "1";
+      expect(isBrokerEnabled(tempDir)).toBe(false);
+    } finally {
+      if (orig === undefined) delete process.env.ASK_CODEX_BROKER;
+      else process.env.ASK_CODEX_BROKER = orig;
+    }
+  });
+
+  it("M4: isBrokerEnabled returns TRUE when all gates pass (env, descriptor, protocol, pid)", async () => {
+    const { isBrokerEnabled } = await import("../../scripts/lib/broker.mjs");
+    fs.mkdirSync(path.join(tempDir, ".codex-pair", "state"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempDir, ".codex-pair", "state", "broker.json"),
+      JSON.stringify({ pid: process.pid, transportUrl: "unix:///tmp/x.sock", protocolVersion: "v2" }),
+    );
+    const orig = process.env.ASK_CODEX_BROKER;
+    try {
+      process.env.ASK_CODEX_BROKER = "1";
+      expect(isBrokerEnabled(tempDir)).toBe(true);
+    } finally {
+      if (orig === undefined) delete process.env.ASK_CODEX_BROKER;
+      else process.env.ASK_CODEX_BROKER = orig;
+    }
+  });
+
+  it("M4: readBrokerState returns the actual descriptor (was null stub in M2)", async () => {
+    const { readBrokerState } = await import("../../scripts/lib/broker.mjs");
+    fs.mkdirSync(path.join(tempDir, ".codex-pair", "state"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempDir, ".codex-pair", "state", "broker.json"),
+      JSON.stringify({ pid: 12345, transportUrl: "unix:///tmp/x.sock", protocolVersion: "v2" }),
+    );
+    const state = readBrokerState(tempDir);
+    expect(state).not.toBeNull();
+    expect(state?.pid).toBe(12345);
+    expect(state?.transportUrl).toBe("unix:///tmp/x.sock");
+  });
+
+  it("M4: submitReview thread_start failure sets err.brokerFailure (hook will fall back)", async () => {
+    const { submitReview } = await import("../../scripts/lib/broker.mjs");
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const mockRpc: any = {
+      request: async (method: string) => {
+        if (method === "thread/start")
+          return {
+            thread: {
+              /* missing id */
+            },
+          };
+        return {};
+      },
+      waitFor: async () => ({ method: "turn/completed", params: {} }),
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const mockConn: any = { close: () => {}, on: () => {}, destroyed: false };
+    let caught: Error | null = null;
+    try {
+      await submitReview({
+        rpc: mockRpc,
+        connection: mockConn,
+        cwd: "/tmp",
+        baseInstructions: "ctx",
+        prompt: "x",
+        model: "gpt-5.5",
+      });
+    } catch (err) {
+      caught = err as Error;
+    }
+    // biome-ignore lint/suspicious/noExplicitAny: structured marker
+    expect((caught as any)?.brokerFailure).toBe(true);
+    // biome-ignore lint/suspicious/noExplicitAny: structured marker
+    expect((caught as any)?.brokerPhase).toBe("thread_start");
+  });
+
+  it("M4: submitReview turn.status:failed does NOT set brokerFailure (real codex result, not broker outage)", async () => {
+    const { submitReview } = await import("../../scripts/lib/broker.mjs");
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const mockRpc: any = {
+      request: async (method: string) => {
+        if (method === "thread/start") return { thread: { id: "T1" } };
+        if (method === "turn/start") return { turn: { id: "U1" } };
+        return {};
+      },
+      waitFor: async () => ({
+        method: "turn/completed",
+        params: { threadId: "T1", turn: { id: "U1", status: "failed", error: { message: "model error" }, items: [] } },
+      }),
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const mockConn: any = { close: () => {}, on: () => {}, destroyed: false };
+    let caught: Error | null = null;
+    try {
+      await submitReview({
+        rpc: mockRpc,
+        connection: mockConn,
+        cwd: "/tmp",
+        baseInstructions: "ctx",
+        prompt: "x",
+        model: "gpt-5.5",
+      });
+    } catch (err) {
+      caught = err as Error;
+    }
+    // turn.status:failed is a REAL codex result — must NOT fall back
+    // biome-ignore lint/suspicious/noExplicitAny: structured marker
+    expect((caught as any)?.brokerFailure).toBeUndefined();
+    // biome-ignore lint/suspicious/noExplicitAny: structured marker
+    expect((caught as any)?.verdict).toBe("error");
+  });
+
+  it("M4: submitReview missing-agentMessage sets brokerFailure (protocol-layer failure)", async () => {
+    const { submitReview } = await import("../../scripts/lib/broker.mjs");
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const mockRpc: any = {
+      request: async (method: string) => {
+        if (method === "thread/start") return { thread: { id: "T1" } };
+        if (method === "turn/start") return { turn: { id: "U1" } };
+        return {};
+      },
+      waitFor: async () => ({
+        method: "turn/completed",
+        params: { threadId: "T1", turn: { id: "U1", status: "completed", items: [] } },
+      }),
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const mockConn: any = { close: () => {}, on: () => {}, destroyed: false };
+    let caught: Error | null = null;
+    try {
+      await submitReview({
+        rpc: mockRpc,
+        connection: mockConn,
+        cwd: "/tmp",
+        baseInstructions: "ctx",
+        prompt: "x",
+        model: "gpt-5.5",
+      });
+    } catch (err) {
+      caught = err as Error;
+    }
+    // biome-ignore lint/suspicious/noExplicitAny: structured marker
+    expect((caught as any)?.brokerFailure).toBe(true);
+    // biome-ignore lint/suspicious/noExplicitAny: structured marker
+    expect((caught as any)?.brokerPhase).toBe("protocol");
+    // biome-ignore lint/suspicious/noExplicitAny: structured marker
+    expect((caught as any)?.verdict).toBe("parse_failed");
+  });
+
+  it("M4 structural: codex-pair-watch.mjs wires the broker integration", () => {
+    const watch = fs.readFileSync(path.join(PLUGIN_ROOT, "scripts", "codex-pair-watch.mjs"), "utf-8");
+    expect(watch).toMatch(/import.*isBrokerEnabled.*from\s+["']\.\/lib\/broker\.mjs["']/);
+    expect(watch).toMatch(/runWithBroker/);
+    expect(watch).toMatch(/isBrokerEnabled\(markerDir\)/);
+    expect(watch).toMatch(/err\?\.brokerFailure/);
+    // Cache integration: broker path must NOT add a discriminator to the cache key
+    expect(watch).not.toMatch(/cacheKey.*broker|broker.*cacheKey/);
+  });
 });


### PR DESCRIPTION
## Summary

**Tier 3 Milestone 4 — the FINAL milestone.** Wires the broker into the per-edit hook. Behind `ASK_CODEX_BROKER=1`; production behavior byte-identical without the flag.

When this merges, **Tier 3 is complete on `main`** (M1+M2+M3+M4 all shipped).

## M4 brainstorm-verified design

Both Codex and Claude probed the actual source. Key decisions:

| Decision | Rationale |
|---|---|
| **LATE connection lifetime** | Open broker only AFTER cache + inflight checks. Cache-hit fast path NEVER touches the broker — zero added latency for cached reviews. |
| **`err.brokerFailure` discriminator** | Distinguishes broker outage (fall back to spawnCodex silently) from real codex result (`turn.status: "failed"` → preserve, don't double-spend) |
| **No pre-probe** | `initializeBroker` IS the health check with a tight 2s budget. `probeBrokerHealth` would double handshake latency |
| **Cache integration unchanged** | Cross-mode reuse is a feature — same `prompt+model+file` hits same cache entry across spawn and broker modes |
| **2s handshake budget in hook path** | Tighter than bootstrap's default 5s — broker should ALREADY be running; slow handshake = broken broker = fall back |

## Files changed

### `scripts/lib/broker.mjs`

- **`isBrokerEnabled`** flipped from "always false" to real check (ASK_CODEX_BROKER=1 + descriptor + protocolVersion match + pid alive). Per ADR-077, any check failure returns false silently.
- **`readBrokerState`** delegates to `lifecycle.readBrokerDescriptorSync` (was M2 null stub).
- **`submitReview`** adds `err.brokerFailure = true` + `err.brokerPhase` markers on broker-layer failures (`thread_start`, `turn_start`, `protocol`/missing-agentMessage, missing turn.items). **NOT marked**: `turn.status === "failed"` (real codex result), waitFor timeout (retry would double spend).

### `scripts/codex-pair-watch.mjs`

- **`brokerClientInfo()`**: one-time-cached `{name, title, version}` from package.json. Uses static ESM `readFileSync` (per ADR-095 — no `require()` in ESM).
- **`runWithBroker({prompt, timeoutMs, model, markerDir})`**: reads descriptor, `initializeBroker` with 2s budget, `submitReview`, close connection in `finally`. Connect/init failures tagged `brokerFailure=true`.
- **`runCodexWithFallback`** branches on `isBrokerEnabled(markerDir)`:
  - Broker path first if enabled
  - On `err.brokerFailure`: log `"broker_fallback"` verdict + silently fall through to spawnCodex
  - On other errors (`verdict:"error"`, `verdict:"timeout"`): propagate without retry

## Tests added (10 new M4 pins, 289 → 300)

- `isBrokerEnabled` returns false: when env unset, descriptor missing, protocol mismatch, dead pid
- `isBrokerEnabled` returns TRUE when all 4 gates pass (env, descriptor, protocol, pid alive)
- `readBrokerState` returns actual descriptor (was null stub)
- `submitReview` thread_start failure: `brokerFailure=true` + `phase="thread_start"`
- `submitReview` `turn.status:"failed"`: does NOT set brokerFailure (real codex result) + verdict="error" preserved
- `submitReview` missing-agentMessage: `brokerFailure=true` + `phase="protocol"` + `verdict="parse_failed"`
- Structural: `watch.mjs` imports broker + defines `runWithBroker` + checks `isBrokerEnabled(markerDir)` + uses `err?.brokerFailure` discriminator + does NOT add broker-vs-spawn to cache key

## Tier 3 progression (complete after this merges)

| Milestone | PR | Status |
|---|---|---|
| **M1** — protocol discovery + interface refinement (ADR-093) | #97 | ✅ merged |
| **M2 PR1** — transport + RPC client | #99 | ✅ merged |
| **M2 PR2** — SessionStart spawn + handshake + descriptor | #100 | ✅ merged |
| **M2 PR3** — SessionEnd + stale recovery | #101 | ✅ merged |
| **M2 hotfix** — multi-review BLOCKING findings | #103 | ✅ merged |
| **M2 debt** — codex-pair lived-experience lessons (ADR-095) | #104 | ✅ merged |
| **M3** — submitReview body + multi-review hotfix | #105 | ✅ merged |
| **M4** — hook integration (this PR) | **this** | 🟡 awaiting CI + /multi-review |

## User-visible result when `ASK_CODEX_BROKER=1`

- SessionStart spawns `codex app-server` once (~3-5s up-front cost)
- Every per-edit review on a marked project routes through broker
- Cache hits remain instant; cache misses skip the ~3-10s cold-spawn overhead
- Any broker failure silently falls back to per-edit `spawnCodex` (ADR-077 contract preserved)
- ADR-077's 5x recall improvement preserved at fractional per-edit cost

## Test plan

- [x] Plugin tests: 289 → 300 passing
- [x] Lint clean
- [x] No production behavior change (ASK_CODEX_BROKER default off)
- [x] `runCodexWithFallback` fallback discriminator distinguishes broker outage from real codex result
- [x] Cache integration verified to NOT discriminate by broker-vs-spawn
- [ ] /multi-review on M4 diff (per goal-directive)
- [ ] Optional gated end-to-end against real `codex app-server` (`RUN_CODEX_E2E=1` — deferred to follow-on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)