### PR TITLE
docs(antigravity): pin transcript_full no-fallback contract (#154 review)

### DIFF
--- a/packages/antigravity-mcp/src/utils/__tests__/transcriptReader.test.ts
+++ b/packages/antigravity-mcp/src/utils/__tests__/transcriptReader.test.ts
@@ -121,14 +121,16 @@ describe("readLatestResponse", () => {
 
   it("returns null when transcript_full.jsonl exists but has no model entry (no fallback to truncated)", () => {
     // truncated copy HAS a usable answer...
-    writeTranscript("conv1", [{ source: "MODEL", status: "DONE", type: "PLANNER_RESPONSE", content: "truncated answer" }]);
+    writeTranscript("conv1", [
+      { source: "MODEL", status: "DONE", type: "PLANNER_RESPONSE", content: "truncated answer" },
+    ]);
     // ...but the full copy exists with no MODEL/DONE/PLANNER_RESPONSE (e.g. agy crashed mid-write)
     writeTranscript(
       "conv1",
       [{ source: "USER_EXPLICIT", status: "DONE", type: "USER_INPUT", content: "question" }],
       "transcript_full.jsonl",
     );
-    // full > truncated: a present-but-empty full file means the run didn't finish → null (#154)
+    // full > truncated: a full file with no model entry means the run didn't finish → null (#154)
     expect(readLatestResponse(0, baseDir)).toBeNull();
   });
 });

--- a/packages/antigravity-mcp/src/utils/__tests__/transcriptReader.test.ts
+++ b/packages/antigravity-mcp/src/utils/__tests__/transcriptReader.test.ts
@@ -118,4 +118,17 @@ describe("readLatestResponse", () => {
     utimesSync(stray, new Date(9000), new Date(9000)); // newer than the real dir
     expect(readLatestResponse(0, baseDir)).toBe("real answer");
   });
+
+  it("returns null when transcript_full.jsonl exists but has no model entry (no fallback to truncated)", () => {
+    // truncated copy HAS a usable answer...
+    writeTranscript("conv1", [{ source: "MODEL", status: "DONE", type: "PLANNER_RESPONSE", content: "truncated answer" }]);
+    // ...but the full copy exists with no MODEL/DONE/PLANNER_RESPONSE (e.g. agy crashed mid-write)
+    writeTranscript(
+      "conv1",
+      [{ source: "USER_EXPLICIT", status: "DONE", type: "USER_INPUT", content: "question" }],
+      "transcript_full.jsonl",
+    );
+    // full > truncated: a present-but-empty full file means the run didn't finish → null (#154)
+    expect(readLatestResponse(0, baseDir)).toBeNull();
+  });
 });

--- a/packages/antigravity-mcp/src/utils/transcriptReader.ts
+++ b/packages/antigravity-mcp/src/utils/transcriptReader.ts
@@ -104,6 +104,10 @@ export function readLatestResponse(sinceMs: number, baseDir: string = defaultBas
   // agy writes a token-truncated transcript.jsonl plus a complete
   // transcript_full.jsonl; prefer the full one so long responses aren't clipped
   // (verified against agy 1.0.6 — #153 dogfood), falling back to transcript.jsonl.
+  // Note: readFileOrNull returns file *contents*, so once transcript_full.jsonl
+  // exists it wins even if it yields no model entry (e.g. agy crashed mid-write) —
+  // we return null rather than fall back to the truncated copy. Intentional:
+  // full > truncated; a present-but-empty full file means the run didn't finish (#154).
   const raw =
     readFileOrNull(join(logsDir, "transcript_full.jsonl")) ?? readFileOrNull(join(logsDir, "transcript.jsonl"));
   if (raw === null) {

--- a/packages/antigravity-mcp/src/utils/transcriptReader.ts
+++ b/packages/antigravity-mcp/src/utils/transcriptReader.ts
@@ -107,7 +107,7 @@ export function readLatestResponse(sinceMs: number, baseDir: string = defaultBas
   // Note: readFileOrNull returns file *contents*, so once transcript_full.jsonl
   // exists it wins even if it yields no model entry (e.g. agy crashed mid-write) —
   // we return null rather than fall back to the truncated copy. Intentional:
-  // full > truncated; a present-but-empty full file means the run didn't finish (#154).
+  // full > truncated; a full file with no model entry means the run didn't finish (#154).
   const raw =
     readFileOrNull(join(logsDir, "transcript_full.jsonl")) ?? readFileOrNull(join(logsDir, "transcript.jsonl"));
   if (raw === null) {


### PR DESCRIPTION
## Summary
Addresses the single non-blocking observation from `claude-review` on #154 (which was otherwise LGTM and merged).

When `transcript_full.jsonl` exists but contains no `MODEL/DONE/PLANNER_RESPONSE` entry (e.g. `agy` crashed mid-write), `readLatestResponse` returns `null` **without** falling back to the truncated `transcript.jsonl` — because `readFileOrNull` returns the file's *contents* as soon as the file exists, so `??` short-circuits on a present-but-empty full file.

This is intentional (`full > truncated`; a present-but-empty full file means the run didn't finish). This PR:
- **Documents** the behavior in the `readLatestResponse` comment so it's not mistaken for a bug.
- **Adds a characterization test** cementing the contract (full-exists-but-empty → `null`, even when truncated has a usable answer).

No logic change. 28 tests pass; lint + build clean.

## Test Plan
- [ ] CI green (`test 20.x/22.x`, `claude-review`)
- [x] `yarn workspace ask-antigravity-mcp run test` (28 passed) + lint + build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)