### PR TITLE
test(plugin): parallel-fire test fixtures + slow fake-codex scenario

### DIFF
--- a/.changeset/parallel-fire-test-fixtures.md
+++ b/.changeset/parallel-fire-test-fixtures.md
@@ -1,0 +1,67 @@
+---
+"@ask-llm/plugin": patch
+---
+
+# Parallel-fire test fixtures — closes the MultiEdit + concurrent-hook test gap
+
+Adds 6 new tests + a `slow` scenario to the fake-codex fixture, closing
+the empirical gap surfaced by the deep-investigation tracing: the 313
+pre-existing plugin tests used `tool_name: "Edit"` exclusively, with
+zero MultiEdit payloads and zero concurrent-hook scenarios. The actual
+codex-pair workload — agentic Claude making multiple Edit/Write/Multi-
+Edit tool calls per turn — wasn't exercised by any test.
+
+## New tests (`packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts`)
+
+1. **MultiEdit payload acceptance** — pins that `{tool_name: "MultiEdit",
+   tool_input: {file_path, edits: [...]}}` reaches the codex-spawn path
+   and logs a review entry with `tool: "MultiEdit"`. Guards against
+   silent payload-shape drift if Claude Code's MultiEdit schema ever
+   changes.
+
+2. **Cache participation (MultiEdit→MultiEdit)** — pins that the cache
+   key is content-derived (not tool-name-derived) so identical-content
+   MultiEdit re-fires hit the cache. Closes a regression class: a
+   tool_name-specific cache bypass.
+
+3. **Cross-file parallel fires (3 concurrent processes)** — fires 3
+   hooks concurrently via `Promise.all` on 3 different files. Verifies:
+   - All 3 exit 0
+   - 3 distinct review log entries with distinct file paths
+   - 3 separate cache entries across cache buckets
+   - 3 separate per-file repetition shards under `state/repetitions/`
+   - No cross-file contention (ADR-097 sharded layout invariant)
+
+4. **Same-file in-flight coalescing (ADR-087)** — fires hook A with the
+   `slow` codex scenario, waits 250ms (past lock acquisition), fires
+   hook B on the same file. Verifies hook B logs `verdict: "skipped"`
+   with `coalesced` in the reason, emits no systemMessage, and that
+   only ONE review verdict (from hook A) lands in the log.
+
+5. **MultiEdit + ignore gate** — verifies an ignored file matched by
+   `.codex-pair/ignore` is skipped pre-codex even when the tool is
+   MultiEdit. Guards against a tool_name-specific gate bypass.
+
+6. **Slow-scenario fixture self-test** — sanity-pins that the new
+   `slow` scenario actually sleeps for `FAKE_CODEX_SLEEP_MS` before
+   emitting NONE. If someone breaks the fixture, this gives a direct
+   failure pointing at the cause rather than confusing race-flakes
+   in the dependent coalescing test.
+
+## New fake-codex `slow` scenario (`_fixtures/codex`)
+
+Adds a configurable-latency scenario: sleeps `FAKE_CODEX_SLEEP_MS`
+(default 500ms) then emits a NONE verdict. Enables deterministic
+race-window control for the in-flight coalescing test without the
+30-second `timeout` scenario's wall-clock penalty.
+
+## Test count and wall-clock impact
+
+- Test count: 313 → 319 (+6).
+- Wall-clock: 4.2s → 7.1s (+2.9s), dominated by the 1.5s slow-scenario
+  hold-time in the coalescing test plus ~500ms for 3 concurrent
+  codex spawns in the cross-file test. Acceptable.
+- Lint clean across 6 workspaces.
+
+No production code changes. The fixture file (`_fixtures/codex`) is
+test-only and not shipped to npm consumers.

--- a/packages/claude-plugin/src/__tests__/_fixtures/codex
+++ b/packages/claude-plugin/src/__tests__/_fixtures/codex
@@ -169,6 +169,20 @@ async function run() {
       process.exit(0);
       break;
 
+    case "slow": {
+      // Configurable-latency happy path. Sleeps FAKE_CODEX_SLEEP_MS (default
+      // 500ms) before emitting a NONE verdict. Used by parallel-fire tests
+      // to create a deterministic window where one hook holds the inflight
+      // lock long enough for another hook to race in and observe coalescing.
+      // Stays well under ASK_CODEX_TIMEOUT_MS — this is "slow enough to
+      // race against, fast enough not to slow the test suite."
+      const sleepMs = Number(process.env.FAKE_CODEX_SLEEP_MS ?? 500);
+      await new Promise((resolve) => setTimeout(resolve, sleepMs));
+      emitAgentMessage("NONE");
+      process.exit(0);
+      break;
+    }
+
     default:
       process.stderr.write(`fake-codex: unknown FAKE_CODEX_SCENARIO=${SCENARIO}\n`);
       process.exit(2);

--- a/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
+++ b/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -3659,5 +3659,294 @@ describe("scripts/codex-pair-watch.mjs — runtime behavior (no codex calls)", (
     for (const call of verdictCalls) {
       expect(call).toMatch(/repeatedIgnoredCount/);
     }
+  });
+});
+
+// Parallel-fire fixtures — closes the test gap the deep-investigation surfaced:
+// 313 existing tests, zero MultiEdit fixtures and zero concurrent-fire fixtures.
+// These tests pin behavior the simple single-fire trace doesn't reach:
+//   - MultiEdit payload shape acceptance (tool_input.file_path singular, edits[])
+//   - Cache participation across tool_name values (key is content-derived)
+//   - Cross-file concurrent fires → independent shards / caches / log entries
+//   - Same-file concurrent fires → ADR-087 inflight-lock coalescing (silent skip)
+//   - MultiEdit + ignore gate (no tool_name-specific bypass of the ignore list)
+describe("scripts/codex-pair-watch.mjs — MultiEdit + parallel-fire fixtures", () => {
+  let tempDir: string;
+  const FIXTURE_DIR = path.join(PLUGIN_ROOT, "src", "__tests__", "_fixtures");
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-pair-parallel-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function setupMarker(dir: string, content = "# test context") {
+    fs.mkdirSync(path.join(dir, ".codex-pair"), { recursive: true });
+    fs.writeFileSync(path.join(dir, ".codex-pair/context.md"), content);
+  }
+
+  function runHookSyncWithFakeCodex(
+    payload: string,
+    cwd: string,
+    scenario: string,
+    extraEnv: Record<string, string> = {},
+  ) {
+    return spawnSync("node", [HOOK_PATH], {
+      input: payload,
+      cwd,
+      env: {
+        ...process.env,
+        PATH: `${FIXTURE_DIR}:${process.env.PATH}`,
+        FAKE_CODEX_SCENARIO: scenario,
+        ASK_CODEX_TIMEOUT_MS: extraEnv.ASK_CODEX_TIMEOUT_MS ?? "30000",
+        ...extraEnv,
+      },
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+  }
+
+  // Async variant — needed for parallel fires. spawnSync blocks; spawn returns
+  // immediately and we collect output via stream events. Multiple of these can
+  // be in flight via Promise.all to exercise the concurrent-process path.
+  function runHookAsyncWithFakeCodex(
+    payload: string,
+    cwd: string,
+    scenario: string,
+    extraEnv: Record<string, string> = {},
+  ): Promise<{ status: number | null; stdout: string; stderr: string }> {
+    return new Promise((resolve) => {
+      const child = spawn("node", [HOOK_PATH], {
+        cwd,
+        env: {
+          ...process.env,
+          PATH: `${FIXTURE_DIR}:${process.env.PATH}`,
+          FAKE_CODEX_SCENARIO: scenario,
+          ASK_CODEX_TIMEOUT_MS: extraEnv.ASK_CODEX_TIMEOUT_MS ?? "30000",
+          ...extraEnv,
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (c) => {
+        stdout += c.toString();
+      });
+      child.stderr.on("data", (c) => {
+        stderr += c.toString();
+      });
+      child.on("close", (code) => resolve({ status: code, stdout, stderr }));
+      child.stdin.write(payload);
+      child.stdin.end();
+    });
+  }
+
+  function readLog(dir: string): Array<Record<string, unknown>> {
+    const logPath = path.join(dir, ".codex-pair/log.jsonl");
+    if (!fs.existsSync(logPath)) return [];
+    return fs
+      .readFileSync(logPath, "utf-8")
+      .trim()
+      .split("\n")
+      .filter((l) => l.length > 0)
+      .map((l) => JSON.parse(l));
+  }
+
+  it("MultiEdit: payload with {file_path, edits[]} is accepted and reviewed (closes 313→0 MultiEdit fixture gap)", () => {
+    // The hook reads payload.tool_input.file_path (singular) at codex-pair-
+    // watch.mjs:809. MultiEdit's actual Claude Code schema is {file_path,
+    // edits: [{old_string, new_string, replace_all?}, ...]} — singular file,
+    // multiple inline edits. This test pins that the singular-read is correct
+    // for MultiEdit's actual payload shape.
+    setupMarker(tempDir, "# ctx");
+    const filePath = path.join(tempDir, "src.ts");
+    fs.writeFileSync(filePath, "export const x = 1;");
+    const payload = JSON.stringify({
+      tool_name: "MultiEdit",
+      tool_input: {
+        file_path: filePath,
+        edits: [
+          { old_string: "x = 1", new_string: "x = 2" },
+          { old_string: "x = 2", new_string: "x = 3" },
+        ],
+      },
+    });
+    const result = runHookSyncWithFakeCodex(payload, tempDir, "none");
+    expect(result.status).toBe(0);
+    const lines = readLog(tempDir);
+    const reviewEntry = lines.find((l) => l.verdict === "none");
+    expect(reviewEntry).toBeTruthy();
+    expect(reviewEntry?.tool).toBe("MultiEdit");
+    expect(reviewEntry?.file).toBe(filePath);
+  });
+
+  it("Cache participation: MultiEdit twice on identical content → second fire is a cache hit", () => {
+    // Cache key = sha256(model | prompt | fileContent | surfaceThreshold).
+    // tool_name flows into `prompt` (rendered into the review prompt body),
+    // so MultiEdit→MultiEdit on identical content reuses the cache.
+    // This pins that MultiEdit participates in the cache the same way Edit
+    // does — no tool_name-specific bypass.
+    setupMarker(tempDir, "# ctx");
+    const filePath = path.join(tempDir, "src.ts");
+    fs.writeFileSync(filePath, "export const x = 1;");
+    const payload = JSON.stringify({
+      tool_name: "MultiEdit",
+      tool_input: {
+        file_path: filePath,
+        edits: [{ old_string: "x = 1", new_string: "x = 1" }],
+      },
+    });
+    const first = runHookSyncWithFakeCodex(payload, tempDir, "none");
+    expect(first.status).toBe(0);
+    const second = runHookSyncWithFakeCodex(payload, tempDir, "none");
+    expect(second.status).toBe(0);
+    const lines = readLog(tempDir);
+    expect(lines.find((l) => l.verdict === "none")).toBeTruthy();
+    expect(lines.find((l) => l.verdict === "cached")).toBeTruthy();
+  });
+
+  it("Cross-file parallel fires: 3 hooks on different files all complete; each gets its own cache + repetition shard (ADR-097 sharded path eliminates cross-file contention)", async () => {
+    // Deep-investigation finding: when Claude dispatches Edit on 3 different
+    // files in one turn, Claude Code spawns 3 separate hook processes
+    // concurrently. ADR-097's per-file shard layout means each fire writes
+    // to a disjoint shard path, no contention. Verify all 3 reviews complete
+    // with no lost increments.
+    setupMarker(tempDir, "# ctx");
+    const files = ["a.ts", "b.ts", "c.ts"].map((f) => path.join(tempDir, f));
+    for (const [i, f] of files.entries()) {
+      fs.writeFileSync(f, `export const f${i} = ${i};`);
+    }
+    const payloads = files.map((f) => JSON.stringify({ tool_name: "Edit", tool_input: { file_path: f } }));
+    const results = await Promise.all(payloads.map((p) => runHookAsyncWithFakeCodex(p, tempDir, "concerns-labeled")));
+    for (const r of results) expect(r.status).toBe(0);
+
+    // All 3 reviews landed in the log with distinct file paths.
+    const lines = readLog(tempDir);
+    const reviewedFiles = new Set(lines.filter((l) => l.verdict === "concerns").map((l) => l.file as string));
+    expect(reviewedFiles.size).toBe(3);
+    for (const f of files) expect(reviewedFiles.has(f)).toBe(true);
+
+    // Each file got its own cache entry (3 entries total across all buckets).
+    const cacheDir = path.join(tempDir, ".codex-pair/cache");
+    let cacheCount = 0;
+    if (fs.existsSync(cacheDir)) {
+      for (const prefix of fs.readdirSync(cacheDir)) {
+        const bucketPath = path.join(cacheDir, prefix);
+        if (fs.statSync(bucketPath).isDirectory()) {
+          cacheCount += fs.readdirSync(bucketPath).filter((f) => f.endsWith(".json")).length;
+        }
+      }
+    }
+    expect(cacheCount).toBe(3);
+
+    // Each file got its own repetition shard at the ADR-097 path.
+    const repDir = path.join(tempDir, ".codex-pair/state/repetitions");
+    expect(fs.existsSync(repDir)).toBe(true);
+    const shards = fs.readdirSync(repDir).filter((f) => f.endsWith(".json"));
+    expect(shards.length).toBe(3);
+  });
+
+  it("Same-file in-flight coalescing: hook B fires on same file while hook A is mid-codex → B logs coalesced and exits silently (ADR-087)", async () => {
+    // Deep-investigation finding: same-file edit bursts coalesce via the
+    // inflight lock — hook A holds the lock for the full review duration;
+    // hook B sees EEXIST + fresh mtime → coalesce-skip with no codex spawn
+    // and no systemMessage. This is intentional cost-control behavior; the
+    // trade-off is that intermediate edits don't get their own review.
+    setupMarker(tempDir, "# ctx");
+    const filePath = path.join(tempDir, "src.ts");
+    fs.writeFileSync(filePath, "export const x = 1;");
+    const payload = JSON.stringify({
+      tool_name: "Edit",
+      tool_input: { file_path: filePath },
+    });
+
+    // Hook A: slow scenario gives a ~1500ms window where the lock is held.
+    const aPromise = runHookAsyncWithFakeCodex(payload, tempDir, "slow", {
+      FAKE_CODEX_SLEEP_MS: "1500",
+    });
+
+    // Wait long enough for Hook A to acquire the inflight lock (which it
+    // does within the first ~50ms of main() — after marker walk, ignore
+    // gate, cache miss, but before codex spawn). 250ms is comfortably past
+    // lock acquisition while still well inside the 1500ms codex sleep.
+    await new Promise((r) => setTimeout(r, 250));
+
+    // Hook B fires on the same file. Should observe the existing inflight
+    // lock and coalesce-exit silently.
+    const b = await runHookAsyncWithFakeCodex(payload, tempDir, "concerns-labeled");
+    expect(b.status).toBe(0);
+    // Coalesced fires emit no systemMessage (silent skip).
+    expect(b.stdout).toBe("");
+
+    // Now drain Hook A.
+    const a = await aPromise;
+    expect(a.status).toBe(0);
+
+    // Log should contain exactly: 1 coalesced skip (from B) + 1 review (from A).
+    const lines = readLog(tempDir);
+    const coalesced = lines.filter((l) => l.verdict === "skipped" && /coalesced/.test((l.reason as string) ?? ""));
+    expect(coalesced.length).toBe(1);
+    const reviews = lines.filter((l) => l.verdict === "none" || l.verdict === "concerns");
+    expect(reviews.length).toBe(1);
+    // The review that DID happen was Hook A's (the slow one → none verdict).
+    expect(reviews[0].verdict).toBe("none");
+  });
+
+  it("MultiEdit + ignore gate: ignored file is skipped before codex spawn (no tool_name-specific bypass)", () => {
+    // Guards against a regression class: someone adds a tool_name-specific
+    // branch BEFORE the ignore-list check (e.g. "always review MultiEdits
+    // because they touch multiple things") and accidentally bypasses opt-out.
+    // The ignore check at codex-pair-watch.mjs:888 must fire regardless of
+    // tool_name.
+    setupMarker(tempDir, "# ctx");
+    fs.writeFileSync(path.join(tempDir, ".codex-pair/ignore"), "src/skip-me.ts\n");
+    const filePath = path.join(tempDir, "src/skip-me.ts");
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, "export const x = 1;");
+    const payload = JSON.stringify({
+      tool_name: "MultiEdit",
+      tool_input: {
+        file_path: filePath,
+        edits: [{ old_string: "x = 1", new_string: "x = 2" }],
+      },
+    });
+    const result = runHookSyncWithFakeCodex(payload, tempDir, "concerns-labeled");
+    expect(result.status).toBe(0);
+    const lines = readLog(tempDir);
+    const skip = lines.find((l) => l.verdict === "skipped");
+    expect(skip).toBeTruthy();
+    expect(skip?.reason).toMatch(/matched \.codex-pair\/ignore/);
+    expect(skip?.file).toBe(filePath);
+    expect(skip?.tool).toBe("MultiEdit");
+    // No codex spawn → no review verdict landed.
+    expect(lines.find((l) => l.verdict === "concerns")).toBeUndefined();
+    expect(lines.find((l) => l.verdict === "none")).toBeUndefined();
+  });
+
+  it("fake-codex slow scenario: sleeps for FAKE_CODEX_SLEEP_MS then emits NONE (fixture self-test)", () => {
+    // Sanity-pin the new slow scenario the parallel-fire tests rely on. If
+    // someone breaks this fixture, the dependent tests would race-flake
+    // confusingly; this gives a direct test failure pointing at the cause.
+    setupMarker(tempDir, "# ctx");
+    const filePath = path.join(tempDir, "src.ts");
+    fs.writeFileSync(filePath, "export const x = 1;");
+    const payload = JSON.stringify({
+      tool_name: "Edit",
+      tool_input: { file_path: filePath },
+    });
+    const startedAt = Date.now();
+    const result = runHookSyncWithFakeCodex(payload, tempDir, "slow", {
+      FAKE_CODEX_SLEEP_MS: "300",
+    });
+    const elapsedMs = Date.now() - startedAt;
+    expect(result.status).toBe(0);
+    // Wall-clock at least 300ms (the configured sleep) plus normal hook
+    // overhead. Upper bound is generous to avoid CI flakes.
+    expect(elapsedMs).toBeGreaterThanOrEqual(300);
+    expect(elapsedMs).toBeLessThan(5000);
+    const lines = readLog(tempDir);
+    expect(lines.find((l) => l.verdict === "none")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

Closes the empirical test gap surfaced by the deep-investigation tracing from this session: **313 pre-existing plugin tests all used `tool_name: "Edit"` exclusively, with zero MultiEdit payloads and zero concurrent-hook scenarios.** Real codex-pair workload — agentic Claude making multiple Edit/Write/MultiEdit tool calls per assistant turn — was unexercised by any test.

Adds 6 new tests + a `slow` fake-codex scenario to enable deterministic race-window control.

## Tests added (`packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts`)

1. **MultiEdit payload acceptance** — pins `{tool_name: "MultiEdit", tool_input: {file_path, edits: [...]}}` reaches the review path with the correct `tool: "MultiEdit"` log tag. Guards against silent schema drift.

2. **Cache participation (MultiEdit→MultiEdit on identical content)** — pins the cache key is content-derived, not tool-name-derived. Closes a regression class where a tool_name-specific cache bypass could leak.

3. **Cross-file parallel fires (3 concurrent processes via `Promise.all`)** — fires 3 hooks concurrently on 3 different files. Asserts:
   - All 3 exit 0
   - 3 distinct review log entries with distinct file paths
   - 3 separate cache entries across cache buckets
   - 3 separate per-file repetition shards under `state/repetitions/`
   - No cross-file contention (ADR-097 sharded layout invariant)

4. **Same-file in-flight coalescing (ADR-087)** — hook A holds the lock via the `slow` codex scenario; hook B fires 250ms later on the same file. Asserts hook B logs `verdict: "skipped"` with `coalesced` reason, emits no systemMessage, and only ONE review verdict (from hook A) lands in the log.

5. **MultiEdit + ignore gate** — pins that `.codex-pair/ignore` fires regardless of tool_name. Guards against the regression class where someone might add a tool_name-specific branch BEFORE the ignore-list check.

6. **Slow-scenario fixture self-test** — sanity-pins the new fake-codex scenario behavior so a fixture break gives a direct failure instead of confusing race-flakes in the dependent coalescing test.

## New fake-codex scenario (`_fixtures/codex`)

`slow` — sleeps `FAKE_CODEX_SLEEP_MS` (default 500ms) before emitting NONE. Enables precise race-window control for concurrent-hook tests without the 30-second `timeout` scenario's wall-clock penalty.

## Numbers

- Test count: **313 → 319** (+6)
- Wall-clock: **4.2s → 7.1s** (+2.9s, dominated by the 1.5s slow-scenario hold in the coalescing test plus ~500ms for 3 concurrent codex spawns)
- Lint clean across 6 workspaces

## What this is NOT

No production code changes. The fake-codex fixture is test-only and not shipped to npm consumers. The hook source (`codex-pair-watch.mjs`) is byte-identical; this PR only adds tests + the test fixture's `slow` scenario.

## Forward-pointer

The deep investigation also surfaced two follow-on ADRs worth scoping later (not in this PR):
- **ADR-099: Edit-burst coalescing semantics** — currently a same-file edit burst loses intermediate reviews. Decide whether to keep + document, post-completion re-review, or debounce.
- **ADR-100: Agentic-Claude cost characterization** — the cost model in the docs assumes sequential single-file edits; measure realistic per-turn / per-session cost under agentic 5–15-tool-call bursts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)