### PR TITLE
chore(changeset): v0.7.0 family sync + ADR-097 attribution

### DIFF
--- a/.changeset/adr-097-codex-pair-multireview-hotfix.md
+++ b/.changeset/adr-097-codex-pair-multireview-hotfix.md
@@ -1,0 +1,41 @@
+---
+"@ask-llm/plugin": patch
+---
+
+# ADR-097 — codex-pair UX hotfix on ADR-096
+
+Closes the four `/multi-review` findings explicitly tracked as "follow-on hotfix
+before wide adoption" in the v0.7.0 changeset. Both Gemini and Codex
+independently flagged each at 80+ confidence; all four reproduced empirically
+before fixing per the ADR-095 verify-before-fixing discipline.
+
+1. **TOCTOU race on singleton `repetitions.json`** (Gemini 95, Codex 88) →
+   state moves from `<markerDir>/.codex-pair/state/repetitions.json` to
+   `<markerDir>/.codex-pair/state/repetitions/<sha256(file)[0:16]>.json`. Each
+   shard's read-modify-write is now naturally serialized by ADR-087's per-file
+   inflight lock. Schema bumped to `v: 2`.
+
+2. **Unbounded state growth** (Codex 85) → `sweepStaleRepetitions` drops
+   shards older than 30 days, called probabilistically (5% per update) so
+   abandoned files don't accumulate state.
+
+3. **Cache-hit double-count under rapid re-saves** (Gemini 87) → new
+   read-only `getBlockingFromShard` surfaces blocking entries without
+   mutating state. Cache-hit branch in `codex-pair-watch.mjs` uses this
+   instead of `updateRepetitions`. Rapid undo/redo cycles can no longer
+   push a finding to BLOCKING without a real new live review.
+
+4. **Include-list negation-only edge case** (Codex 82) → `.codex-pair/include`
+   with ONLY negation rules (e.g. just `!build/**`) previously gated every
+   file out (no positive rule = no match for anything). Now the negations
+   transform into positive ignore-list entries with an info-level log line
+   explaining the semantic mapping.
+
+Backward-compat shims keep the v1 `loadRepetitions`/`saveRepetitions` exports
+as no-ops so external scripts that imported the v1 surface don't break at
+import time. No data migration needed — repetition state is advisory and
+regenerates from continued reviews; any lingering v1 `repetitions.json` file
+on disk is harmless (different path, ignored by new code, won't be swept by
+the new TTL).
+
+Test count 308 → 313 (+5 ADR-097 regressions). Lint clean across 6 workspaces.

--- a/.changeset/v0.7.0-mcp-family-sync.md
+++ b/.changeset/v0.7.0-mcp-family-sync.md
@@ -1,0 +1,24 @@
+---
+"ask-gemini-mcp": patch
+"ask-codex-mcp": patch
+"ask-ollama-mcp": patch
+"ask-llm-mcp": patch
+---
+
+# v0.7.0 family sync — synchronized MCP-package patch bump
+
+The MCP server packages (`ask-gemini-mcp`, `ask-codex-mcp`, `ask-ollama-mcp`,
+`ask-llm-mcp`) are unchanged in code since the prior release (v1.6.4 / v0.3.x —
+`git diff v1.6.4..main -- packages/shared packages/gemini-mcp packages/codex-mcp
+packages/ollama-mcp packages/llm-mcp` returns empty). They are patch-bumped here
+to keep the gemini-codex-ollama-llm family aligned on the same SHA-stamped release
+moment that ships the v0.7.0 plugin work (Tier 3 broker + ADR-092/094/095/096/097
+codex-pair improvements — all inside the private `@ask-llm/plugin` package).
+
+This preserves the unified-tag convention from the original gemini-mcp-tool fork
+(legacy v1.5.x..v1.6.x URLs still resolve at `v<gemini_version>`) and gives npm
+consumers a single discoverable release moment instead of a v0.7.0 plugin-only
+event with no npm-visible artifact.
+
+No functional changes in these packages. Tests, type contracts, executor
+behavior, MCP tool surface — all byte-identical to the prior release.


### PR DESCRIPTION
## Summary

Two changesets to round out the v0.7.0 release moment so the publish flow ships a coherent, synchronized release:

1. **`.changeset/v0.7.0-mcp-family-sync.md`** — patch bumps for `ask-gemini-mcp`, `ask-codex-mcp`, `ask-ollama-mcp`, `ask-llm-mcp`. The MCP server packages are unchanged in code since v1.6.4 / v0.3.x (`git diff v1.6.4..main -- packages/shared packages/gemini-mcp packages/codex-mcp packages/ollama-mcp packages/llm-mcp` returns empty) but are bumped to keep the family aligned with the v0.7.0 plugin work — preserves the unified-tag convention so npm consumers see a single discoverable release moment.

2. **`.changeset/adr-097-codex-pair-multireview-hotfix.md`** — patch on `@ask-llm/plugin` attributing ADR-097's multi-review hotfix (sharded repetitions, TTL sweep, read-only cache-hit path, negation-only include semantics). The hotfix code landed on main via PR #110 but its changeset was missing; absorbs into the v0.7.0 release (largest bump wins: minor + patch = minor) so the changelog accurately describes everything actually in v0.7.0.

## Why this is needed

After merging PR #108 (queue v0.7.0 intent) and PR #110 (ADR-097 code), the state on `main` is:
- `@ask-llm/plugin@0.6.2` with pending minor bump for v0.7.0 + ADR-092/094/095/096 narrative
- ADR-097 code present but **no changeset attributing it**
- All MCP packages unchanged but the user's intent is for them to share the v0.7.0 release moment

Without this PR, merging the bot-generated version-packages PR (#109) would:
- Bump only the plugin (private — no npm visibility)
- Ship ADR-097 code without changelog attribution
- Leave npm registry showing no new release at all

After this PR + bot refresh + #109 merge:
- Plugin bumps to v0.7.0 with a CHANGELOG that lists ADR-092 through ADR-097
- MCP packages all patch-bump and publish to npm
- Unified GitHub Release fires; MCP Registry sync fires

## Test plan

- [ ] Merge this PR
- [ ] Confirm the `changesets/action` bot regenerates `#109 (chore: version packages)` to include MCP patch bumps + the additional ADR-097 entry in plugin's CHANGELOG
- [ ] Verify `#109`'s diff shows: `@ask-llm/plugin 0.6.2 → 0.7.0`, four MCP packages at `+1` patch (e.g. `1.6.4 → 1.6.5`), CHANGELOG entries for both ADR-096 and ADR-097
- [ ] Merge `#109` — the Release workflow's Mode 2 fires: npm publish (4 packages) + MCP Registry sync + unified GitHub Release at `v<gemini_version>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)