### PR TITLE
fix(parsers): codex turn.failed + error-message extraction; log unknown gemini stream events

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,29 @@
 # Architectural Decisions
 
+## ADR-109: Upstream-Issue Consolidation — 21 Issues → 5 Fix Blocks, Audit-Cadence Retirement
+
+- **Date:** 2026-05-30
+- **Status:** Accepted (branch `fix/block-1-parser-defensiveness`; Block 1 shipped, Blocks 2–5 pending)
+
+**Context.** The open-issue tracker had grown to 21, of which **19 were a self-authored "upstream-CLI audit" cadence** (one issue every 1–3 days since 2026-04-21, each a "follow-up to" the last, the majority concluding *"no breaking changes"*). The remaining 2 were codex-pair feature reports. The audits had already diagnosed their own problem (#28: *"drain the backlog instead of recutting it"*; #39: *"cut the consolidated PR"*) and the `ROADMAP.md` already held the latent fix taxonomy (Tiers C–F). The defect was a **process artifact**, not 19 distinct bugs: no canonical upstream-compat tracker, so every re-audit spawned a new tracked issue.
+
+**Decision.** Consolidate by **root cause, not by audit**, after verifying each audit claim directly against the executors/constants (audits are secondary sources):
+
+1. **Close immediately (6):** verified-already-shipped (#27 trust-env co-emit `geminiExecutor.ts:421-424`; #35 reasoning-token mapping `codexExecutor.ts:65,77`) as `completed`; pure-noise cadence check-ins (#24/#25/#28/#39) as `not planned`, folded into the roadmap.
+2. **Fix the remaining 15 as 5 root-cause story blocks**, each gated by `/multi-review` per fix + live smoke per block, closed via its fix PR:
+   - Block 1 — parser event-coverage defensiveness (#57/#114/#116/#117)
+   - Block 2 — quota/fallback freshness (#127/#131)
+   - Block 3 — flag/contract drift cleanup incl. the verified-live `--full-auto` plugin residual (#37/#38/#52/#54/#75)
+   - Block 4 — capability adoption (#59/#102)
+   - Block 5 — codex-pair reliability (#74/#96)
+3. **Retire the cadence:** future upstream deltas become a comment on the standing roadmap, not a new tracked issue (per the ROADMAP meta-observation: stop re-cutting when the backlog is unchanged ≥48h).
+
+Roadmap/tracker: [`docs/plans/2026-05-30-upstream-issue-consolidation.md`](plans/2026-05-30-upstream-issue-consolidation.md).
+
+**Block 1 (shipped this ADR).** Both JSONL/stream-json parsers used `if`-chains with no default branch, silently dropping new upstream event types. Fixes: codex `turn.failed` branch extracting `error.message` so failed/quota turns propagate and trigger fallback (instead of returning the raw JSONL dump); codex `error` events surface `parsed.message` not the JSON envelope; gemini stream parser logs unrecognized event types via `Logger.debug` against a `RECOGNIZED_STREAM_EVENT_TYPES` set. TDD (4 RED→GREEN), full suites green (codex 49 / gemini 109), `/multi-review` clean (both providers, zero findings), live smoke green.
+
+**Consequences.** Tracker drops 21→15 immediately and trends to `open issues == open work`. The verification step caught that the audit's "`JSON.stringify` breaks `isQuotaError`" claim was overstated (substring matching still matched) — the real quota gap was `turn.failed` being unhandled; fixing the right defect required checking the claim, not trusting it.
+
 ## ADR-108: Internal Bug-Hunt Sweep (2026-05-29) + Correction to the `workspace:*` Alarm
 
 - **Date:** 2026-05-29

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,6 +20,13 @@ Repo-wide defensive review (8 parallel agents → findings re-verified by hand �
 - **ADR-100 benchmark harness**: surfaced its own SIGKILL bug on first run (cost: $0 because runs hung before producing tokens), got fixed before being trusted — the meta-pattern that test infrastructure only proves itself by running.
 - **Release workflow hardening**: motivated by 6 days of silent npm publish failures across PRs #109/#112/#118 → fix landed as PR #123 the same session the issue was empirically reproduced.
 
+### 2026-05-30 — upstream-issue consolidation (21 → 15) + Block 1 shipped
+
+Drained the GitHub backlog by root cause (ADR-109), **superseding the 2026-05-27 backlog snapshot below**. Verified every audit claim against code first, then closed #27/#35 as completed (already shipped) and cadence-noise #24/#25/#28/#39 as not-planned, and grouped the remaining 15 issues into **5 fix story blocks** tracked in [`docs/plans/2026-05-30-upstream-issue-consolidation.md`](plans/2026-05-30-upstream-issue-consolidation.md). Each block: TDD fix → `/multi-review` per fix → live smoke per block → PR closing its issues.
+
+- ✅ **Block 1 — parser event-coverage defensiveness** (Tier C, closes #57/#114/#116/#117). Added codex `turn.failed` handling (extract `error.message` → propagate + fallback, was silently returning the raw JSONL dump), codex `error`-event message extraction, and a gemini stream-parser default branch logging unknown event types. 4 RED→GREEN tests; codex 49 / gemini 109 green; `/multi-review` clean both providers; live smoke green. Branch `fix/block-1-parser-defensiveness`.
+- [ ] Block 2 — quota/fallback freshness (#127/#131) · Block 3 — flag/contract cleanup incl. live `--full-auto` plugin residual (#37/#38/#52/#54/#75) · Block 4 — capability adoption (#59/#102) · Block 5 — codex-pair reliability (#74/#96).
+
 ### Open issue backlog (2026-05-27, sorted by signal-to-effort)
 
 GitHub triage: 19 open issues. Of those, **14 are entries in the recurring upstream-CLI audit series** (#24/25/27/28/35/37/38/39/52/54/57/59/75/102/114/116/117) — the audit cadence has stabilized at every 2 days, and as of #117 (2026-05-25) the bottleneck is explicitly _"no longer detection, it's the missing PR"_. The 5 non-audit issues are listed below in priority order.

--- a/docs/plans/2026-05-30-upstream-issue-consolidation.md
+++ b/docs/plans/2026-05-30-upstream-issue-consolidation.md
@@ -1,0 +1,87 @@
+# Upstream-Issue Consolidation & Fix Roadmap (2026-05-30)
+
+> **For agentic workers:** Each story block below is executed live with TDD (write failing test → run → implement → pass → `/multi-review` → smoke). Steps use checkbox (`- [ ]`) syntax for tracking. This doc is the canonical Roadmap and task tracker for draining the 21-issue backlog.
+
+**Goal:** Consolidate the 21 open GitHub issues into 5 actionable story blocks, fix every actionable item with a `/multi-review` gate per fix and a smoke-test gate per block, and close each issue via its fix PR.
+
+**Architecture:** The backlog is 19 self-authored "upstream-CLI audit" check-ins (a process artifact, not user bugs) + 2 codex-pair feature reports. Most "breakages" the audits cite are already shipped; the genuine open work is a small set of root-cause defects verified directly against the executors/constants. We fix by root cause, not by audit.
+
+**Tech stack:** Yarn workspaces monorepo, TypeScript ESM (Node16), Vitest, Biome. Providers: `gemini` CLI 0.44.1, `codex` CLI 0.135.0.
+
+**Review/smoke tooling:** `/multi-review` is driven via the built plugin binaries `node packages/claude-plugin/dist/run.js` (gemini) + `codex-run.js` (codex), piping the diff. Smoke = `yarn build && yarn smoke` (+ targeted `yarn test`).
+
+---
+
+## Issue routing (21 → 5 blocks + drained)
+
+| Disposition | Issues | Action |
+|---|---|---|
+| **Block 1 · Parser defensiveness** | #57, #114, #116, #117 | fix → PR `Closes` |
+| **Block 2 · Quota/fallback freshness** | #127, #131 | fix → PR `Closes` |
+| **Block 3 · Flag/contract cleanup** | #37, #38, #52, #54, #75 | fix → PR `Closes` |
+| **Block 4 · Capability adoption** | #59, #102 | fix → PR `Closes` |
+| **Block 5 · codex-pair reliability** | #74, #96 | fix → PR `Closes` |
+| **Close now — verified already shipped** | #27, #35 | close `completed` (refs below) |
+| **Close now — pure audit-cadence noise** | #24, #25, #28, #39 | close `not planned` (folded here) |
+
+**Verified-shipped refs (for closing #27/#35):**
+- Gemini workspace-trust env: `geminiExecutor.ts:421-424` co-emits `GEMINI_CLI_TRUST_WORKSPACE` (≥0.42) + `GEMINI_TRUST_WORKSPACE` (≤0.41), tested `geminiExecutor.test.ts:725-812`. (#27)
+- Codex reasoning tokens: `codexExecutor.ts:65,77` maps `reasoning_output_tokens`→`thinkingTokens`, tested `codexExecutor.test.ts:173-216`. (#35)
+
+---
+
+## Block 1 · Parser event-coverage defensiveness  (Tier C — #57, #114, #116, #117)
+
+**Defect:** Both JSONL/stream-json parsers use `if`-chains with no default branch, so new upstream event types fall through silently. Verified: `codexExecutor.ts` handles only `thread.started`/`item.completed`/`turn.completed`/`error` — **no `turn.failed`**; the `error` branch stringifies the whole event instead of preferring `parsed.message` (breaks `isQuotaError()`); `geminiExecutor.ts` streaming parser handles `init`/`message`/`result`/`error` with **no default branch**.
+
+**Files:** `packages/codex-mcp/src/utils/codexExecutor.ts`, `packages/gemini-mcp/src/utils/geminiExecutor.ts`, tests in each package's `utils/__tests__/`, `scripts/smoke-test.sh`.
+
+- [x] **1a · codex `turn.failed`** — `CodexTurnFailed` branch extracts `error?.message` (`codexExecutor.ts`); failed/quota turns now propagate + trigger fallback. Tests: "throws on turn.failed", "falls back when a turn.failed event carries a quota signal".
+- [x] **1b · codex `error` `.message` extraction** — `error` branch prefers `parsed.message` over `JSON.stringify`. (Verified the audit's "breaks isQuotaError" claim was overstated; real gap was 1a. This is the clean-error-message fix.) Test: "surfaces the error event's message field".
+- [x] **1c · gemini default branch** — `RECOGNIZED_STREAM_EVENT_TYPES` set + `Logger.debug` for unknown types (`geminiExecutor.ts`). Test: "logs unrecognized stream-json event types".
+- [~] **1d · pin versions** — **skipped**: a hard CLI-version gate in `scripts/smoke-test.sh` would make CI brittle; the live smoke gate already exercises the real CLIs. (audit hygiene, not a defect)
+- [x] **Gate:** codex 49 / gemini 109 green → `/multi-review` clean (both providers, 0 findings) → live smoke green (22.6s gemini / 10.4s codex) → PR `Closes #114 #116 #117 #57`.
+
+## Block 2 · Quota / fallback freshness  (Tier G — #127, #131)
+
+**Defect:** Quota detection is a frozen substring list and the Flash fallback is a frozen model literal, so the safety net rots. Verified: codex `QUOTA_SIGNALS = ["rate_limit_exceeded","quota_exceeded","429","insufficient_quota"]` (`constants.ts:2`) — missing workspace credit / spend-cap strings; gemini `FLASH` default still `gemini-3-flash-preview` (`constants.ts:32`) with the preview model also hardcoded in `QUOTA_EXCEEDED_SHORT` (`constants.ts:9`) — GA `gemini-3.5-flash` exists.
+
+- [ ] **2a · codex quota signals** — add workspace-plan substrings (`out of credits`, `spend cap`, + the v0.134 enum tags) to `QUOTA_SIGNALS`; test a synthetic workspace-credit error triggers `gpt-5.4-mini` fallback.
+- [ ] **2b · gemini Flash → GA** — `FLASH` default `gemini-3-flash-preview` → `gemini-3.5-flash`; update `QUOTA_EXCEEDED_SHORT` (`:9`) + READMEs; keep `ASK_GEMINI_FALLBACK_MODEL` override; test pins the new default.
+- [ ] **2c · fallback semantics** — smoke scenario asserting `usage.fellBack === true` on Pro-quota exhaustion.
+- [ ] **Gate:** tests → `/multi-review` → smoke → PR `Closes #127 #131`.
+
+## Block 3 · Flag / contract drift cleanup  (#37, #38, #52, #54, #75)
+
+**Defect (LIVE BUG):** the executor migrated `--full-auto` → `--sandbox workspace-write`, but `packages/claude-plugin/agents/brainstorm-coordinator.md:71,97` **still spawns `codex exec --full-auto`** — a no-op trap on codex ≥0.128 that silently drops the workspace-write sandbox. Plus two cheap guards.
+
+- [ ] **3a · kill `--full-auto`** in `brainstorm-coordinator.md:71,97` → `codex exec --sandbox workspace-write`; grep-guard test that no plugin source ships `--full-auto`.
+- [ ] **3b · `-m` guard** — snapshot test asserting `buildArgs()` always includes `-m <model>` (`gemini` + `codex`).
+- [ ] **3c · gemini `--ignore-env`** parity opt-out (`ignoreLocalEnv`), symmetric with `ASK_CODEX_LOAD_USER_CONFIG`.
+- [ ] **Gate:** tests → `/multi-review` → smoke → PR `Closes #37 #38 #52 #54 #75`.
+
+## Block 4 · Capability adoption  (Tier E — #59, #102)
+
+**Defect:** upstream features not yet adopted. `ask-codex-edit` via codex `--output-schema` on `exec resume` is the top cross-audit unblock (mirrors `ask-gemini-edit` changeMode, reuses `@ask-llm/shared` chunker). NOTE: `ask-codex-edit` is design-heavy — **brainstorm before implementing.**
+
+- [ ] **4a · `ask-codex-edit`** via `codex exec --output-schema` (brainstorm design first).
+- [ ] **4b · codex `--add-dir`** parity with gemini `--include-directories`.
+- [ ] **4c · `codex doctor` hint** in the fallback-failure error (`codexExecutor.ts:~212`).
+- [ ] **4d · surface codex `reasoning`/`error` item types** in output; **4e · bump documented min codex version**.
+- [ ] **Gate:** tests → `/multi-review` per item → smoke → PR(s) `Closes #102 #59`.
+
+## Block 5 · codex-pair reliability  (Tier D+F — #74, #96)
+
+**Defect:** codex-pair's review signal fails to reach the consumer. #96 Bug 1: next-turn `[codex-pair]` systemMessage never surfaces (verified surfacing path at `codex-pair-watch.mjs:188`). #96 Bug 2: reviews fire on intermediate file states (verify ADR-087/088 debounce covers it). #96 Enh 2: compact verdict-count header. #74: hook not auto-invoked after install — Claude Code session-state limitation, doc-only.
+
+- [ ] **5a · #96 Bug 1** — diagnose + fix next-turn surface emission (repro from issue body first; this is an existing `BUGS.md` entry).
+- [ ] **5b · #96 Bug 2** — verify debounce resolves intermediate-state reviews; if not, per-file settle timer.
+- [ ] **5c · #96 Enh 2** — verdict-count header in `buildVerdictMessage` (gated on 5a).
+- [ ] **5d · #74** — document full-restart-after-install in plugin install instructions; close.
+- [ ] **Gate:** tests → `/multi-review` → smoke → PR `Closes #96 #74`.
+
+---
+
+## Self-review (spec coverage)
+
+Every one of the 21 issues maps to a block or a close-now bucket (table above). The two design-heavy items (`ask-codex-edit`) are flagged for brainstorming before code. Each block has a `/multi-review` gate per fix and a `yarn build && yarn smoke` gate before its PR. Internal-doc obligations per CLAUDE.md: `ROADMAP.md` updated to point here; `DECISIONS.md` gets ADR-109 (this consolidation); `BUGS.md` gets the live `--full-auto` bug (Block 3a).

--- a/packages/codex-mcp/src/utils/__tests__/codexExecutor.test.ts
+++ b/packages/codex-mcp/src/utils/__tests__/codexExecutor.test.ts
@@ -245,6 +245,26 @@ describe("JSONL output parsing", () => {
     const result = await executeCodexCLI({ prompt: "test" });
     expect(result.response).toContain("Partial answer before error");
   });
+
+  // #114 §3.1 — turn.failed (codex rust-v0.131.0+) was unhandled: a failed turn
+  // with no agent_message silently returned the raw JSONL dump as the response.
+  it("throws on turn.failed events, extracting error.message", async () => {
+    mockExecuteCommand.mockResolvedValue(
+      [
+        '{"type":"thread.started","thread_id":"t1"}',
+        '{"type":"turn.failed","error":{"message":"context deadline exceeded"}}',
+      ].join("\n"),
+    );
+
+    await expect(executeCodexCLI({ prompt: "test" })).rejects.toThrow("context deadline exceeded");
+  });
+
+  // #114 §3.2 — error event surfaced the JSON envelope instead of the message field.
+  it("surfaces the error event's message field, not the JSON envelope", async () => {
+    mockExecuteCommand.mockResolvedValue('{"type":"error","message":"You are out of quota"}');
+
+    await expect(executeCodexCLI({ prompt: "test" })).rejects.toThrow("Codex error event: You are out of quota");
+  });
 });
 
 describe("quota fallback", () => {
@@ -302,6 +322,20 @@ describe("quota fallback", () => {
 
     await expect(executeCodexCLI({ prompt: "test" })).rejects.toThrow("ENOENT: codex not found");
     expect(mockExecuteCommand).toHaveBeenCalledTimes(1);
+  });
+
+  // #114 — a quota signal delivered via turn.failed (rather than a thrown CLI
+  // error) must still trigger the fallback, not return the raw JSONL dump.
+  it("falls back when a turn.failed event carries a quota signal", async () => {
+    mockExecuteCommand
+      .mockResolvedValueOnce('{"type":"turn.failed","error":{"message":"rate_limit_exceeded: usage cap hit"}}')
+      .mockResolvedValueOnce('{"type":"item.completed","item":{"type":"agent_message","text":"Recovered"}}');
+
+    const result = await executeCodexCLI({ prompt: "test" });
+    expect(result.response).toContain("Recovered");
+    expect(mockExecuteCommand).toHaveBeenCalledTimes(2);
+    const [, fallbackArgs] = mockExecuteCommand.mock.calls[1];
+    expect(fallbackArgs).toContain(MODELS.FALLBACK);
   });
 });
 

--- a/packages/codex-mcp/src/utils/codexExecutor.ts
+++ b/packages/codex-mcp/src/utils/codexExecutor.ts
@@ -35,7 +35,26 @@ interface CodexThreadStarted {
   thread_id?: string;
 }
 
-type CodexJsonLine = CodexItemCompleted | CodexTurnCompleted | CodexThreadStarted | { type: string };
+// codex rust-v0.131.0+ emits turn.failed for turns that abort (quota, policy,
+// deadline) without producing an agent_message; the human-readable reason is
+// nested under error.message.
+interface CodexTurnFailed {
+  type: "turn.failed";
+  error?: { message?: string };
+}
+
+interface CodexErrorEvent {
+  type: "error";
+  message?: string;
+}
+
+type CodexJsonLine =
+  | CodexItemCompleted
+  | CodexTurnCompleted
+  | CodexThreadStarted
+  | CodexTurnFailed
+  | CodexErrorEvent
+  | { type: string };
 
 export interface CodexExecutorOptions {
   prompt: string;
@@ -115,8 +134,12 @@ function parseCodexJsonlOutput(raw: string, model: string, durationMs: number, f
       usage = (parsed as CodexTurnCompleted).usage;
     }
 
+    if (parsed.type === "turn.failed") {
+      lastError = (parsed as CodexTurnFailed).error?.message ?? JSON.stringify(parsed);
+    }
+
     if (parsed.type === "error") {
-      lastError = JSON.stringify(parsed);
+      lastError = (parsed as CodexErrorEvent).message ?? JSON.stringify(parsed);
     }
   }
 

--- a/packages/gemini-mcp/src/utils/__tests__/geminiExecutor.test.ts
+++ b/packages/gemini-mcp/src/utils/__tests__/geminiExecutor.test.ts
@@ -14,7 +14,7 @@ vi.mock("@ask-llm/shared", async (importOriginal) => {
   };
 });
 
-import { executeCommand, responseCache } from "@ask-llm/shared";
+import { executeCommand, Logger, responseCache } from "@ask-llm/shared";
 import { executeGeminiCLI } from "../geminiExecutor.js";
 
 const mockExecuteCommand = vi.mocked(executeCommand);
@@ -514,6 +514,24 @@ describe("executeGeminiCLI session support", () => {
       CLI.FLAGS.PROMPT,
       "hello",
     ]);
+  });
+});
+
+describe("stream-json event coverage (#114/#116)", () => {
+  it("logs unrecognized stream-json event types instead of dropping them silently", async () => {
+    mockExecuteCommand.mockResolvedValueOnce(
+      [
+        '{"type":"init","session_id":"s1"}',
+        '{"type":"AgentExecutionStopped","reason":"policy"}',
+        '{"type":"message","role":"assistant","content":"hi"}',
+        '{"type":"result","stats":{}}',
+      ].join("\n"),
+    );
+
+    const result = await executeGeminiCLI({ prompt: "hello" });
+
+    expect(result.response).toContain("hi");
+    expect(vi.mocked(Logger.debug)).toHaveBeenCalledWith(expect.stringContaining("AgentExecutionStopped"));
   });
 });
 

--- a/packages/gemini-mcp/src/utils/geminiExecutor.ts
+++ b/packages/gemini-mcp/src/utils/geminiExecutor.ts
@@ -270,6 +270,12 @@ function streamStatsToCliStats(stats: GeminiStreamStats | undefined): GeminiCliS
   return { models };
 }
 
+// stream-json event types we explicitly handle. Anything outside this set is
+// logged (not silently dropped) so new upstream event variants — e.g.
+// AgentExecutionStopped/Blocked added in gemini-cli v0.43 — surface in debug
+// output instead of vanishing (#116).
+const RECOGNIZED_STREAM_EVENT_TYPES = new Set(["init", "message", "result", "error"]);
+
 export function parseGeminiStreamJsonl(
   raw: string,
   requestedModel: string,
@@ -314,6 +320,8 @@ export function parseGeminiStreamJsonl(
       }
     } else if (event.type === "error") {
       errorMsg = typeof event.message === "string" ? event.message : JSON.stringify(event);
+    } else if (!RECOGNIZED_STREAM_EVENT_TYPES.has(event.type)) {
+      Logger.debug(`Unrecognized Gemini stream-json event type: ${event.type}`);
     }
   }
 


### PR DESCRIPTION
## Block 1 of the 2026-05-30 upstream-issue consolidation (ADR-109)

Both the codex JSONL parser and the gemini stream-json parser used `if`-chains with **no default branch**, so new upstream event types fell through silently. This is the highest-value slice of the consolidated backlog (Tier C in `ROADMAP.md`).

### Changes
- **codex `turn.failed`** (`codexExecutor.ts`) — new branch extracts `error.message`. Previously a failed turn with no `agent_message` (quota, policy, deadline) silently returned the **raw JSONL dump** as the response and never triggered fallback. Now it propagates as a thrown error, so a quota-carrying `turn.failed` routes through the existing fallback path.
- **codex `error` events** — surface `parsed.message` instead of `JSON.stringify(entire event)`, so the user sees the real message, not the JSON envelope.
- **gemini stream parser** (`geminiExecutor.ts`) — `default` branch logs unrecognized event types via `Logger.debug` against a `RECOGNIZED_STREAM_EVENT_TYPES` set (e.g. `AgentExecutionStopped`/`Blocked` added in gemini-cli v0.43), instead of dropping them silently.

> Note: while implementing 1b I verified the audit's "`JSON.stringify` breaks `isQuotaError()`" claim was overstated — `isQuotaError` does substring matching, which still matched inside the stringified JSON. The **real** quota-detection gap was `turn.failed` being unhandled (fixed above). The `error`-message change is the clean-message improvement it actually is.

### Verification
- **TDD**: 4 RED→GREEN tests (turn.failed throws; turn.failed quota → fallback; error message extraction; gemini unknown-event logging)
- **Suites**: codex 49 ✓ / gemini 109 ✓ (no regressions); lint + tsc clean
- **`/multi-review`**: Gemini + Codex both clean, zero findings — both independently confirmed the "partial `agent_message` survives a trailing error" invariant is preserved
- **Live smoke**: green for both providers (22.6s gemini / 10.4s codex — real API integration)

Closes #114
Closes #116
Closes #117
Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)