### PR TITLE
fix(plugin): benchmark harness — SIGKILL timeout respect + graceful error-state report rendering

### DIFF
--- a/.changeset/benchmark-harness-sigkill-and-error-rendering.md
+++ b/.changeset/benchmark-harness-sigkill-and-error-rendering.md
@@ -1,0 +1,37 @@
+---
+"@ask-llm/plugin": patch
+---
+
+# Benchmark harness fixes — SIGKILL timeout respect + graceful error-state report rendering
+
+Two defects in the ADR-100 prompt A/B benchmark harness (`packages/claude-plugin/scripts/benchmark/`) discovered during the first real run validating ADR-099. Both fixes are isolated to maintainer tooling — no runtime impact, no test-suite changes needed.
+
+## Fix 1: `lib/invoke-codex.mjs` — SIGKILL respect + settled guard
+
+**Defect**: codex ignored `SIGTERM` when mid-turn. The first benchmark run recorded fixture durations of **712s / 985s / 908s** past a 240-second `SIGTERM` — codex held the script open until its own internal lifecycle decided to exit. The promise-rejection from the timer fired, but the child process kept the Node script alive via its still-open stdio pipes.
+
+**Fix**:
+- Switch from `SIGTERM` to `SIGKILL` — codex respects the latter immediately
+- Explicit `child.stdout.destroy()` + `child.stderr.destroy()` + `child.stdin.destroy()` to release stdio backpressure when killing
+- `settled` guard variable prevents the `close` handler from double-settling the promise if it fires after the timer
+- `child.on("error", ...)` handler added so spawn-failure (ENOENT, EACCES) routes through the same settle path instead of crashing the driver
+- Default `timeoutMs` bumped 120s → 300s; codex with reasoning tokens occasionally needs >2 min for complex fixtures
+- Timeout error message now includes captured stdout/stderr byte counts for diagnostic visibility
+
+## Fix 2: `lib/report.mjs` — error-state rendering without crashing
+
+**Defect**: when ANY fixture errored on EITHER arm, `report.mjs` crashed with `Cannot read properties of undefined (reading 'recall')` because per-fixture iteration accessed `run.score.recall` without checking whether `run` had an `error` instead.
+
+**Fix**:
+- Per-fixture loop now branches on `run.error` and renders a `FAILED — <message>` section with the duration, instead of trying to render score data that doesn't exist
+- Aggregate section now detects "at least one arm errored on every fixture" and surfaces that explicitly instead of computing a nonsensical recall delta on empty data
+
+## Why these matter
+
+The harness will be re-run for every future prompt change (severity-vs-urgency refactor, structured-output tweaks, additional baseline rules). Without these fixes, a single codex non-determinism event would cost 12+ minutes of wall-clock per hung fixture, and the report would crash trying to render the result. The fixes turn the harness from "works when codex is cooperative" into "works regardless of codex's mood."
+
+## What's unchanged
+
+Hook source, broker, cache, lock, parser, prompt rendering — none of these touch runtime code. Pure maintainer-tooling fix.
+
+Plugin test count unchanged at 313; lint clean across 6 workspaces.

--- a/packages/claude-plugin/scripts/benchmark/lib/invoke-codex.mjs
+++ b/packages/claude-plugin/scripts/benchmark/lib/invoke-codex.mjs
@@ -5,7 +5,7 @@
 
 import { spawn } from "node:child_process";
 
-export function invokeCodex({ prompt, model = "gpt-5.5", timeoutMs = 120_000, codexBin = "codex" }) {
+export function invokeCodex({ prompt, model = "gpt-5.5", timeoutMs = 300_000, codexBin = "codex" }) {
   return new Promise((resolve, reject) => {
     const child = spawn(
       codexBin,
@@ -15,11 +15,38 @@ export function invokeCodex({ prompt, model = "gpt-5.5", timeoutMs = 120_000, co
 
     let stdout = "";
     let stderr = "";
-    const timer = setTimeout(() => {
+    let settled = false;
+
+    // First-run discovery: codex ignores SIGTERM mid-turn (observed 712s + 985s
+    // hangs past a 240s SIGTERM in the ADR-100 first run). SIGKILL + explicit
+    // stdio destroy is required to actually release the script. The `settled`
+    // guard prevents double-settle if `close` fires after the timer.
+    const settleReject = (err) => {
+      if (settled) return;
+      settled = true;
       try {
-        child.kill("SIGTERM");
+        child.kill("SIGKILL");
       } catch {}
-      reject(new Error(`codex timed out after ${timeoutMs}ms`));
+      try {
+        child.stdout.destroy();
+      } catch {}
+      try {
+        child.stderr.destroy();
+      } catch {}
+      try {
+        child.stdin.destroy();
+      } catch {}
+      reject(err);
+    };
+
+    const settleResolve = (val) => {
+      if (settled) return;
+      settled = true;
+      resolve(val);
+    };
+
+    const timer = setTimeout(() => {
+      settleReject(new Error(`codex timed out after ${timeoutMs}ms (stdout=${stdout.length}B, stderr=${stderr.length}B captured before SIGKILL)`));
     }, timeoutMs);
 
     child.stdout.on("data", (c) => {
@@ -30,15 +57,20 @@ export function invokeCodex({ prompt, model = "gpt-5.5", timeoutMs = 120_000, co
     });
     child.on("close", (code) => {
       clearTimeout(timer);
+      if (settled) return;
       if (code !== 0) {
-        reject(new Error(`codex exited ${code}: ${stderr.slice(0, 500)}`));
+        settleReject(new Error(`codex exited ${code}: ${stderr.slice(0, 500)}`));
         return;
       }
       try {
-        resolve(parseCodexJsonl(stdout));
+        settleResolve(parseCodexJsonl(stdout));
       } catch (err) {
-        reject(err);
+        settleReject(err);
       }
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      settleReject(err);
     });
     child.stdin.write(prompt);
     child.stdin.end();

--- a/packages/claude-plugin/scripts/benchmark/lib/report.mjs
+++ b/packages/claude-plugin/scripts/benchmark/lib/report.mjs
@@ -48,7 +48,15 @@ export function renderReport({ fixtures, runs, meta }) {
   }
   lines.push("");
 
-  if (meta.arms.length === 2) {
+  // If every fixture errored on at least one arm, there's no signal to compute
+  // a recall delta on. Surface the situation and skip the decision-rule line.
+  const anyArmAllErrored = meta.arms.some((arm) =>
+    fixtures.every((f) => runs[arm][f.name]?.error),
+  );
+  if (anyArmAllErrored) {
+    lines.push("> **No comparable data — at least one arm errored on every fixture.** See per-fixture sections below for individual error messages.");
+    lines.push("");
+  } else if (meta.arms.length === 2) {
     const [armA, armB] = meta.arms;
     const recallDelta = aggregate[armB].recall - aggregate[armA].recall;
     const extraDelta = aggregate[armB].extra - aggregate[armA].extra;
@@ -71,6 +79,12 @@ export function renderReport({ fixtures, runs, meta }) {
       const run = runs[arm][fixture.name];
       if (!run) {
         lines.push(`### Arm \`${arm}\`: (no run data)`);
+        lines.push("");
+        continue;
+      }
+      if (run.error) {
+        lines.push(`### Arm \`${arm}\`: FAILED — ${run.error}`);
+        lines.push(`*Duration: ${(run.durationMs / 1000).toFixed(1)}s*`);
         lines.push("");
         continue;
       }


### PR DESCRIPTION
## Summary

Two defects in the ADR-100 prompt A/B benchmark harness (\`packages/claude-plugin/scripts/benchmark/\`) discovered during the first real run that validated ADR-099 (PR #120). Both fixes are isolated to maintainer tooling — no runtime impact.

## Fix 1: \`lib/invoke-codex.mjs\` — SIGKILL respect + settled guard

**Defect**: codex ignored \`SIGTERM\` when mid-turn. The first benchmark run recorded fixture durations of **712s / 985s / 908s** past a 240-second \`SIGTERM\` — the child held the Node script open via still-open stdio pipes even after promise rejection.

**Changes**:
- Switch from \`SIGTERM\` to \`SIGKILL\` — codex respects the latter immediately
- Explicit \`destroy()\` on \`child.stdout\`/\`stderr\`/\`stdin\` to release backpressure
- \`settled\` guard prevents the \`close\` handler from double-settling the promise
- \`child.on("error", ...)\` handler routes spawn failures through the same path
- Default \`timeoutMs\` bumped 120s → 300s for reasoning-heavy fixtures
- Timeout error now includes captured stdout/stderr byte counts (\`stdout=NB, stderr=NB captured before SIGKILL\`)

## Fix 2: \`lib/report.mjs\` — error-state rendering without crashing

**Defect**: when ANY fixture errored on EITHER arm, \`report.mjs\` crashed with \`Cannot read properties of undefined (reading 'recall')\` because the per-fixture loop read \`run.score.recall\` without checking for an \`error\` field.

**Changes**:
- Per-fixture loop branches on \`run.error\` and renders a \`FAILED — <message>\` section with duration
- Aggregate section detects "at least one arm errored on every fixture" and surfaces that explicitly instead of computing a nonsensical recall delta

## Why these matter

The harness will be re-run for every future prompt change (severity-vs-urgency, structured-output tweaks, additional baseline rules). Without these fixes:

| Without fixes | With fixes |
|---|---|
| One codex non-determinism event costs 12+ min wall-clock per hung fixture | Hard cap at 300s; SIGKILL releases the script |
| Report crashes silently when any fixture errors | Report renders cleanly with FAILED rows |
| User has to manually diagnose what hung | Timeout error includes captured stdout/stderr byte counts |

## What's unchanged

Hook source, broker, cache, lock, parser, prompt rendering — pure maintainer-tooling fix.

## Empirical justification

This isn't speculative. The first ADR-099 benchmark run hit exactly these defects:

```
[pre-baseline] 02-drive-by-refactor... FAILED: codex timed out after 240000ms
[pre-baseline] 03-orphan-imports... done — recall 100% (2/2), 1 extra, 13.351s
[pre-baseline] 04-hidden-assumption... done — recall 100% (2/2), 0 extra, 8.706s
[baseline] 01-overcomplication... done — recall 100% (4/4), 0 extra, 13.71s
[baseline] 02-drive-by-refactor... FAILED: codex timed out after 240000ms
[baseline] 03-orphan-imports... FAILED: codex timed out after 240000ms
[baseline] 04-hidden-assumption... done — recall 100% (2/2), 0 extra, 13.215s

benchmark driver failed: Cannot read properties of undefined (reading 'recall')
```

After applying these fixes, the second run produced clean data (validated ADR-099 with recall delta +12.5 pp, no crashes).

## Test plan

- [x] \`yarn workspace @ask-llm/plugin run test\` — 313/313 pass (no test surface for benchmark scripts; they're one-off tooling exercised manually)
- [x] \`yarn lint\` — clean across 6 workspaces
- [x] Single-fixture sanity (\`02-drive-by-refactor\`) — completed in 12.7s + 18.4s with the new SIGKILL path
- [x] Full 4-fixture run — completed cleanly, report rendered with FAILED row for the one pre-baseline arm that still hung (codex non-determinism)

🤖 Generated with [Claude Code](https://claude.com/claude-code)