### PR TITLE
docs(antigravity): document the ask-antigravity-mcp provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 | [`ask-gemini-mcp`](https://www.npmjs.com/package/ask-gemini-mcp) | MCP Server | [![npm](https://img.shields.io/npm/v/ask-gemini-mcp)](https://www.npmjs.com/package/ask-gemini-mcp) | [![downloads](https://img.shields.io/npm/dt/ask-gemini-mcp)](https://www.npmjs.com/package/ask-gemini-mcp) |
 | [`ask-codex-mcp`](https://www.npmjs.com/package/ask-codex-mcp) | MCP Server | [![npm](https://img.shields.io/npm/v/ask-codex-mcp)](https://www.npmjs.com/package/ask-codex-mcp) | [![downloads](https://img.shields.io/npm/dt/ask-codex-mcp)](https://www.npmjs.com/package/ask-codex-mcp) |
 | [`ask-ollama-mcp`](https://www.npmjs.com/package/ask-ollama-mcp) | MCP Server | [![npm](https://img.shields.io/npm/v/ask-ollama-mcp)](https://www.npmjs.com/package/ask-ollama-mcp) | [![downloads](https://img.shields.io/npm/dt/ask-ollama-mcp)](https://www.npmjs.com/package/ask-ollama-mcp) |
+| [`ask-antigravity-mcp`](https://www.npmjs.com/package/ask-antigravity-mcp) | MCP Server | [![npm](https://img.shields.io/npm/v/ask-antigravity-mcp)](https://www.npmjs.com/package/ask-antigravity-mcp) | [![downloads](https://img.shields.io/npm/dt/ask-antigravity-mcp)](https://www.npmjs.com/package/ask-antigravity-mcp) |
 | [`ask-llm-mcp`](https://www.npmjs.com/package/ask-llm-mcp) | MCP Server | [![npm](https://img.shields.io/npm/v/ask-llm-mcp)](https://www.npmjs.com/package/ask-llm-mcp) | [![downloads](https://img.shields.io/npm/dt/ask-llm-mcp)](https://www.npmjs.com/package/ask-llm-mcp) |
 | [`@ask-llm/plugin`](https://github.com/Lykhoyda/ask-llm/tree/main/packages/claude-plugin) | Claude Code Plugin | [![GitHub](https://img.shields.io/github/v/release/Lykhoyda/ask-llm?label=latest)](https://github.com/Lykhoyda/ask-llm/releases) | `/plugin install` |
 
@@ -19,9 +20,9 @@
 
 </div>
 
-MCP servers that bridge your AI client with multiple LLM providers for AI-to-AI collaboration. Works with Claude Code, Claude Desktop, Cursor, Warp, Copilot, and [40+ other MCP clients](https://modelcontextprotocol.io/clients). Leverage Gemini's 1M+ token context, Codex's GPT-5.5, or local Ollama models — all via standard [MCP](https://modelcontextprotocol.io/).
+MCP servers that bridge your AI client with multiple LLM providers for AI-to-AI collaboration. Works with Claude Code, Claude Desktop, Cursor, Warp, Copilot, and [40+ other MCP clients](https://modelcontextprotocol.io/clients). Leverage Gemini's 1M+ token context, Codex's GPT-5.5, local Ollama models, or Google Antigravity (`agy`) — all via standard [MCP](https://modelcontextprotocol.io/).
 
-> **⚠️ Gemini CLI tier change (2026-06-18):** Google stopped serving Gemini CLI requests for free, Google AI Pro, and Ultra accounts on 2026-06-18 — only **Gemini Code Assist Standard/Enterprise** seats keep working. `ask-gemini-mcp` still installs and launches (the failure is account/backend access, so reinstalling won't help); on a non-enterprise account it now surfaces actionable guidance instead of a raw error. Google's successor, **Antigravity CLI (`agy`)**, is a separate tool that `ask-gemini-mcp` does **not** support yet. Free/Pro users can switch to `ask-codex` or `ask-ollama`. [Announcement](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/).
+> **⚠️ Gemini CLI tier change (2026-06-18):** Google stopped serving Gemini CLI requests for free, Google AI Pro, and Ultra accounts on 2026-06-18 — only **Gemini Code Assist Standard/Enterprise** seats keep working. `ask-gemini-mcp` still installs and launches (the failure is account/backend access, so reinstalling won't help); on a non-enterprise account it now surfaces actionable guidance instead of a raw error. Google's successor, **Antigravity CLI (`agy`)**, is now supported via the separate **[`ask-antigravity-mcp`](https://www.npmjs.com/package/ask-antigravity-mcp)** package — subscription-backed through your Google AI Pro/Ultra plan (no per-token API billing). Free/Pro users can switch to `ask-antigravity`, `ask-codex`, or `ask-ollama`. [Announcement](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/).
 
 ## Why?
 
@@ -47,6 +48,7 @@ claude mcp add --scope user ask-llm -- npx -y ask-llm-mcp
 claude mcp add --scope user gemini -- npx -y ask-gemini-mcp
 claude mcp add --scope user codex -- npx -y ask-codex-mcp
 claude mcp add --scope user ollama -- npx -y ask-ollama-mcp
+claude mcp add --scope user antigravity -- npx -y ask-antigravity-mcp
 ```
 
 </details>
@@ -160,6 +162,7 @@ See the [plugin docs](https://lykhoyda.github.io/ask-llm/plugin/overview) for de
 | `fetch-chunk` | ask-gemini-mcp | Retrieve chunks from cached large responses |
 | `ask-codex` | ask-codex-mcp | Send prompts to Codex CLI. GPT-5.5 with mini fallback. Native session resume via `sessionId` |
 | `ask-ollama` | ask-ollama-mcp | Send prompts to local Ollama. Fully private, zero cost. Server-side conversation replay via `sessionId` |
+| `ask-antigravity` | ask-antigravity-mcp | Send a prompt to Google Antigravity (`agy`) for a subscription-backed second opinion. Experimental; one-shot |
 | `ask-llm` | ask-llm-mcp | Unified orchestrator — pick provider per call. Fan out to all installed providers |
 | `multi-llm` | ask-llm-mcp | Dispatch the same prompt to multiple providers in parallel; returns per-provider responses + usage in one call |
 | `get-usage-stats` | all | Per-session token totals, fallback counts, breakdowns by provider/model — all in-memory, no persistence |

--- a/apps/docs/.vitepress/components/SetupTabs.vue
+++ b/apps/docs/.vitepress/components/SetupTabs.vue
@@ -180,6 +180,7 @@ const providerConfigs: Record<string, ProviderConfig> = {
   gemini: { pkg: "ask-gemini-mcp", serverName: "gemini-cli" },
   codex: { pkg: "ask-codex-mcp", serverName: "codex-cli" },
   ollama: { pkg: "ask-ollama-mcp", serverName: "ollama" },
+  antigravity: { pkg: "ask-antigravity-mcp", serverName: "antigravity" },
   unified: { pkg: "ask-llm-mcp", serverName: "ask-llm" },
 };
 

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -5,7 +5,7 @@ const SITE_URL = "https://lykhoyda.github.io/ask-llm";
 const SITE_HOSTNAME = "https://lykhoyda.github.io/ask-llm/";
 const SITE_TITLE = "Ask LLM";
 const SITE_DESCRIPTION =
-  "MCP servers for AI-to-AI collaboration — Gemini, Codex, Ollama";
+  "MCP servers for AI-to-AI collaboration — Gemini, Codex, Ollama, Antigravity";
 
 export default withMermaid(
   defineConfig({
@@ -115,6 +115,7 @@ export default withMermaid(
             { text: "Gemini", link: "/providers/gemini" },
             { text: "Codex", link: "/providers/codex" },
             { text: "Ollama", link: "/providers/ollama" },
+            { text: "Antigravity", link: "/providers/antigravity" },
             { text: "Unified", link: "/providers/unified" },
           ],
         },
@@ -137,6 +138,7 @@ export default withMermaid(
             { text: "Gemini", link: "/providers/gemini" },
             { text: "Codex", link: "/providers/codex" },
             { text: "Ollama", link: "/providers/ollama" },
+            { text: "Antigravity", link: "/providers/antigravity" },
             { text: "Unified (ask-llm)", link: "/providers/unified" },
           ],
         },

--- a/apps/docs/installation.md
+++ b/apps/docs/installation.md
@@ -14,6 +14,7 @@ Multiple ways to install Ask LLM, depending on whether you want the unified orch
   - `npm install -g @google/gemini-cli && gemini login` for Gemini
   - `npm install -g @openai/codex` (then follow CLI auth) for Codex
   - [Ollama](https://ollama.com) running locally with a model pulled (`ollama pull qwen2.5-coder:7b`)
+  - [Antigravity CLI](https://antigravity.google) (`agy`) installed and logged in once for Antigravity
 
 ## Packages
 
@@ -23,6 +24,7 @@ Multiple ways to install Ask LLM, depending on whether you want the unified orch
 | [`ask-gemini-mcp`](https://www.npmjs.com/package/ask-gemini-mcp) | Gemini-only — full feature set including `@` file syntax, sandbox, edit mode | `ask-gemini`, `ask-gemini-edit`, `fetch-chunk`, `get-usage-stats`, `ping` |
 | [`ask-codex-mcp`](https://www.npmjs.com/package/ask-codex-mcp) | Codex-only | `ask-codex`, `get-usage-stats`, `ping` |
 | [`ask-ollama-mcp`](https://www.npmjs.com/package/ask-ollama-mcp) | Ollama-only (local) | `ask-ollama`, `get-usage-stats`, `ping` |
+| [`ask-antigravity-mcp`](https://www.npmjs.com/package/ask-antigravity-mcp) | Antigravity-only (experimental) — subscription-backed via `agy` | `ask-antigravity`, `get-usage-stats`, `ping` |
 
 The unified orchestrator uses a single `ask-llm` tool with a `provider` parameter for token efficiency ([ADR-029](https://github.com/Lykhoyda/ask-llm/blob/main/docs/DECISIONS.md)) — you pick the provider per call. Per-provider packages expose the richer per-provider tool surface (`ask-gemini-edit` for structured edits, `fetch-chunk` for large response pagination, etc.).
 
@@ -52,6 +54,7 @@ claude mcp add --scope user ask-llm -- npx -y ask-llm-mcp
 claude mcp add --scope user gemini -- npx -y ask-gemini-mcp
 claude mcp add --scope user codex  -- npx -y ask-codex-mcp
 claude mcp add --scope user ollama -- npx -y ask-ollama-mcp
+claude mcp add --scope user antigravity -- npx -y ask-antigravity-mcp
 ```
 
 `--scope user` registers globally for all projects. Drop the flag for per-project scope.

--- a/apps/docs/providers/antigravity.md
+++ b/apps/docs/providers/antigravity.md
@@ -1,0 +1,58 @@
+---
+description: Bridge Claude with Google's Antigravity CLI (agy) for subscription-backed code review and second opinions. Experimental — uses agy stdout with a transcript-file fallback.
+---
+
+# Antigravity
+
+Bridge Claude with Google's Antigravity CLI (`agy`) — Google's successor to Gemini CLI. Get a subscription-backed second opinion or code review using your Google AI Pro/Ultra plan, without per-token API billing.
+
+::: warning Experimental
+On `agy` ≥ 1.0.6 the headless `-p` mode prints the response to stdout (used directly); older versions / edge cases fall back to reading `agy`'s transcript files, which is sensitive to `agy`'s on-disk layout. One-shot only: no model selection, no multi-turn. Validated end-to-end against `agy` 1.0.6.
+:::
+
+## Installation
+
+<SetupTabs provider="antigravity" />
+
+Or install globally:
+
+```bash
+npm install -g ask-antigravity-mcp
+```
+
+## Prerequisites
+
+1. **Node.js** v20.0.0 or higher
+2. **[Antigravity CLI](https://antigravity.google)** (`agy`) installed and **logged in once** — run `agy` interactively to complete the Google Sign-In before using the MCP server
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `ask-antigravity` | Send a prompt to `agy` for a second opinion / code review. Optional `includeDirs` maps to `agy --add-dir` for monorepo context |
+| `get-usage-stats` | Per-session token totals (in-memory) |
+| `ping` | Connection test; also reports whether `agy` is installed |
+
+`ask-antigravity` returns both human-readable text and a structured `AskResponse` (provider, response, model, sessionId, usage) via MCP `outputSchema`.
+
+## How it works
+
+`agy` ≥ 1.0.6 prints the response to stdout (gemini-cli #27466, the empty-stdout bug, is fixed there), so the executor uses a **stdout-first source chain** — structured JSON → plain stdout → transcript file. The transcript fallback reads the complete `transcript_full.jsonl` under `~/.gemini/antigravity-cli/brain/<id>/.system_generated/logs/`. Calls are serialized in-process (concurrent `agy` runs race on shared state files). It runs with a read-only prompt preamble plus `--dangerously-skip-permissions` + `--sandbox` so `agy` never hangs on approval prompts.
+
+## Config
+
+| Env var | Default | Purpose |
+|---------|---------|---------|
+| `ASK_ANTIGRAVITY_TIMEOUT_MS` | `300000` | Process timeout (5 minutes) |
+| `ASK_ANTIGRAVITY_SANDBOX` | on | Set `0` to drop `agy`'s `--sandbox` flag if it blocks `--add-dir` context reads |
+
+## Limitations
+
+- **Experimental** — the transcript fallback is sensitive to changes in `agy`'s on-disk format.
+- **One-shot** — no model selection (`agy -p` hangs on model switches) and no multi-turn sessions (no capturable conversation id, antigravity-cli #7).
+- **Interactive auth** — requires an `agy` login, so it isn't suited to headless CI.
+
+## npm
+
+- **Package:** [ask-antigravity-mcp](https://www.npmjs.com/package/ask-antigravity-mcp)
+- **Binary:** `ask-antigravity-mcp`


### PR DESCRIPTION
## Summary
Makes the now-published `ask-antigravity-mcp` discoverable in the docs (the follow-up Antigravity's own dogfood review flagged).

- **New `providers/antigravity.md`** page mirroring codex/ollama: install (`<SetupTabs provider="antigravity"/>`), tools, how-it-works (stdout-first chain + transcript fallback), config env vars, and limitations (experimental, one-shot).
- **Nav + sidebar + site description** updated; `SetupTabs.vue` `providerConfigs` gains an `antigravity` entry so the provider tab resolves (it previously fell back to gemini).
- **`installation.md`**: prerequisites bullet, packages table row, per-provider `claude mcp add` command.
- **README**: package badge table, intro line, install commands, tools table — plus refreshed the Gemini-tier note (it said `agy` is "not supported yet"; it now points to the published `ask-antigravity-mcp`).

## Verification
- `yarn docs:build` completes clean (validates the new page, nav links, and the Vue change).
- Docs-only + README; no source/test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)