### PR TITLE
fix(broker): tag transport system errors (string err.code) as brokerFailure

### DIFF
--- a/packages/claude-plugin/scripts/lib/broker.mjs
+++ b/packages/claude-plugin/scripts/lib/broker.mjs
@@ -344,14 +344,17 @@ export async function probeBrokerHealth(state) {
 // ADR-077 a post-handshake broker hang must be a silent fallback to the
 // per-edit spawn, but broker-rpc's timeout/close/error rejections are PLAIN
 // Errors lacking that marker, so runCodexWithFallback would otherwise
-// rethrow them as a hard verdict. A genuine JSON-RPC error RESPONSE carries
-// `err.code` (broker-rpc sets it from env.error.code) — that's a real
-// server-side verdict, not a broker outage, so we leave it untagged.
+// rethrow them as a hard verdict. broker-rpc rejects a transport failure with
+// either a PLAIN Error (timeout / connection-closed → no `.code`) or the RAW
+// socket error (transport "error" event → a STRING `.code` like ECONNRESET).
+// Only a genuine JSON-RPC error RESPONSE carries a NUMERIC `.code` (broker-rpc
+// sets it from env.error.code) — that's a real server-side verdict, not a
+// broker outage. So we tag everything EXCEPT numeric-coded errors.
 async function brokerRequest(rpc, method, params, timeoutMs, brokerPhase) {
   try {
     return await rpc.request(method, params, { timeoutMs });
   } catch (err) {
-    if (err && typeof err === "object" && err.code === undefined && !err.brokerFailure) {
+    if (err && typeof err === "object" && typeof err.code !== "number" && !err.brokerFailure) {
       err.verdict = "error";
       err.brokerFailure = true;
       err.brokerPhase = brokerPhase;

--- a/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
+++ b/packages/claude-plugin/src/__tests__/codex-pair-watch.test.ts
@@ -3516,6 +3516,47 @@ describe("scripts/codex-pair-watch.mjs — runtime behavior (no codex calls)", (
     expect((caught as any)?.brokerFailure).toBeUndefined();
   });
 
+  it("Bug#6: submitReview tags brokerFailure on a transport system error (string err.code, e.g. ECONNRESET)", async () => {
+    const { submitReview } = await import("../../scripts/lib/broker.mjs");
+    // broker-rpc's transport "error" handler rejects pending requests with the
+    // RAW socket error, which carries a STRING .code (ECONNRESET/EPIPE/...) —
+    // a broker outage mid-session that must tag brokerFailure so the hook falls
+    // back. Only a genuine JSON-RPC error response (NUMERIC .code) is a real
+    // server-side verdict. So `err.code === undefined` is too narrow.
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const mockRpc: any = {
+      request: async (method: string) => {
+        if (method === "thread/start") {
+          const e = new Error("read ECONNRESET");
+          // biome-ignore lint/suspicious/noExplicitAny: structured marker
+          (e as any).code = "ECONNRESET";
+          throw e;
+        }
+        return {};
+      },
+      waitFor: async () => ({ method: "turn/completed", params: {} }),
+    };
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const mockConn: any = { close: () => {}, on: () => {}, destroyed: false };
+    let caught: Error | null = null;
+    try {
+      await submitReview({
+        rpc: mockRpc,
+        connection: mockConn,
+        cwd: "/tmp",
+        baseInstructions: "ctx",
+        prompt: "x",
+        model: "gpt-5.5",
+      });
+    } catch (err) {
+      caught = err as Error;
+    }
+    // biome-ignore lint/suspicious/noExplicitAny: structured marker
+    expect((caught as any)?.brokerFailure).toBe(true);
+    // biome-ignore lint/suspicious/noExplicitAny: structured marker
+    expect((caught as any)?.brokerPhase).toBe("thread_start");
+  });
+
   it("M4 structural: codex-pair-watch.mjs wires the broker integration", () => {
     const watch = fs.readFileSync(path.join(PLUGIN_ROOT, "scripts", "codex-pair-watch.mjs"), "utf-8");
     expect(watch).toMatch(/import.*isBrokerEnabled.*from\s+["']\.\/lib\/broker\.mjs["']/);

--- a/packages/llm-mcp/src/repl.ts
+++ b/packages/llm-mcp/src/repl.ts
@@ -177,6 +177,10 @@ function questionOrEof(rl: readline.Interface, prompt: string): Promise<string |
 }
 
 export async function runReplLoop(rl: readline.Interface, state: ReplState, out: NodeJS.WritableStream): Promise<void> {
+  // `closed` is NOT redundant with questionOrEof's null-on-close return: if the
+  // stream closes while we're inside dispatchPrompt (between prompts),
+  // questionOrEof's own "close" listener isn't registered yet, so without this
+  // flag the loop would re-enter questionOrEof on a closed interface and hang.
   let closed = false;
   rl.once("close", () => {
     closed = true;


### PR DESCRIPTION
## Summary

Follow-up to #130. The fix for the `claude-review` **Medium** on #130 landed on the branch ~4 minutes *after* #130 was merged, so it missed the merge. This PR lands it on `main`.

## The fix

`broker.mjs`'s `brokerRequest` distinguished broker-transport failures (→ tag `brokerFailure`, fall back to per-edit spawn) from genuine JSON-RPC verdicts (→ leave untagged) via `err.code === undefined`. But `broker-rpc`'s transport `"error"` handler (`broker-rpc.mjs:116-122`) rejects pending requests with the **raw** socket error, which carries a **string** `.code` (`ECONNRESET`/`EPIPE`/`ECONNREFUSED`). So a socket failure mid-request was left untagged → hard-rejected instead of falling back — the connection-error half of the "broker died mid-session" case Bug #6 (#130) was meant to cover.

Broadened to `typeof err.code !== "number"`: JSON-RPC error responses carry a **numeric** code (genuine server-side verdict → stays untagged); timeouts (no code) and socket errors (string code) are transport failures → tag `brokerFailure`.

## Changes

- `broker.mjs` — discriminator fix + corrected comment
- `codex-pair-watch.test.ts` — +1 regression test (string-coded `ECONNRESET` → tagged `brokerFailure`), complementing the numeric-code negative test
- `repl.ts` — comment explaining why the `closed` flag is load-bearing (close can fire inside `dispatchPrompt`, before `questionOrEof` registers its listener)

## Testing

- Plugin suite: **324 passed** (incl. the new regression test). `yarn lint` (biome + `tsc --noEmit`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
