### PR TITLE
fix(codex): actionable error for archived-session resume (#139)

### DIFF
--- a/packages/codex-mcp/src/constants.ts
+++ b/packages/codex-mcp/src/constants.ts
@@ -3,6 +3,12 @@ export const ERROR_MESSAGES = {
   // "out of credits" + "spend cap" cover the 4 codex 0.134 workspace usage-limit
   // messages (owner/member × credits/spend-cap) from PR #24114. See #127.
   QUOTA_SIGNALS: ["rate_limit_exceeded", "quota_exceeded", "429", "insufficient_quota", "out of credits", "spend cap"],
+  // codex 0.136 archived sessions: `codex exec resume <id>` fails if the session
+  // was archived. Lowercased substrings; isArchivedSessionError() lowercases
+  // before matching. "archived_sessions" is the rollout path from upstream
+  // openai/codex#19362 — confirm the exact string against a live archived
+  // session on codex >= 0.136. #139 / #141 F1.
+  ARCHIVED_SESSION_SIGNALS: ["archived_sessions", "archived session", "session is archived"],
   NO_PROMPT_PROVIDED:
     "Please provide a prompt for analysis. Ask general questions or describe the code you want reviewed.",
   TOOL_NOT_FOUND: "not found in registry",

--- a/packages/codex-mcp/src/utils/__tests__/codexExecutor.test.ts
+++ b/packages/codex-mcp/src/utils/__tests__/codexExecutor.test.ts
@@ -719,8 +719,10 @@ describe("ask-codex-edit / editMode (#102)", () => {
 // archived session fails. Translate it to an actionable error and do NOT fall
 // back to the mini model (the session is still archived after a retry). #139 / #141 F1.
 describe("executeCodexCLI archived-session resume (codex 0.136, #139)", () => {
-  it("archived-session error on resume → actionable message, no mini fallback", async () => {
-    mockExecuteCommand.mockReset();
+  // beforeEach already runs vi.clearAllMocks() + sets a default resolved value,
+  // so no per-test mockReset() is needed; mockRejectedValueOnce overrides for
+  // the single call these tests make.
+  it("archived-session error on resume (rollout-path signal) → actionable message, no mini fallback", async () => {
     mockExecuteCommand.mockRejectedValueOnce(
       new Error("Failed to resume session from ~/.codex/archived_sessions/rollout-2026-06-05.jsonl"),
     );
@@ -730,8 +732,14 @@ describe("executeCodexCLI archived-session resume (codex 0.136, #139)", () => {
     expect(mockExecuteCommand).toHaveBeenCalledTimes(1); // no mini fallback
   });
 
+  it("matches the prose 'session is archived' signal too (not just the rollout path)", async () => {
+    mockExecuteCommand.mockRejectedValueOnce(new Error("error: session is archived"));
+    const err = await executeCodexCLI({ prompt: "follow up", sessionId: "thread-xyz" }).catch((e) => e as Error);
+    expect(err.message).toMatch(/session thread-xyz is archived/i);
+    expect(err.message).toMatch(/codex unarchive thread-xyz/);
+  });
+
   it("archived signal without a sessionId is not special-cased (no false trigger)", async () => {
-    mockExecuteCommand.mockReset();
     mockExecuteCommand.mockRejectedValueOnce(new Error("unrelated archived_sessions mention"));
     const err = await executeCodexCLI({ prompt: "hi" }).catch((e) => e as Error);
     expect(err.message).not.toMatch(/codex unarchive/i);

--- a/packages/codex-mcp/src/utils/__tests__/codexExecutor.test.ts
+++ b/packages/codex-mcp/src/utils/__tests__/codexExecutor.test.ts
@@ -714,3 +714,26 @@ describe("ask-codex-edit / editMode (#102)", () => {
     expect([...item.required].sort()).toEqual(Object.keys(item.properties).sort());
   });
 });
+
+// codex 0.136 introduced archived sessions; `codex exec resume <id>` against an
+// archived session fails. Translate it to an actionable error and do NOT fall
+// back to the mini model (the session is still archived after a retry). #139 / #141 F1.
+describe("executeCodexCLI archived-session resume (codex 0.136, #139)", () => {
+  it("archived-session error on resume → actionable message, no mini fallback", async () => {
+    mockExecuteCommand.mockReset();
+    mockExecuteCommand.mockRejectedValueOnce(
+      new Error("Failed to resume session from ~/.codex/archived_sessions/rollout-2026-06-05.jsonl"),
+    );
+    const err = await executeCodexCLI({ prompt: "follow up", sessionId: "thread-xyz" }).catch((e) => e as Error);
+    expect(err.message).toMatch(/session thread-xyz is archived/i);
+    expect(err.message).toMatch(/codex unarchive thread-xyz/);
+    expect(mockExecuteCommand).toHaveBeenCalledTimes(1); // no mini fallback
+  });
+
+  it("archived signal without a sessionId is not special-cased (no false trigger)", async () => {
+    mockExecuteCommand.mockReset();
+    mockExecuteCommand.mockRejectedValueOnce(new Error("unrelated archived_sessions mention"));
+    const err = await executeCodexCLI({ prompt: "hi" }).catch((e) => e as Error);
+    expect(err.message).not.toMatch(/codex unarchive/i);
+  });
+});

--- a/packages/codex-mcp/src/utils/codexExecutor.ts
+++ b/packages/codex-mcp/src/utils/codexExecutor.ts
@@ -178,6 +178,11 @@ function isQuotaError(error: unknown): boolean {
   return ERROR_MESSAGES.QUOTA_SIGNALS.some((signal) => msg.includes(signal));
 }
 
+function isArchivedSessionError(error: unknown): boolean {
+  const msg = (error instanceof Error ? error.message : String(error)).toLowerCase();
+  return ERROR_MESSAGES.ARCHIVED_SESSION_SIGNALS.some((signal) => msg.includes(signal));
+}
+
 interface CodexEditItem {
   file: string;
   startLine?: number;
@@ -364,6 +369,14 @@ export async function executeCodexCLI(options: CodexExecutorOptions): Promise<Co
       if (cacheKey) responseCache.set(cacheKey, result.response);
       return result;
     } catch (error) {
+      // codex 0.136: resuming an archived session can't be retried (the session
+      // stays archived), so surface an actionable message and do NOT fall back
+      // to the mini model. Only when a sessionId was actually supplied.
+      if (sessionId && isArchivedSessionError(error)) {
+        throw new Error(
+          `Codex session ${sessionId} is archived. Run \`codex unarchive ${sessionId}\` to resume it, or omit sessionId to start a new thread.`,
+        );
+      }
       if (isQuotaError(error) && model !== MODELS.FALLBACK) {
         Logger.warn(`${STATUS_MESSAGES.QUOTA_SWITCHING} Falling back to ${MODELS.FALLBACK}.`);
         Logger.debug(`Status: ${STATUS_MESSAGES.FALLBACK_RETRY}`);


### PR DESCRIPTION
Addresses the **#141 F1** correctness gap tracked in **#139** (rolling upstream-sync tracker). Does **not** close #139 — that tracker still owns the gemini stream-json work + docs items.

## Summary

codex 0.136 introduced archived sessions; `codex exec resume <id>` against an archived session fails. Previously `ask-codex` surfaced the raw error (e.g. *"Failed to resume session from ~/.codex/archived_sessions/…"*), and a quota-shaped variant could even trigger a pointless mini-model retry (the session is still archived after the retry).

- New `ARCHIVED_SESSION_SIGNALS` (`constants.ts`) + `isArchivedSessionError` (`codexExecutor.ts`), mirroring the existing `QUOTA_SIGNALS`/`isQuotaError` pattern.
- In the executor catch: when a `sessionId` was supplied **and** the error is archived-class, throw a clean message — *"Codex session `<id>` is archived. Run `codex unarchive <id>` to resume it, or omit sessionId to start a new thread."* — and **do not** fall back to mini. Fires only when `sessionId` is present.

## Test Plan

- [x] 2 new catch-flow tests (`vi.mock(@ask-llm/shared)`): archived error on resume → actionable message + **no** mini fallback (call count 1); archived signal **without** a sessionId → not special-cased.
- [x] Full `ask-codex-mcp` suite **67 passing**; `yarn lint` clean.
- [ ] **Verify the exact signal string** against a live archived session on codex ≥0.136 before relying on it — `ARCHIVED_SESSION_SIGNALS` are best-guess (`archived_sessions` is the rollout path from upstream openai/codex#19362). The match fails safe (raw error, as today) if the real string differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)