### PR TITLE
[codex] Add context brief contract

### DIFF
--- a/packages/claude-plugin/agents/brainstorm-coordinator.md
+++ b/packages/claude-plugin/agents/brainstorm-coordinator.md
@@ -39,11 +39,43 @@ Understand what needs brainstorming:
 - If the topic involves code, gather relevant context (diffs, file contents, architecture)
 - If the topic is a plan or design, include the full proposal text
 - Note which files, skills, or artifacts are referenced — you'll Read them in Phase 3B
+- Build or refine a **Context Brief** before external dispatch. If the caller supplied one, preserve it and fill gaps rather than starting over. The brief is a compact manifest, not a raw-data dump:
+
+```markdown
+## Context Brief
+
+Intent:
+- User request:
+- Brainstorm mode:
+- Providers:
+
+Scope:
+- Changed/referenced files:
+- Included files/docs:
+- Excluded files/docs and reason:
+- Diff bytes:
+
+Repository signals:
+- Relevant package/workspace:
+- CLAUDE.md files read:
+- ADRs/docs read:
+
+Risk focus:
+- Security:
+- Data loss:
+- Concurrency/state:
+- API/contract:
+- Tests/build:
+
+Open questions:
+- Items not verified before dispatch:
+```
 
 ### Phase 2: Prompt Construction
 
 Build a clear, structured prompt for the external providers. The prompt should:
 - State the topic or question precisely
+- Include the Context Brief before any diff, plan, or source excerpts
 - Include all relevant context (code, plans, constraints)
 - Ask for specific deliverables (e.g., "review for X, Y, Z" or "suggest alternatives for X")
 - Request structured output (numbered points, pros/cons, priorities)
@@ -56,10 +88,11 @@ Your own deep research phase. Do NOT skip this. Do NOT delegate it to a sub-agen
 2. **Trace through the real behavior.** If the topic involves a pipeline, effect, state machine, or control flow, mentally execute the code with the repo's actual conventions in mind. Factor in framework-specific semantics (React Compiler, XState, RTK Query, etc.) that a generic reviewer might miss.
 3. **Use WebFetch/WebSearch when the topic references external docs.** If the topic mentions a library, framework, RFC, or public URL, fetch the current docs — don't rely on training data.
 4. **Form independent findings** structured identically to the external providers' output: numbered points, pros/cons, priorities.
-5. **Record confidence per finding.** Mark each finding as:
+5. **Update the Context Brief.** Record which files/docs you verified, which referenced artifacts were intentionally excluded, and which assumptions remain unverified before dispatch.
+6. **Record confidence per finding.** Mark each finding as:
    - **Verified** — backed by an actual file Read, code trace, or fetched document (highest confidence)
    - **Inferred** — reasoned from the topic description without direct verification (lower confidence)
-6. **Do NOT skip ahead to Phase 4.** External provider responses don't exist yet — Phase 3A hasn't run. Complete your entire Claude view *before* issuing the Phase 3A Bash call. This blindness is what makes you a peer participant instead of a commentator.
+7. **Do NOT skip ahead to Phase 4.** External provider responses don't exist yet — Phase 3A hasn't run. Complete your entire Claude view *before* issuing the Phase 3A Bash call. This blindness is what makes you a peer participant instead of a commentator.
 
 ### Phase 3A: External Provider Dispatch (runs after 3B — single blocking Bash call)
 

--- a/packages/claude-plugin/agents/brainstorm-coordinator.md
+++ b/packages/claude-plugin/agents/brainstorm-coordinator.md
@@ -39,7 +39,7 @@ Understand what needs brainstorming:
 - If the topic involves code, gather relevant context (diffs, file contents, architecture)
 - If the topic is a plan or design, include the full proposal text
 - Note which files, skills, or artifacts are referenced — you'll Read them in Phase 3B
-- Build or refine a **Context Brief** before external dispatch. If the caller supplied one, preserve it and fill gaps rather than starting over. The brief is a compact manifest, not a raw-data dump:
+- Build an initial **Context Brief** now; Phase 3B will refine it after verifying artifacts. If the caller supplied one, preserve it and fill gaps rather than starting over. The brief is a compact manifest, not a raw-data dump:
 
 ```markdown
 ## Context Brief

--- a/packages/claude-plugin/skills/brainstorm/SKILL.md
+++ b/packages/claude-plugin/skills/brainstorm/SKILL.md
@@ -29,7 +29,37 @@ Consult multiple external LLM providers simultaneously on a topic while Claude O
   - **Size-check**: if combined diff > 150KB, ask the user before sending (the providers will take 5–15 min on payloads that large)
 - If the context is a design/plan, gather the relevant documentation or conversation context
 - If no topic is clear, ask the user what they'd like to brainstorm about
-- Create a compact **Context Brief** before launching the coordinator. Include the user request, selected providers, changed/referenced files, included/excluded files and reasons, diff bytes if any, relevant docs/ADRs, risk focus, and open questions. Keep it tiny for simple topics; add detail when the request is architecture/design/security/concurrency/migration related, spans packages, references external specs, or depends on conversation context external providers cannot see.
+- Create a compact **Context Brief** before launching the coordinator. Keep it tiny for simple topics; add detail when the request is architecture/design/security/concurrency/migration related, spans packages, references external specs, or depends on conversation context external providers cannot see.
+
+```markdown
+## Context Brief
+
+Intent:
+- User request:
+- Brainstorm mode:
+- Providers: <list the selected providers for this run>
+
+Scope:
+- Changed/referenced files:
+- Included files/docs:
+- Excluded files/docs and reason:
+- Diff bytes:
+
+Repository signals:
+- Relevant package/workspace:
+- CLAUDE.md files read:
+- ADRs/docs read:
+
+Risk focus:
+- Security:
+- Data loss:
+- Concurrency/state:
+- API/contract:
+- Tests/build:
+
+Open questions:
+- Items not verified before dispatch:
+```
 
 ### Phase 3: Launch the brainstorm-coordinator agent
 

--- a/packages/claude-plugin/skills/brainstorm/SKILL.md
+++ b/packages/claude-plugin/skills/brainstorm/SKILL.md
@@ -29,13 +29,15 @@ Consult multiple external LLM providers simultaneously on a topic while Claude O
   - **Size-check**: if combined diff > 150KB, ask the user before sending (the providers will take 5–15 min on payloads that large)
 - If the context is a design/plan, gather the relevant documentation or conversation context
 - If no topic is clear, ask the user what they'd like to brainstorm about
+- Create a compact **Context Brief** before launching the coordinator. Include the user request, selected providers, changed/referenced files, included/excluded files and reasons, diff bytes if any, relevant docs/ADRs, risk focus, and open questions. Keep it tiny for simple topics; add detail when the request is architecture/design/security/concurrency/migration related, spans packages, references external specs, or depends on conversation context external providers cannot see.
 
 ### Phase 3: Launch the brainstorm-coordinator agent
 
-Launch with: the topic, the selected external providers list, any gathered context (diff/files/docs).
+Launch with: the topic, the selected external providers list, the Context Brief, and any gathered context (diff/files/docs).
 
 The coordinator handles:
 - Phase 3B: its own Claude Opus research (reads actual files, traces code, uses WebFetch/WebSearch on referenced external docs) — runs FIRST so Claude doesn't anchor on external responses
+- Context Brief update: after Phase 3B, records verified files/docs and unverified assumptions before external dispatch
 - Phase 3A: external provider dispatch via a single blocking foreground Bash call (ADR-050 dispatch pattern)
 - Phase 4: synthesis — consensus, unique insights, contradictions across all participants
 - Verified findings (backed by Claude's file reads) are weighted higher than inferred ones

--- a/packages/claude-plugin/skills/multi-review/SKILL.md
+++ b/packages/claude-plugin/skills/multi-review/SKILL.md
@@ -54,13 +54,13 @@ The two skills compose. Run both when you want both questions answered; do not m
 Intent:
 - User request:
 - Review mode: multi-review
-- Providers: gemini, codex
+- Providers: <list the actual providers selected for this run>
 
 Scope:
 - Base ref:
 - Changed files:
-- Included files:
-- Excluded files and reason:
+- Included files/docs:
+- Excluded files/docs and reason:
 - Diff bytes:
 
 Repository signals:

--- a/packages/claude-plugin/skills/multi-review/SKILL.md
+++ b/packages/claude-plugin/skills/multi-review/SKILL.md
@@ -46,11 +46,46 @@ The two skills compose. Run both when you want both questions answered; do not m
    - **> 150KB**: tell the user, ask whether to truncate (head -c 150000) or split by package, do NOT silently send a giant payload
    - **Empty**: stop and inform the user "no changes to review"
 
+4. **Create a Context Brief** — a compact manifest that makes the handoff reproducible. Put it before the diff in every reviewer prompt; do not use it as an excuse to paste more raw files by default.
+
+```markdown
+## Context Brief
+
+Intent:
+- User request:
+- Review mode: multi-review
+- Providers: gemini, codex
+
+Scope:
+- Base ref:
+- Changed files:
+- Included files:
+- Excluded files and reason:
+- Diff bytes:
+
+Repository signals:
+- Relevant package/workspace:
+- CLAUDE.md files read:
+- ADRs/docs read:
+
+Risk focus:
+- Security:
+- Data loss:
+- Concurrency/state:
+- API/contract:
+- Tests/build:
+
+Open questions:
+- Items not verified before dispatch:
+```
+
+Keep the brief tiny for simple diffs. Escalate detail when the diff is over 50KB, spans more than 5 files, crosses package boundaries, includes untracked files, references ADRs/specs, or depends on conversation context the external providers cannot see.
+
 ### Phase 2: Dispatch (with fallback)
 
 **Preferred: launch both reviewer agents in parallel** using the Agent tool in a single message:
-- `gemini-reviewer` agent with the diff content
-- `codex-reviewer` agent with the diff content
+- `gemini-reviewer` agent with the Context Brief + diff content
+- `codex-reviewer` agent with the Context Brief + diff content
 - Each agent performs its own 4-phase pipeline: Context → Prompt → Synthesis → Validation
 
 **Fallback when reviewer agents are unavailable** (e.g., plugin not installed in this Claude Code session): dispatch directly via the project's `dist/run.js` and `dist/codex-run.js` runner binaries using the **ADR-050 dispatch pattern** (single foreground blocking Bash call, direct backgrounding, per-PID `wait`, 25-min timeout):
@@ -96,6 +131,11 @@ When a provider fails (timeout, capacity exhaustion, exit code ≠ 0, 0-byte out
 
 ```markdown
 ## Multi-Provider Review
+
+**Context used:**
+- Included: <files / packages>
+- Excluded: <files / patterns and reason>
+- Diff bytes: <N>
 
 **Verified by both providers (highest confidence):**
 - ⟨finding⟩ — Gemini: 92, Codex: 88. Verified at <file>:<line>.

--- a/packages/claude-plugin/src/__tests__/skills-and-agents.test.ts
+++ b/packages/claude-plugin/src/__tests__/skills-and-agents.test.ts
@@ -152,6 +152,14 @@ describe("multi-review skill — load-bearing polish (ADR-064)", () => {
   it("requires resilient failure handling (don't silently drop a failed provider)", () => {
     expect(body).toMatch(/[Dd]o NOT silently drop|silently drop|surface the failure/i);
   });
+
+  it("requires a Context Brief before dispatching reviewer prompts", () => {
+    expect(body).toMatch(/Context Brief/);
+    expect(body).toMatch(/Included files/);
+    expect(body).toMatch(/Excluded files and reason/);
+    expect(body).toMatch(/Diff bytes/);
+    expect(body).toMatch(/before the diff/);
+  });
 });
 
 describe("brainstorm skill — polish (ADR-064)", () => {
@@ -174,6 +182,13 @@ describe("brainstorm skill — polish (ADR-064)", () => {
   it("points users to /multi-review for source-verified code review", () => {
     expect(body).toMatch(/\/multi-review/);
   });
+
+  it("requires passing a Context Brief into the coordinator", () => {
+    expect(body).toMatch(/Context Brief/);
+    expect(body).toMatch(/selected providers/);
+    expect(body).toMatch(/included\/excluded files and reasons/i);
+    expect(body).toMatch(/unverified assumptions/);
+  });
 });
 
 describe("brainstorm-coordinator agent — Phase 4 cross-check polish (ADR-064)", () => {
@@ -190,6 +205,13 @@ describe("brainstorm-coordinator agent — Phase 4 cross-check polish (ADR-064)"
 
   it("includes a Rejected section in the synthesis to surface false positives", () => {
     expect(body).toMatch(/Rejected.*false positives/i);
+  });
+
+  it("requires the coordinator to update the Context Brief after Claude research", () => {
+    expect(body).toMatch(/Context Brief/);
+    expect(body).toMatch(/verified files\/docs|files\/docs you verified/i);
+    expect(body).toMatch(/assumptions remain unverified|unverified assumptions/i);
+    expect(body).toMatch(/before external dispatch|before dispatch/i);
   });
 });
 

--- a/packages/claude-plugin/src/__tests__/skills-and-agents.test.ts
+++ b/packages/claude-plugin/src/__tests__/skills-and-agents.test.ts
@@ -155,10 +155,18 @@ describe("multi-review skill — load-bearing polish (ADR-064)", () => {
 
   it("requires a Context Brief before dispatching reviewer prompts", () => {
     expect(body).toMatch(/Context Brief/);
-    expect(body).toMatch(/Included files/);
-    expect(body).toMatch(/Excluded files and reason/);
+    expect(body).toMatch(/Providers: <list the actual providers selected for this run>/);
+    expect(body).toMatch(/Included files\/docs/);
+    expect(body).toMatch(/Excluded files\/docs and reason/);
     expect(body).toMatch(/Diff bytes/);
     expect(body).toMatch(/before the diff/);
+  });
+
+  it("pins the Context used section in the output template", () => {
+    expect(body).toMatch(/Context used:/);
+    expect(body).toMatch(/Included: <files \/ packages>/);
+    expect(body).toMatch(/Excluded: <files \/ patterns and reason>/);
+    expect(body).toMatch(/Diff bytes: <N>/);
   });
 });
 
@@ -185,8 +193,9 @@ describe("brainstorm skill — polish (ADR-064)", () => {
 
   it("requires passing a Context Brief into the coordinator", () => {
     expect(body).toMatch(/Context Brief/);
-    expect(body).toMatch(/selected providers/);
-    expect(body).toMatch(/included\/excluded files and reasons/i);
+    expect(body).toMatch(/Providers: <list the selected providers for this run>/);
+    expect(body).toMatch(/Included files\/docs/);
+    expect(body).toMatch(/Excluded files\/docs and reason/);
     expect(body).toMatch(/unverified assumptions/);
   });
 });


### PR DESCRIPTION
## Summary

Adds a lightweight Context Brief contract to the Claude plugin review and brainstorm flows so provider dispatches include a concise scope manifest before raw diffs, plans, or source excerpts.

## What changed

- `/multi-review` now requires a Context Brief with included/excluded files, diff bytes, repository signals, risk focus, and open questions before reviewer dispatch.
- `/brainstorm` now passes a Context Brief into the coordinator and expects it to be updated after Claude research.
- `brainstorm-coordinator` now preserves/refines the brief, includes it before external-provider payloads, and records verified files/docs plus unverified assumptions before dispatch.
- Structural tests pin the new prompt contract.

## Why

The current data volume is reasonable for routine reviews, but the gather step was implicit and duplicated across skills and agents. A small manifest makes the handoff reproducible without increasing default raw payload size or weakening source verification.

## Validation

- `yarn workspace @ask-llm/plugin test` passed: 366 tests
- `yarn build` passed
- `yarn workspace @ask-llm/plugin lint` passed
- `git diff --check` passed
