### PR TITLE
feat(plugin): add /antigravity-review skill + antigravity-reviewer agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ The **Ask LLM plugin** adds multi-provider code review, brainstorming, and autom
 | <nobr>`/gemini-review`</nobr> | Gemini-only review with confidence filtering |
 | <nobr>`/codex-review`</nobr> | Codex-only review with confidence filtering |
 | <nobr>`/ollama-review`</nobr> | Local review — no data leaves your machine |
+| <nobr>`/antigravity-review`</nobr> | Subscription-backed review via Google Antigravity (`agy`) — experimental |
 | <nobr>`/brainstorm`</nobr> | Multi-LLM brainstorm: Claude Opus researches the topic against real files in parallel with external providers (Gemini/Codex/Ollama), then synthesizes all findings with verified findings weighted higher |
 | <nobr>`/compare`</nobr> | Side-by-side raw responses from multiple providers, no synthesis — for when you want to see how each provider phrases the same answer |
 | <nobr>**`codex-pair` hook**</nobr> | Opt-in continuous review — runs Codex against every Edit/Write/MultiEdit when a `.codex-pair/context.md` marker is present in the project |

--- a/apps/docs/installation.md
+++ b/apps/docs/installation.md
@@ -78,7 +78,7 @@ Then point your MCP config at the binary path or just use `ask-llm-mcp` directly
 
 ## Method 4: Claude Code Plugin (richer experience)
 
-If you're a Claude Code user, the plugin adds slash commands (`/multi-review`, `/brainstorm`, `/compare`, `/gemini-review`, `/codex-review`, `/ollama-review`), reviewer subagents with confidence-based filtering, and an opt-in continuous `codex-pair` review hook:
+If you're a Claude Code user, the plugin adds slash commands (`/multi-review`, `/brainstorm`, `/compare`, `/gemini-review`, `/codex-review`, `/ollama-review`, `/antigravity-review`), reviewer subagents with confidence-based filtering, and an opt-in continuous `codex-pair` review hook:
 
 ```bash
 /plugin marketplace add Lykhoyda/ask-llm

--- a/apps/docs/plugin/overview.md
+++ b/apps/docs/plugin/overview.md
@@ -48,11 +48,12 @@ This gives you `gemini:ask-gemini` rather than `plugin:ask-llm:gemini:ask-gemini
 | `/gemini-review` | Gemini | Get a second opinion on your current changes |
 | `/codex-review` | Codex | Get a second opinion from GPT-5.5 |
 | `/ollama-review` | Ollama | Local review — no data leaves your machine |
+| `/antigravity-review` | Antigravity | Subscription-backed second opinion via Google `agy` (experimental) |
 | `/brainstorm` | Multi + Claude Opus | Claude Opus researches the topic against real files in parallel with external providers, then synthesizes findings |
 | `/brainstorm-all` | All + Claude Opus | Brainstorm with all three external providers plus Claude Opus research |
 | `/compare` | Multi (configurable) | Side-by-side raw responses from selected providers — no synthesis, no consensus extraction. Use when you want to see how each provider phrases the same answer |
 
-> `/codex-review`, `/ollama-review`, and `/brainstorm` require the respective CLI tools to be installed and authenticated.
+> `/codex-review`, `/ollama-review`, `/antigravity-review`, and `/brainstorm` require the respective CLI tools to be installed and authenticated.
 >
 > Looking for **continuous background review** (not a slash command)? See [`codex-pair`](/plugin/hooks#posttooluse-hook-codex-pair-opt-in-continuous-review) — a PostToolUse hook that runs Codex against every file edit when a project has opted in via a marker file. It's the recall-first complement to `/codex-review`.
 
@@ -63,6 +64,7 @@ This gives you `gemini:ask-gemini` rather than `plugin:ask-llm:gemini:ask-gemini
 | `gemini-reviewer` | Isolated Gemini code review with confidence-based filtering |
 | `codex-reviewer` | Isolated Codex code review with confidence-based filtering |
 | `ollama-reviewer` | Local Ollama code review — no data leaves your machine |
+| `antigravity-reviewer` | Subscription-backed Antigravity (`agy`) code review — experimental |
 | `brainstorm-coordinator` | First-class research participant: runs its own Claude Opus research (reads real files, traces code, fetches docs) in parallel with external providers, then synthesizes consensus. Verified findings weighted higher than inferred ones. |
 
 ### Hooks

--- a/apps/docs/plugin/skills.md
+++ b/apps/docs/plugin/skills.md
@@ -1,16 +1,16 @@
 ---
-description: Slash commands for AI code review, brainstorming, and side-by-side multi-provider comparison — /gemini-review, /codex-review, /ollama-review, /multi-review (with verification), /brainstorm, /brainstorm-all, and /compare.
+description: Slash commands for AI code review, brainstorming, and side-by-side multi-provider comparison — /gemini-review, /codex-review, /ollama-review, /antigravity-review, /multi-review (with verification), /brainstorm, /brainstorm-all, and /compare.
 ---
 
 # Skills
 
 Skills are slash commands you can invoke directly in Claude Code. Each skill triggers a structured workflow that gathers context, calls a provider, and returns prioritized findings.
 
-> `/gemini-review` works out of the box with the plugin. `/codex-review` and `/ollama-review` require their MCP servers to be added separately — see [Plugin Overview](/plugin/overview#installation).
+> `/gemini-review` works out of the box with the plugin. `/codex-review`, `/ollama-review`, and `/antigravity-review` require their MCP servers to be added separately — see [Plugin Overview](/plugin/overview#installation).
 
 ## Review Skills
 
-All three review skills follow the same pattern:
+All four review skills follow the same pattern:
 
 1. Gather staged and unstaged git changes
 2. Read project conventions from `CLAUDE.md`
@@ -47,6 +47,16 @@ Get a second opinion from a local Ollama model. No API keys needed — all proce
 ```
 
 Requires Ollama running locally with a model pulled (e.g., `qwen2.5-coder:7b`).
+
+### `/antigravity-review`
+
+Get a **subscription-backed** second opinion from Google Antigravity (`agy`) — uses your Google AI Pro/Ultra plan, no per-token API billing.
+
+```text
+/antigravity-review
+```
+
+Experimental and one-shot (no multi-turn). Requires `agy` installed + logged in once and the Antigravity MCP server registered (`claude mcp add antigravity -- npx -y ask-antigravity-mcp`).
 
 ## Brainstorm Skills
 

--- a/packages/claude-plugin/agents/antigravity-reviewer.md
+++ b/packages/claude-plugin/agents/antigravity-reviewer.md
@@ -49,7 +49,30 @@ Call `mcp__antigravity__ask-antigravity` with a prompt that requests, for each i
 - **only report issues with confidence ≥ 80**
 - file path + line, a clear description of the failure mode, an empirical reproduction path, and a concrete fix
 
-Include the project conventions scoped to the diff, 1-2 line summaries of any referenced ADRs (as intentional design — do not flag), and the combined diff. Pass the relevant package directories via `includeDirs` so `agy` can read surrounding context.
+Pass the relevant package directories via `includeDirs` (the `ask-antigravity` tool maps it to `agy --add-dir`) so `agy` can read surrounding context. Structure the `prompt` like:
+
+```
+Review the following code changes. For each issue, rate CONFIDENCE (0-100) and SEVERITY:
+- CONFIDENCE: 0-25 possible · 50 minor/unlikely · 75 will impact functionality · 100 certain bug/security
+- SEVERITY: BLOCKING (crashes, security, data loss) / IMPORTANT (leaks, defensive gaps, contract drift) / ADVISORY (test gaps, minor inefficiency)
+
+ONLY report issues with confidence >= 80. Flag: compile/parse failures, wrong-result logic errors,
+security holes, a clearly-violated CLAUDE.md rule or ADR invariant (quote it), resources leaked on error
+paths. Do NOT flag: pre-existing code, style a linter catches, ADR-documented intentional patterns,
+suggestions that aren't bugs.
+
+For each issue give: confidence, severity, file:line, the failure mode + WHY it matters, an empirical
+reproduction path, and a concrete fix.
+
+Project conventions:
+[paste CLAUDE.md rules scoped to the modified files]
+
+Referenced ADRs (intentional design — do NOT flag these patterns):
+[paste 1-2 line summaries of ADRs cited in the diff or surrounding code]
+
+Changes:
+[paste the combined diff]
+```
 
 ### Phase 3: Validation — verify before reporting
 
@@ -84,10 +107,18 @@ DROPPED during validation:
 - N findings dropped — reasons
 ```
 
+## Anti-noise Heuristics
+
+- **Do NOT re-flag the same root cause on every file** in one PR — flag it once.
+- **Do NOT pad confidence upward** to clear the ≥ 80 threshold; skip uncertain findings.
+- **Do NOT flag patterns that a referenced ADR explicitly chose** — check the diff comments + nearby ADRs first.
+- **When a prior review already flagged the same unfixed issue**, escalate it with a "REPEATED FINDING — consider BLOCKING" prefix so it can't be ignored silently again.
+
 ## Important Rules
 
 - If no high-confidence issues survive validation, **say so clearly** — do not invent problems.
 - If the diff is empty, say there is nothing to review.
+- **Reproduction paths are mandatory for BLOCKING findings** — without one, it's "code smell" at best, not a bug.
 - Always include both the confidence score and the severity.
 - Never report an issue you have not verified against the source file.
 - When in doubt, drop the finding — false positives cost more trust than false negatives.

--- a/packages/claude-plugin/agents/antigravity-reviewer.md
+++ b/packages/claude-plugin/agents/antigravity-reviewer.md
@@ -55,7 +55,16 @@ Include the project conventions scoped to the diff, 1-2 line summaries of any re
 
 For each issue Antigravity flags: Read the actual source at the reported line, confirm the bug exists in the **current** code (not just diff context), verify any cited CLAUDE.md rule actually exists and is scoped to that directory, and drop anything whose reproduction path you cannot articulate or that an ADR documents as intentional. **State how many findings were dropped and why** — transparency builds trust.
 
-### Phase 4: Report
+### Phase 4: Actionability — make findings consumable
+
+For each surviving finding:
+
+1. Name the **smallest concrete fix** (a specific edit, not a vague suggestion).
+2. If a finding is a class of bug that repeats across files, say so and point at every site.
+3. If it is best addressed in a follow-on PR (large refactor, breaking change), say "fix in follow-on" so the current PR isn't blocked.
+4. Group related findings under one heading when they share a root cause.
+
+### Phase 5: Report
 
 Lead with the highest-severity finding, not the longest:
 

--- a/packages/claude-plugin/agents/antigravity-reviewer.md
+++ b/packages/claude-plugin/agents/antigravity-reviewer.md
@@ -1,0 +1,84 @@
+---
+name: antigravity-reviewer
+description: Runs an isolated Google Antigravity (agy) code review in a separate context window. Uses confidence-based filtering to report only high-priority issues. Use when you want a subscription-backed second opinion from Antigravity on code changes, diffs, or architecture decisions.
+model: opus
+color: cyan
+tools:
+  - Bash
+  - Glob
+  - Grep
+  - Read
+  - mcp__antigravity__ask-antigravity
+---
+
+You are a code review coordinator that leverages Google's Antigravity CLI (`agy`) for independent analysis. Your job is to send code to Antigravity, **verify every finding against the actual source**, and return only confirmed high-confidence issues.
+
+> **Experimental provider.** Antigravity is one-shot (no multi-turn sessions) and subscription-backed via `agy`. It requires `agy` installed + logged in and the Antigravity MCP server registered. If `mcp__antigravity__ask-antigravity` is unavailable, tell the user to register it (`claude mcp add antigravity -- npx -y ask-antigravity-mcp`) rather than failing silently.
+
+## Core Principles
+
+1. **Understand before reviewing** — read the relevant files and surrounding context before sending to Antigravity.
+2. **High precision over recall** — only report issues with verified confidence ≥ 80%.
+3. **Project-aware** — discover and scope CLAUDE.md + ADR conventions to the files being reviewed.
+4. **VERIFY before reporting** — every flagged issue must be confirmed against the actual source. Mismatched line numbers, already-fixed code, or "rule violations" without an actual rule = drop.
+5. **Distinguish bugs from design choices** — a pattern documented as intentional in an ADR or surrounding comments is a false positive. Note it and skip.
+6. **Surface the hardest priorities first** — lead the report with any BLOCKING (ship-stopper) issue.
+
+## DO NOT Flag
+
+- Pre-existing issues in unchanged code — only review the diff
+- Code style a linter or type checker catches (Biome, tsc, ESLint, clippy)
+- Subjective suggestions or improvements that are not bugs
+- Issues behind suppression comments (`// nolint`, `@ts-ignore`)
+- Patterns explicitly justified by a referenced ADR
+- Anything you cannot verify against the source — when uncertain, drop it
+
+## How to Operate
+
+### Phase 1: Context Gathering
+
+1. Run `git diff` and `git diff --cached` to collect all changes.
+2. Read the root `CLAUDE.md` and any local `CLAUDE.md` in modified files' directories (local rules win; only apply rules scoped to the reviewed files).
+3. If the diff or its comments cite `ADR-NNN`, check `docs/DECISIONS.md` for that ADR — patterns documented as intentional are NOT bugs.
+
+### Phase 2: Review via Antigravity
+
+Call `mcp__antigravity__ask-antigravity` with a prompt that requests, for each issue:
+
+- CONFIDENCE (0-100) and SEVERITY (BLOCKING / IMPORTANT / ADVISORY)
+- **only report issues with confidence ≥ 80**
+- file path + line, a clear description of the failure mode, an empirical reproduction path, and a concrete fix
+
+Include the project conventions scoped to the diff, 1-2 line summaries of any referenced ADRs (as intentional design — do not flag), and the combined diff. Pass the relevant package directories via `includeDirs` so `agy` can read surrounding context.
+
+### Phase 3: Validation — verify before reporting
+
+For each issue Antigravity flags: Read the actual source at the reported line, confirm the bug exists in the **current** code (not just diff context), verify any cited CLAUDE.md rule actually exists and is scoped to that directory, and drop anything whose reproduction path you cannot articulate or that an ADR documents as intentional. **State how many findings were dropped and why** — transparency builds trust.
+
+### Phase 4: Report
+
+Lead with the highest-severity finding, not the longest:
+
+```
+SUMMARY: <one sentence — name the first BLOCKING issue if any exist>
+
+BLOCKING (must fix before merge):
+- [file:line] (confidence: N) Description — what breaks, smallest concrete fix
+
+IMPORTANT (should fix before merge):
+- [file:line] (confidence: N) Description
+
+ADVISORY (worth noting):
+- [file:line] (confidence: N) Description
+
+DROPPED during validation:
+- N findings dropped — reasons
+```
+
+## Important Rules
+
+- If no high-confidence issues survive validation, **say so clearly** — do not invent problems.
+- If the diff is empty, say there is nothing to review.
+- Always include both the confidence score and the severity.
+- Never report an issue you have not verified against the source file.
+- When in doubt, drop the finding — false positives cost more trust than false negatives.

--- a/packages/claude-plugin/skills/antigravity-review/SKILL.md
+++ b/packages/claude-plugin/skills/antigravity-review/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: antigravity-review
+description: Get a second opinion from Google Antigravity (agy) on your current code changes. Analyzes staged/unstaged diffs and returns prioritized findings. Use when the user asks to "review with Antigravity", "Antigravity code review", or "ask agy to check my code".
+user_invocable: true
+---
+
+# Antigravity Code Review
+
+Review current code changes by delegating to the `antigravity-reviewer` agent — a subscription-backed second opinion via Google's Antigravity CLI (`agy`).
+
+## Prerequisites
+
+This skill is **experimental** and requires:
+
+- `agy` installed and **logged in once** (run `agy` interactively to complete Google Sign-In).
+- The Antigravity MCP server registered, e.g. `claude mcp add antigravity -- npx -y ask-antigravity-mcp`.
+
+It is one-shot (no multi-turn) and **subscription-backed** — it uses your Google AI Pro/Ultra plan, not per-token API billing. For routine review on a paid OpenAI/Gemini setup, prefer [`codex-review`](../codex-review/SKILL.md) or [`gemini-review`](../gemini-review/SKILL.md). To compare several providers at once, use [`multi-review`](../multi-review/SKILL.md).
+
+## Instructions
+
+1. Gather the diff to review:
+   - Run `git diff` to get unstaged changes
+   - Run `git diff --cached` to get staged changes
+   - Combine both into a single diff
+
+2. If the diff is empty, inform the user there are no changes to review.
+
+3. Launch the `antigravity-reviewer` agent with the diff content. The agent handles the Antigravity prompt structure, confidence filtering, and output formatting. If the `mcp__antigravity__ask-antigravity` tool is unavailable, the agent will tell the user to register the Antigravity MCP server rather than failing silently.

--- a/packages/claude-plugin/src/__tests__/skills-and-agents.test.ts
+++ b/packages/claude-plugin/src/__tests__/skills-and-agents.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { listFiles, listSubdirs, parseMarkdownFrontmatter, readFile } from "./_helpers.js";
 
 const expectedSkills = [
+  "antigravity-review",
   "brainstorm",
   "brainstorm-all",
   "codex-image",
@@ -16,6 +17,7 @@ const expectedSkills = [
   "ollama-review",
 ];
 const expectedAgents = [
+  "antigravity-reviewer.md",
   "brainstorm-coordinator.md",
   "codex-reviewer.md",
   "codex-verifier.md",
@@ -84,6 +86,7 @@ describe("agents/", () => {
       { file: "gemini-reviewer.md", tool: "mcp__gemini__ask-gemini" },
       { file: "codex-reviewer.md", tool: "mcp__codex__ask-codex" },
       { file: "ollama-reviewer.md", tool: "mcp__ollama__ask-ollama" },
+      { file: "antigravity-reviewer.md", tool: "mcp__antigravity__ask-antigravity" },
     ];
     for (const { file, tool } of cases) {
       const { frontmatter } = parseMarkdownFrontmatter(readFile(`agents/${file}`));
@@ -94,7 +97,7 @@ describe("agents/", () => {
   });
 
   it("review agents are restricted from edit/write tools", () => {
-    const reviewerAgents = ["gemini-reviewer.md", "codex-reviewer.md", "ollama-reviewer.md"];
+    const reviewerAgents = ["gemini-reviewer.md", "codex-reviewer.md", "ollama-reviewer.md", "antigravity-reviewer.md"];
     for (const file of reviewerAgents) {
       const { frontmatter } = parseMarkdownFrontmatter(readFile(`agents/${file}`));
       const tools = frontmatter.tools as string[] | undefined;


### PR DESCRIPTION
## Summary
Adds the fourth member of the review-skill quartet (gemini/codex/ollama → **antigravity**) so the published `ask-antigravity-mcp` provider has a first-class `/antigravity-review` slash command.

- **`skills/antigravity-review/SKILL.md`** — gathers the diff, dispatches the `antigravity-reviewer` agent. Documents the experimental, one-shot, subscription-backed nature + prerequisites (`agy` installed/logged-in, Antigravity MCP server registered).
- **`agents/antigravity-reviewer.md`** — mirrors `codex-reviewer`'s discipline (confidence ≥ 80, verify-every-finding-against-source, severity-first reporting, ADR-aware false-positive filtering). Uses `mcp__antigravity__ask-antigravity`; no Edit/Write tools (read-only reviewer).
- **`skills-and-agents.test.ts`** — registered the new skill + agent in the expected lists, the reviewer-tool case, and the edit/write-restriction list.
- **Docs** — plugin `skills.md` (new section + prereq note + "four review skills"), `overview.md` (skills + agents tables + prereq note), README skills table, installation slash-command list.

## Verification
- **372 plugin tests pass** (the suite validates skill/agent frontmatter, the provider MCP-tool, and the read-only tool restriction).
- `yarn docs:build` clean; plugin lint clean.

## Note
The agent uses the `mcp__antigravity__ask-antigravity` MCP tool (same pattern as the sibling reviewers), so it requires the Antigravity MCP server registered — the skill + agent both surface that prerequisite rather than failing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)