### PR TITLE
chore(antigravity): wire ask-antigravity-mcp for npm + MCP Registry publish

### DIFF
--- a/.changeset/publish-ask-antigravity.md
+++ b/.changeset/publish-ask-antigravity.md
@@ -1,0 +1,6 @@
+---
+"ask-antigravity-mcp": minor
+"ask-llm-mcp": patch
+---
+
+Publish the experimental `ask-antigravity-mcp` provider for Google's Antigravity CLI (`agy`). Validated end-to-end against a real `agy` 1.0.6 (which prints to stdout — gemini-cli #27466 is fixed there; transcript-file reading is the fallback). `ask-llm-mcp` now bundles `ask-antigravity-mcp` so the unified orchestrator can load it when `agy` is installed.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,14 +113,14 @@ jobs:
         run: ./mcp-publisher publish packages/ollama-mcp/server.json
         continue-on-error: true
 
-      - name: Publish ask-llm to MCP Registry
-        if: steps.changesets.outputs.published == 'true'
-        run: ./mcp-publisher publish packages/llm-mcp/server.json
-        continue-on-error: true
-
       - name: Publish ask-antigravity to MCP Registry
         if: steps.changesets.outputs.published == 'true'
         run: ./mcp-publisher publish packages/antigravity-mcp/server.json
+        continue-on-error: true
+
+      - name: Publish ask-llm to MCP Registry
+        if: steps.changesets.outputs.published == 'true'
+        run: ./mcp-publisher publish packages/llm-mcp/server.json
         continue-on-error: true
 
       # Unified GitHub Release tagged at gemini's version (legacy convention from when this
@@ -188,7 +188,7 @@ jobs:
               ``,
               `Likely causes:`,
               `- NODE_AUTH_TOKEN expired, revoked, or wrong type (must be Classic "Automation" or 2FA-bypass Granular)`,
-              `- Package permission changed on npm (token no longer covers ask-gemini-mcp / ask-codex-mcp / ask-ollama-mcp / ask-llm-mcp)`,
+              `- Package permission changed on npm (token no longer covers ask-gemini-mcp / ask-codex-mcp / ask-ollama-mcp / ask-antigravity-mcp / ask-llm-mcp)`,
               `- npm registry outage`,
               ``,
               `**Fix path:**`,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Sync versions from package.json to server.json and marketplace.json
         if: steps.changesets.outputs.published == 'true'
         run: |
-          for entry in "gemini-mcp:server.json" "codex-mcp:packages/codex-mcp/server.json" "ollama-mcp:packages/ollama-mcp/server.json" "llm-mcp:packages/llm-mcp/server.json"; do
+          for entry in "gemini-mcp:server.json" "codex-mcp:packages/codex-mcp/server.json" "ollama-mcp:packages/ollama-mcp/server.json" "antigravity-mcp:packages/antigravity-mcp/server.json" "llm-mcp:packages/llm-mcp/server.json"; do
             pkg="${entry%%:*}"
             file="${entry#*:}"
             PKG_VERSION=$(node -p "require('./packages/$pkg/package.json').version")
@@ -116,6 +116,11 @@ jobs:
       - name: Publish ask-llm to MCP Registry
         if: steps.changesets.outputs.published == 'true'
         run: ./mcp-publisher publish packages/llm-mcp/server.json
+        continue-on-error: true
+
+      - name: Publish ask-antigravity to MCP Registry
+        if: steps.changesets.outputs.published == 'true'
+        run: ./mcp-publisher publish packages/antigravity-mcp/server.json
         continue-on-error: true
 
       # Unified GitHub Release tagged at gemini's version (legacy convention from when this

--- a/packages/antigravity-mcp/server.json
+++ b/packages/antigravity-mcp/server.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.Lykhoyda/ask-antigravity",
+  "description": "Bridge Claude with Google's Antigravity CLI (agy) for code review and second opinions",
+  "repository": {
+    "url": "https://github.com/Lykhoyda/ask-llm",
+    "source": "github"
+  },
+  "version": "0.0.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "ask-antigravity-mcp",
+      "version": "0.0.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "ASK_ANTIGRAVITY_TIMEOUT_MS",
+          "description": "Timeout for Antigravity (agy) execution in milliseconds (default: 300000 = 5 minutes)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false,
+          "default": "300000"
+        },
+        {
+          "name": "ASK_ANTIGRAVITY_SANDBOX",
+          "description": "Set to '0' to drop agy's --sandbox flag if it blocks --add-dir context reads (default: sandbox on)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false,
+          "default": "1"
+        },
+        {
+          "name": "GMCPT_LOG_LEVEL",
+          "description": "Log verbosity: debug, info, warn, error (default: warn)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false,
+          "default": "warn"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/llm-mcp/package.json
+++ b/packages/llm-mcp/package.json
@@ -15,8 +15,8 @@
     "dev": "tsc -b && node dist/cli.js",
     "test": "vitest run",
     "lint": "biome check src/ && tsc --noEmit",
-    "prepack": "node ../../scripts/prepack-bundle.mjs shared gemini-mcp codex-mcp ollama-mcp",
-    "postpack": "node ../../scripts/postpack-restore.mjs shared gemini-mcp codex-mcp ollama-mcp"
+    "prepack": "node ../../scripts/prepack-bundle.mjs shared gemini-mcp codex-mcp ollama-mcp antigravity-mcp",
+    "postpack": "node ../../scripts/postpack-restore.mjs shared gemini-mcp codex-mcp ollama-mcp antigravity-mcp"
   },
   "keywords": [
     "mcp",
@@ -77,6 +77,7 @@
     "@ask-llm/shared",
     "ask-gemini-mcp",
     "ask-codex-mcp",
-    "ask-ollama-mcp"
+    "ask-ollama-mcp",
+    "ask-antigravity-mcp"
   ]
 }

--- a/packages/llm-mcp/package.json
+++ b/packages/llm-mcp/package.json
@@ -2,7 +2,7 @@
   "name": "ask-llm-mcp",
   "version": "0.3.11",
   "mcpName": "io.github.Lykhoyda/ask-llm",
-  "description": "Unified MCP server for multi-LLM consultation — registers tools from all available providers (Gemini, Codex, Ollama) behind runtime availability checks",
+  "description": "Unified MCP server for multi-LLM consultation — registers tools from all available providers (Gemini, Codex, Ollama, Antigravity) behind runtime availability checks",
   "type": "module",
   "main": "dist/index.js",
   "exports": {
@@ -29,6 +29,8 @@
     "openai",
     "google-gemini",
     "ollama",
+    "antigravity",
+    "agy",
     "local-llm",
     "claude",
     "ai",

--- a/packages/llm-mcp/server.json
+++ b/packages/llm-mcp/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.Lykhoyda/ask-llm",
-  "description": "Unified MCP server — auto-detects Gemini, Codex, and Ollama, registers available tools",
+  "description": "Unified MCP server — auto-detects Gemini, Codex, Ollama, Antigravity; registers available tools",
   "repository": {
     "url": "https://github.com/Lykhoyda/ask-llm",
     "source": "github"
@@ -23,6 +23,22 @@
           "format": "string",
           "isSecret": false,
           "default": "http://localhost:11434"
+        },
+        {
+          "name": "ASK_ANTIGRAVITY_TIMEOUT_MS",
+          "description": "Timeout for Antigravity (agy) execution in milliseconds (default: 300000 = 5 minutes)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false,
+          "default": "300000"
+        },
+        {
+          "name": "ASK_ANTIGRAVITY_SANDBOX",
+          "description": "Set to '0' to drop agy's --sandbox flag if it blocks --add-dir context reads (default: sandbox on)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false,
+          "default": "1"
         },
         {
           "name": "GMCPT_TIMEOUT_MS",


### PR DESCRIPTION
## Summary
Prepares the validated `ask-antigravity-mcp` provider for its first npm publish, following the monorepo's bundling/Changesets pipeline (ADR-052/107).

- **`ask-llm-mcp` bundles `ask-antigravity-mcp`** — added to `bundledDependencies` + the `prepack`/`postpack` arg lists. Without this, a published `ask-llm-mcp` would try to fetch `ask-antigravity-mcp@*` and break; now it's bundled like the other four providers.
- **Changeset** — `ask-antigravity-mcp` minor (first publish → 0.1.0), `ask-llm-mcp` patch.
- **MCP Registry** — new `packages/antigravity-mcp/server.json`, wired into `release.yml`'s version-sync loop + an `mcp-publisher` step (parity with siblings).

## Verification
- `yarn build` green; **preflight-no-workspace-protocol gate passes** for all 5 publishable packages.
- **Real `npm pack`** confirms: `ask-llm-mcp` tarball bundles `node_modules/ask-antigravity-mcp/` (33 files) + all 4 other providers; `ask-antigravity-mcp` bundles `@ask-llm/shared` (73 files, identical to codex).
- **Multi-reviewed** by Gemini + Codex + Antigravity. Codex caught the `server.json` `description` exceeding the MCP `2025-12-11` schema's 100-char cap (130 → 85); fixed. Gemini/Antigravity LGTM.

## ⚠️ This PR does not publish
Merging this only adds the changeset. The changesets action then opens a **"chore: version packages"** PR; merging *that* is what actually publishes to npm + the MCP Registry. The publish is gated behind that second, explicit merge.

## Follow-up (out of scope, noted by Antigravity review)
- `apps/docs/` (installation page, SetupTabs.vue) don't list antigravity yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)