### PR TITLE
feat(gemini): surface AgentExecutionStopped/Blocked stream events (#139)

### DIFF
--- a/packages/gemini-mcp/src/utils/__tests__/geminiExecutor.test.ts
+++ b/packages/gemini-mcp/src/utils/__tests__/geminiExecutor.test.ts
@@ -557,21 +557,35 @@ describe("executeGeminiCLI session support", () => {
   });
 });
 
-describe("stream-json event coverage (#114/#116)", () => {
-  it("logs unrecognized stream-json event types instead of dropping them silently", async () => {
+describe("stream-json event coverage (#114/#116, #139)", () => {
+  it("surfaces AgentExecutionStopped as an error (gemini 0.43+; was dropped to debug)", async () => {
+    mockExecuteCommand.mockResolvedValueOnce(
+      ['{"type":"init","session_id":"s1"}', '{"type":"AgentExecutionStopped","reason":"workspace trust denied"}'].join(
+        "\n",
+      ),
+    );
+    const err = await executeGeminiCLI({ prompt: "hello" }).catch((e) => e as Error);
+    expect(err.message).toMatch(/AgentExecutionStopped/);
+    expect(err.message).toMatch(/workspace trust denied/);
+  });
+
+  it("surfaces AgentExecutionBlocked with its reason", async () => {
+    mockExecuteCommand.mockResolvedValueOnce('{"type":"AgentExecutionBlocked","reason":"tool denied"}');
+    const err = await executeGeminiCLI({ prompt: "hello" }).catch((e) => e as Error);
+    expect(err.message).toMatch(/AgentExecutionBlocked: tool denied/);
+  });
+
+  it("still logs a genuinely-unknown event type to debug (no throw)", async () => {
     mockExecuteCommand.mockResolvedValueOnce(
       [
-        '{"type":"init","session_id":"s1"}',
-        '{"type":"AgentExecutionStopped","reason":"policy"}',
+        '{"type":"SomeFutureEvent","x":1}',
         '{"type":"message","role":"assistant","content":"hi"}',
         '{"type":"result","stats":{}}',
       ].join("\n"),
     );
-
     const result = await executeGeminiCLI({ prompt: "hello" });
-
     expect(result.response).toContain("hi");
-    expect(vi.mocked(Logger.debug)).toHaveBeenCalledWith(expect.stringContaining("AgentExecutionStopped"));
+    expect(vi.mocked(Logger.debug)).toHaveBeenCalledWith(expect.stringContaining("SomeFutureEvent"));
   });
 });
 

--- a/packages/gemini-mcp/src/utils/geminiExecutor.ts
+++ b/packages/gemini-mcp/src/utils/geminiExecutor.ts
@@ -252,6 +252,7 @@ interface GeminiStreamEvent {
   status?: string;
   error?: unknown;
   message?: string;
+  reason?: string;
   stats?: GeminiStreamStats;
 }
 
@@ -272,10 +273,18 @@ function streamStatsToCliStats(stats: GeminiStreamStats | undefined): GeminiCliS
 }
 
 // stream-json event types we explicitly handle. Anything outside this set is
-// logged (not silently dropped) so new upstream event variants — e.g.
-// AgentExecutionStopped/Blocked added in gemini-cli v0.43 — surface in debug
-// output instead of vanishing (#116).
-const RECOGNIZED_STREAM_EVENT_TYPES = new Set(["init", "message", "result", "error"]);
+// logged (not silently dropped) so new upstream event variants surface in
+// debug output instead of vanishing (#116). AgentExecutionStopped/Blocked
+// (gemini-cli v0.43+) are now handled as terminal errors rather than logged,
+// since their reason/message is actionable (#139, unblocked by 0.45.0 stable).
+const RECOGNIZED_STREAM_EVENT_TYPES = new Set([
+  "init",
+  "message",
+  "result",
+  "error",
+  "AgentExecutionStopped",
+  "AgentExecutionBlocked",
+]);
 
 export function parseGeminiStreamJsonl(
   raw: string,
@@ -321,6 +330,16 @@ export function parseGeminiStreamJsonl(
       }
     } else if (event.type === "error") {
       errorMsg = typeof event.message === "string" ? event.message : JSON.stringify(event);
+    } else if (event.type === "AgentExecutionStopped" || event.type === "AgentExecutionBlocked") {
+      // gemini-cli v0.43+ stop/block events carry the actionable reason
+      // (workspace-trust block, tool denial, policy, …). Surface as a terminal
+      // error instead of dropping to debug — mirror the `error` extraction.
+      const detail =
+        (typeof event.reason === "string" && event.reason) ||
+        (typeof event.message === "string" && event.message) ||
+        (typeof event.error === "string" ? event.error : event.error ? JSON.stringify(event.error) : "") ||
+        JSON.stringify(event);
+      errorMsg = `Gemini ${event.type}: ${detail}`;
     } else if (!RECOGNIZED_STREAM_EVENT_TYPES.has(event.type)) {
       Logger.debug(`Unrecognized Gemini stream-json event type: ${event.type}`);
     }


### PR DESCRIPTION
Addresses **#139 backlog item 2** (rolling upstream-sync tracker). Does **not** close #139 — additive/docs items remain.

## Summary

gemini-cli 0.43+ emits `AgentExecutionStopped` / `AgentExecutionBlocked` stream-json events carrying the stop/block **reason** (workspace-trust block, tool denial, policy, …). The parser treated them as "unrecognized" and dropped them to `Logger.debug`, **losing the reason** — a clean run that was actually blocked would just return empty/raw text.

- Add `AgentExecutionStopped` / `AgentExecutionBlocked` to `RECOGNIZED_STREAM_EVENT_TYPES`.
- New handler extracts `reason` → `message` → `error` (in that order) into `errorMsg` and throws `Gemini <event>: <detail>`, mirroring the existing `error`-event branch. Added `reason?` to `GeminiStreamEvent`.
- Genuinely-unknown event types still log to debug (the #116 behavior is preserved).

Unblocked by gemini-cli 0.45.0 stable (#143 confirmed the stream-event surface is locked).

## Test Plan

- [x] 3 tests (in the existing `geminiExecutor.test.ts` stream-event describe): `AgentExecutionStopped` → thrown error with reason; `AgentExecutionBlocked` → thrown with reason; a genuinely-unknown event type → still `Logger.debug`, no throw.
- [x] Full `ask-gemini-mcp` suite **136 passing**; `yarn build`/`yarn lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)