### PR TITLE
ci: add timeout-minutes to the test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Cap each matrix leg so a hung runner fails fast instead of stalling up to the
+    # 6h default. Normal build+lint+test is <2m; #155 hit a 22.x runner that hung
+    # ~12m while 20.x passed the same commit in 77s. 10m leaves generous headroom.
+    timeout-minutes: 10
 
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
Adds `timeout-minutes: 10` to the CI `test` matrix job so a hung GitHub Actions runner **fails fast** instead of stalling up to the 6-hour default.

Motivated by PR #155: the `test (22.x)` leg hung `in_progress` for ~12 minutes (and would have held the merge gate indefinitely) while `test (20.x)` passed the *same commit* in 77 seconds — a stuck runner, not a code failure. 10m is generous headroom over the <2m real build+lint+test time, so it won't false-trip on legitimately slow runs but caps a hang.

## Test Plan
- [ ] CI green — this PR's own `test (20.x)`/`test (22.x)` run exercises (and thereby validates) the modified workflow YAML
- [ ] `claude-review` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)