### PR TITLE
feat(plugin): default /multi-review + /brainstorm to antigravity + codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The **Ask LLM plugin** adds multi-provider code review, brainstorming, and autom
 
 | Feature | Description |
 |:---|:---|
-| <nobr>`/multi-review`</nobr> | Parallel Gemini + Codex review with 4-phase validation pipeline and consensus highlighting |
+| <nobr>`/multi-review`</nobr> | Parallel Antigravity + Codex review with 4-phase validation pipeline and consensus highlighting (gemini via `/gemini-review`) |
 | <nobr>`/gemini-review`</nobr> | Gemini-only review with confidence filtering |
 | <nobr>`/codex-review`</nobr> | Codex-only review with confidence filtering |
 | <nobr>`/ollama-review`</nobr> | Local review — no data leaves your machine |

--- a/apps/docs/concepts/models.md
+++ b/apps/docs/concepts/models.md
@@ -26,7 +26,7 @@ Different providers excel at different things. Pick by what you're doing, not by
 | Targeted code reasoning, refactor critique | **Codex** | GPT-5.5's strength is dense code reasoning at moderate context size |
 | Private / air-gapped analysis | **Ollama** | Runs locally, nothing leaves your machine |
 | "What do they all think?" comparison | **Multi-LLM** (`multi-llm` tool or `/compare` skill) | Parallel dispatch, see all responses side-by-side |
-| Code review with verified findings | **`/multi-review` skill** | Gemini + Codex in parallel, then verifies each finding against source |
+| Code review with verified findings | **`/multi-review` skill** | Antigravity + Codex in parallel, then verifies each finding against source |
 
 ## Overriding the Model
 

--- a/apps/docs/plugin/overview.md
+++ b/apps/docs/plugin/overview.md
@@ -44,7 +44,7 @@ This gives you `gemini:ask-gemini` rather than `plugin:ask-llm:gemini:ask-gemini
 
 | Command | Provider | Description |
 |---------|----------|-------------|
-| `/multi-review` | Gemini + Codex | Parallel review with 4-phase validation pipeline and consensus highlighting |
+| `/multi-review` | Antigravity + Codex | Parallel review with 4-phase validation pipeline and consensus highlighting |
 | `/gemini-review` | Gemini | Get a second opinion on your current changes |
 | `/codex-review` | Codex | Get a second opinion from GPT-5.5 |
 | `/ollama-review` | Ollama | Local review — no data leaves your machine |

--- a/apps/docs/plugin/skills.md
+++ b/apps/docs/plugin/skills.md
@@ -85,7 +85,7 @@ Send a topic to multiple LLM providers AND have Claude Opus perform its own inde
 
 ### `/brainstorm-all`
 
-Shortcut for `/brainstorm gemini,codex,ollama <topic>`. Sends to all three external providers (Gemini, Codex, Ollama) plus the always-on Claude Opus research phase — up to four participants total.
+Shortcut for `/brainstorm gemini,codex,ollama,antigravity <topic>`. Sends to all four external providers (Gemini, Codex, Ollama, Antigravity) plus the always-on Claude Opus research phase — up to five participants total.
 
 ```text
 /brainstorm-all What's the best caching strategy for our API?
@@ -97,7 +97,7 @@ Requires Ollama running locally since it includes the local provider.
 
 ### `/multi-review`
 
-Run independent code reviews from Gemini and Codex in parallel, **verify** each finding against the source, then present combined consensus / unique / rejected findings.
+Run independent code reviews from Antigravity and Codex in parallel, **verify** each finding against the source, then present combined consensus / unique / rejected findings. (Gemini via `/gemini-review` or the `gemini-reviewer` agent.)
 
 ```text
 /multi-review

--- a/apps/docs/usage/how-to-ask.md
+++ b/apps/docs/usage/how-to-ask.md
@@ -120,7 +120,7 @@ The orchestrator exposes one MCP Resource for live introspection:
 
 If you've installed [the Ask LLM plugin](/plugin/overview), additional slash commands are available:
 
-- `/multi-review` — parallel Gemini + Codex review **with source verification** of each finding
+- `/multi-review` — parallel Antigravity + Codex review **with source verification** of each finding
 - `/gemini-review`, `/codex-review`, `/ollama-review` — single-provider reviews
 - `/brainstorm` — multi-LLM brainstorm with Claude Opus as a first-class research participant
 - `/compare` — side-by-side responses, no synthesis (raw outputs)

--- a/apps/docs/usage/strategies-and-examples.md
+++ b/apps/docs/usage/strategies-and-examples.md
@@ -42,7 +42,7 @@ Ask Codex to do the same review on the same files — focus on edge cases.
 /multi-review
 ```
 
-The `/multi-review` skill dispatches to Gemini + Codex in parallel, then **verifies each high-confidence finding against the actual source** before presenting. Findings are classified as VERIFIED / REJECTED / UNVERIFIABLE — false positives get caught instead of acted on. See [ADR-064](https://github.com/Lykhoyda/ask-llm/blob/main/docs/DECISIONS.md).
+The `/multi-review` skill dispatches to Antigravity + Codex in parallel, then **verifies each high-confidence finding against the actual source** before presenting. Findings are classified as VERIFIED / REJECTED / UNVERIFIABLE — false positives get caught instead of acted on. See [ADR-064](https://github.com/Lykhoyda/ask-llm/blob/main/docs/DECISIONS.md).
 
 **Multi-provider (raw, no synthesis):**
 
@@ -91,7 +91,7 @@ When choosing between approaches, get all three providers' opinions and let Clau
 /brainstorm Should we use server-sent events or WebSockets for our notification system? Pros, cons, and which fits a team that values backwards compatibility.
 ```
 
-The `/brainstorm` skill runs Claude Opus's own research (reads your real codebase), dispatches to Gemini + Codex in parallel, and returns a synthesis with consensus / unique / contradictory points. Verified findings (Claude reading actual files) outweigh inferred ones.
+The `/brainstorm` skill runs Claude Opus's own research (reads your real codebase), dispatches to Antigravity + Codex in parallel, and returns a synthesis with consensus / unique / contradictory points. Verified findings (Claude reading actual files) outweigh inferred ones.
 
 ### 5. Multi-Turn Iterative Refinement
 

--- a/packages/claude-plugin/agents/brainstorm-coordinator.md
+++ b/packages/claude-plugin/agents/brainstorm-coordinator.md
@@ -142,7 +142,9 @@ ollama run qwen2.5-coder:7b < "$workdir/prompt.md" > "$workdir/ollama.out" 2> "$
 pid_ollama=$!
 
 # Wait for each by PID so we capture per-provider exit codes independently.
-# `wait PID` blocks until that specific child exits.
+# `wait PID` blocks until that specific child exits. IMPORTANT: include a wait line
+# (and its dump below) ONLY for the providers you actually launched above — waiting
+# on an unset pid yields rc=1 and would falsely report that provider as "failed".
 wait "$pid_antigravity" 2>/dev/null; rc_antigravity=$?
 wait "$pid_gemini" 2>/dev/null; rc_gemini=$?
 wait "$pid_codex"  2>/dev/null; rc_codex=$?

--- a/packages/claude-plugin/agents/brainstorm-coordinator.md
+++ b/packages/claude-plugin/agents/brainstorm-coordinator.md
@@ -1,6 +1,6 @@
 ---
 name: brainstorm-coordinator
-description: Coordinates multi-LLM brainstorming by (1) performing its own independent Claude Opus research on the topic and (2) consulting external providers (Gemini, Codex, Ollama) via a single foreground Bash dispatch, then synthesizing all findings into consensus points, unique insights, and actionable recommendations. Claude's findings are weighted higher when verified against real repository state.
+description: Coordinates multi-LLM brainstorming by (1) performing its own independent Claude Opus research on the topic and (2) consulting external providers (Gemini, Codex, Ollama, Antigravity) via a single foreground Bash dispatch, then synthesizing all findings into consensus points, unique insights, and actionable recommendations. Claude's findings are weighted higher when verified against real repository state.
 model: opus
 color: magenta
 tools:
@@ -13,6 +13,7 @@ tools:
   - mcp__gemini__ask-gemini
   - mcp__codex__ask-codex
   - mcp__ollama__ask-ollama
+  - mcp__antigravity__ask-antigravity
 ---
 
 You are a brainstorming coordinator powered by Claude Opus. You have two jobs:
@@ -98,8 +99,9 @@ Your own deep research phase. Do NOT skip this. Do NOT delegate it to a sub-agen
 
 Dispatch all requested external providers via **a single foreground Bash tool call** using direct backgrounding and `wait`. This is the ONLY correct dispatch pattern from within this sub-agent — see the "Critical: Sub-Agent Background Job Lifecycle" section for why.
 
-The user specifies which external providers to use. Default is `gemini,codex`. Only include the requested providers in the Bash call:
+The user specifies which external providers to use. Default is `antigravity,codex`. Only include the requested providers in the Bash call:
 
+- `antigravity` — Google Antigravity, subscription-backed via your Google AI Pro/Ultra plan, via the `agy` CLI (experimental; requires `agy` installed + logged in)
 - `gemini` — Google Gemini (large context, strong at analysis) via the `gemini` CLI
 - `codex` — OpenAI Codex (strong at code reasoning) via `codex exec --sandbox workspace-write`
 - `ollama` — Local Ollama (private, no data leaves machine) via the `ollama` CLI
@@ -124,6 +126,11 @@ PROMPT_EOF
 # Subshells (parentheses) detach the child from this shell's job table,
 # which makes `wait` return immediately and orphans the job to be
 # SIGKILLed when the Bash tool call returns and the sub-agent turn ends.
+# Only include this line if antigravity was requested (in the default set):
+agy -p "$(cat "$workdir/prompt.md")" --dangerously-skip-permissions > "$workdir/antigravity.out" 2> "$workdir/antigravity.err" &
+pid_antigravity=$!
+
+# Only include this line if gemini was requested:
 gemini -p "@$workdir/prompt.md" > "$workdir/gemini.out" 2> "$workdir/gemini.err" &
 pid_gemini=$!
 
@@ -136,11 +143,16 @@ pid_ollama=$!
 
 # Wait for each by PID so we capture per-provider exit codes independently.
 # `wait PID` blocks until that specific child exits.
+wait "$pid_antigravity" 2>/dev/null; rc_antigravity=$?
 wait "$pid_gemini" 2>/dev/null; rc_gemini=$?
 wait "$pid_codex"  2>/dev/null; rc_codex=$?
 wait "$pid_ollama" 2>/dev/null; rc_ollama=$?
 
 # Dump everything so the tool result is self-contained for Phase 4.
+echo "===== ANTIGRAVITY (rc=$rc_antigravity) ====="
+cat "$workdir/antigravity.out" 2>/dev/null
+echo "===== ANTIGRAVITY STDERR ====="
+cat "$workdir/antigravity.err" 2>/dev/null
 echo "===== GEMINI (rc=$rc_gemini) ====="
 cat "$workdir/gemini.out" 2>/dev/null
 echo "===== GEMINI STDERR ====="

--- a/packages/claude-plugin/agents/brainstorm-coordinator.md
+++ b/packages/claude-plugin/agents/brainstorm-coordinator.md
@@ -126,7 +126,9 @@ PROMPT_EOF
 # Subshells (parentheses) detach the child from this shell's job table,
 # which makes `wait` return immediately and orphans the job to be
 # SIGKILLed when the Bash tool call returns and the sub-agent turn ends.
-# Only include this line if antigravity was requested (in the default set):
+# Only include this line if antigravity was requested (in the default set).
+# --dangerously-skip-permissions: agy prompts for tool-use approval in interactive
+# contexts; skipping those prompts keeps the background job from hanging on input.
 agy -p "$(cat "$workdir/prompt.md")" --dangerously-skip-permissions > "$workdir/antigravity.out" 2> "$workdir/antigravity.err" &
 pid_antigravity=$!
 

--- a/packages/claude-plugin/package.json
+++ b/packages/claude-plugin/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": {
+    "ask-antigravity-run": "dist/antigravity-run.js",
     "ask-codex-run": "dist/codex-run.js",
     "ask-gemini-run": "dist/run.js",
     "ask-ollama-run": "dist/ollama-run.js"
@@ -16,6 +17,7 @@
   },
   "dependencies": {
     "@ask-llm/shared": "workspace:*",
+    "ask-antigravity-mcp": "workspace:*",
     "ask-codex-mcp": "workspace:*",
     "ask-gemini-mcp": "workspace:*",
     "ask-ollama-mcp": "workspace:*"

--- a/packages/claude-plugin/skills/brainstorm-all/SKILL.md
+++ b/packages/claude-plugin/skills/brainstorm-all/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: brainstorm-all
-description: Send a topic to ALL LLM providers (Gemini, Codex, Ollama) in parallel while Claude Opus performs its own independent research in parallel. Synthesizes findings from up to four participants. Shortcut for /brainstorm gemini,codex,ollama <topic>. Requires Ollama to be running locally.
+description: Send a topic to ALL LLM providers (Gemini, Codex, Ollama, Antigravity) in parallel while Claude Opus performs its own independent research in parallel. Synthesizes findings from up to five participants. Shortcut for /brainstorm gemini,codex,ollama,antigravity <topic>. Requires Ollama running locally and agy installed for the Antigravity participant.
 user_invocable: true
 ---
 
 # Multi-LLM Brainstorm (All Providers)
 
-Consult all available external LLM providers (Gemini, Codex, Ollama) simultaneously while Claude Opus performs its own independent research on the topic, then synthesize perspectives from all four participants.
+Consult all available external LLM providers (Gemini, Codex, Ollama, Antigravity) simultaneously while Claude Opus performs its own independent research on the topic, then synthesize perspectives from all five participants.
 
 ## Instructions
 
@@ -17,7 +17,7 @@ Consult all available external LLM providers (Gemini, Codex, Ollama) simultaneou
 
 2. If no topic is clear, ask the user what they'd like to brainstorm about.
 
-3. Launch the `brainstorm-coordinator` agent with the topic, external providers set to `gemini,codex,ollama`, and any gathered context. The coordinator will:
+3. Launch the `brainstorm-coordinator` agent with the topic, external providers set to `gemini,codex,ollama,antigravity`, and any gathered context. The coordinator will:
    - Run its own Claude Opus research phase in parallel with the external dispatches (Phase 3B — reads actual files, traces code, uses WebFetch/WebSearch on referenced external docs)
-   - Dispatch the topic to the three external providers in parallel (Phase 3A)
+   - Dispatch the topic to the four external providers in parallel (Phase 3A)
    - Synthesize all findings with Claude's verified findings weighted higher than inferred ones

--- a/packages/claude-plugin/skills/brainstorm/SKILL.md
+++ b/packages/claude-plugin/skills/brainstorm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brainstorm
-description: Send a topic to multiple LLM providers in parallel while Claude Opus performs its own independent research in parallel, then synthesize all findings. Usage /brainstorm [providers] <topic>. External providers default to antigravity,codex. Example /brainstorm gemini,codex,antigravity "review this architecture"
+description: Send a topic to multiple LLM providers in parallel while Claude Opus performs its own independent research in parallel, then synthesize all findings. Usage /brainstorm [providers] <topic>. External providers default to antigravity,codex. Example /brainstorm antigravity,codex,ollama "review this architecture"
 user_invocable: true
 ---
 

--- a/packages/claude-plugin/skills/brainstorm/SKILL.md
+++ b/packages/claude-plugin/skills/brainstorm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brainstorm
-description: Send a topic to multiple LLM providers in parallel while Claude Opus performs its own independent research in parallel, then synthesize all findings. Usage /brainstorm [providers] <topic>. External providers default to gemini,codex. Example /brainstorm gemini,codex,ollama "review this architecture"
+description: Send a topic to multiple LLM providers in parallel while Claude Opus performs its own independent research in parallel, then synthesize all findings. Usage /brainstorm [providers] <topic>. External providers default to antigravity,codex. Example /brainstorm gemini,codex,antigravity "review this architecture"
 user_invocable: true
 ---
 
@@ -12,9 +12,10 @@ Consult multiple external LLM providers simultaneously on a topic while Claude O
 
 ### Phase 1: Parse arguments
 
-- If the first argument looks like a comma-separated provider list (e.g., `gemini,codex` or `gemini,codex,ollama`), use those as the external providers
-- If no provider list is given, default to `gemini,codex`
-- Valid external providers: `gemini`, `codex`, `ollama`
+- If the first argument looks like a comma-separated provider list (e.g., `antigravity,codex` or `gemini,codex,ollama`), use those as the external providers
+- If no provider list is given, default to `antigravity,codex`
+- Valid external providers: `gemini`, `codex`, `ollama`, `antigravity`
+- `antigravity` requires `agy` installed + logged in; if it's unavailable the coordinator surfaces that and continues with the other providers
 - Everything after the provider list (or all args if no list) is the topic
 - Claude Opus is always a participant — it's not in the provider list because it runs inside the coordinator
 

--- a/packages/claude-plugin/skills/multi-review/SKILL.md
+++ b/packages/claude-plugin/skills/multi-review/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: multi-review
-description: This skill should be used when the user asks to "review my code with multiple providers", "get reviews from Gemini and Codex", "multi-provider review", "review changes", or wants independent code reviews from both Gemini and Codex in parallel.
+description: This skill should be used when the user asks to "review my code with multiple providers", "get reviews from Antigravity and Codex", "multi-provider review", "review changes", or wants independent code reviews from both Antigravity and Codex in parallel.
 user_invocable: true
 ---
 
 # Multi-Provider Code Review
 
-Run independent code reviews from Gemini and Codex in parallel, **verify** each finding against the source, then present combined consensus / unique / rejected sections so the user sees what really matters and what was a false positive.
+Run independent code reviews from Antigravity and Codex in parallel, **verify** each finding against the source, then present combined consensus / unique / rejected sections so the user sees what really matters and what was a false positive. (Gemini is one command away via the `gemini-reviewer` agent or `/gemini-review` if you want it in the mix.)
 
 ## Why verification matters
 
@@ -84,26 +84,28 @@ Keep the brief tiny for simple diffs. Escalate detail when the diff is over 50KB
 ### Phase 2: Dispatch (with fallback)
 
 **Preferred: launch both reviewer agents in parallel** using the Agent tool in a single message:
-- `gemini-reviewer` agent with the Context Brief + diff content
+- `antigravity-reviewer` agent with the Context Brief + diff content
 - `codex-reviewer` agent with the Context Brief + diff content
-- Each agent performs its own 4-phase pipeline: Context → Prompt → Synthesis → Validation
+- Each agent performs its own multi-phase pipeline: Context → Prompt → Validation → Report
 
-**Fallback when reviewer agents are unavailable** (e.g., plugin not installed in this Claude Code session): dispatch directly via the project's `dist/run.js` and `dist/codex-run.js` runner binaries using the **ADR-050 dispatch pattern** (single foreground blocking Bash call, direct backgrounding, per-PID `wait`, 25-min timeout):
+> `antigravity-reviewer` requires `agy` installed + logged in and the Antigravity MCP server registered. If it's unavailable it will say so — present the codex-only result and note "antigravity skipped (agy not available)" rather than failing the whole review. To include Gemini instead/as well, also launch the `gemini-reviewer` agent.
+
+**Fallback when reviewer agents are unavailable** (e.g., plugin not installed in this Claude Code session): dispatch directly via the project's `dist/antigravity-run.js` and `dist/codex-run.js` runner binaries using the **ADR-050 dispatch pattern** (single foreground blocking Bash call, direct backgrounding, per-PID `wait`, 25-min timeout):
 
 ```bash
-GMCPT_TIMEOUT_MS=1500000 node ${CLAUDE_PLUGIN_ROOT}/dist/run.js "$REVIEW_PROMPT" < diff.patch > /tmp/mr-gemini.out 2> /tmp/mr-gemini.err &
-gem_pid=$!
+GMCPT_TIMEOUT_MS=1500000 node ${CLAUDE_PLUGIN_ROOT}/dist/antigravity-run.js "$REVIEW_PROMPT" < diff.patch > /tmp/mr-antigravity.out 2> /tmp/mr-antigravity.err &
+agy_pid=$!
 
 GMCPT_TIMEOUT_MS=1500000 node ${CLAUDE_PLUGIN_ROOT}/dist/codex-run.js "$REVIEW_PROMPT" < diff.patch > /tmp/mr-codex.out 2> /tmp/mr-codex.err &
 codex_pid=$!
 
-gem_rc=0; wait $gem_pid || gem_rc=$?
+agy_rc=0; wait $agy_pid || agy_rc=$?
 codex_rc=0; wait $codex_pid || codex_rc=$?
 ```
 
 Set the Bash tool's `timeout` parameter to **600000ms** (10-min max). For diffs > 50KB, expect both providers to take real wall time — this is normal.
 
-Do NOT use raw `gemini -p` or `codex exec` — those bypass the project's quota fallback (ADR-044), Codex stdin handling (ADR-042), and PATH resolution (ADR-047). Use the runner binaries.
+Do NOT use raw `agy -p`, `gemini -p`, or `codex exec` — those bypass the project's quota/transcript handling, Codex stdin handling (ADR-042), and PATH resolution (ADR-047). Use the runner binaries.
 
 ### Phase 3: Verify each finding before presenting
 
@@ -123,7 +125,7 @@ For every finding from either provider at confidence ≥ 80:
 
 When a provider fails (timeout, capacity exhaustion, exit code ≠ 0, 0-byte output):
 - Do NOT silently drop it from the synthesis
-- Surface the failure inline: "Gemini failed (exit 1): <first 3 lines of stderr>"
+- Surface the failure inline: "Antigravity failed (exit 1): <first 3 lines of stderr>"
 - If both providers failed, say so explicitly and surface both stderr — don't pretend you have findings
 - A single-provider review is still useful — present what you have, note what's missing
 
@@ -138,9 +140,9 @@ When a provider fails (timeout, capacity exhaustion, exit code ≠ 0, 0-byte out
 - Diff bytes: <N>
 
 **Verified by both providers (highest confidence):**
-- ⟨finding⟩ — Gemini: 92, Codex: 88. Verified at <file>:<line>.
+- ⟨finding⟩ — Antigravity: 92, Codex: 88. Verified at <file>:<line>.
 
-**Verified by Gemini only:**
+**Verified by Antigravity only:**
 - ⟨finding⟩ — Confidence 85. Verified at <file>:<line>.
 
 **Verified by Codex only:**
@@ -153,7 +155,7 @@ When a provider fails (timeout, capacity exhaustion, exit code ≠ 0, 0-byte out
 - ⟨finding⟩ — Cannot confirm without runtime; flagging for user attention.
 
 **Provider stats:**
-- Gemini: ⟨N⟩ findings, ⟨V⟩ verified, ⟨R⟩ rejected. Status: ⟨ok | failed: ⟨reason⟩⟩
+- Antigravity: ⟨N⟩ findings, ⟨V⟩ verified, ⟨R⟩ rejected. Status: ⟨ok | failed: ⟨reason⟩⟩
 - Codex: ⟨N⟩ findings, ⟨V⟩ verified, ⟨R⟩ rejected. Status: ⟨ok | failed: ⟨reason⟩⟩
 ```
 

--- a/packages/claude-plugin/src/__tests__/providers.test.ts
+++ b/packages/claude-plugin/src/__tests__/providers.test.ts
@@ -2,15 +2,21 @@ import { describe, expect, it } from "vitest";
 import { providers } from "../index.js";
 
 describe("ProviderExecutor wiring", () => {
-  it("exports exactly three providers", () => {
-    expect(providers).toHaveLength(3);
+  it("exports exactly four providers", () => {
+    expect(providers).toHaveLength(4);
   });
 
-  it("each provider has matching name and command", () => {
-    const expectedNames = ["gemini", "codex", "ollama"];
-    expect(providers.map((p) => p.name).sort()).toEqual(expectedNames.sort());
+  it("each provider has the expected name and CLI command", () => {
+    // antigravity's CLI binary is `agy`, so command !== name for it
+    const expectedCommand: Record<string, string> = {
+      gemini: "gemini",
+      codex: "codex",
+      ollama: "ollama",
+      antigravity: "agy",
+    };
+    expect(providers.map((p) => p.name).sort()).toEqual(Object.keys(expectedCommand).sort());
     for (const provider of providers) {
-      expect(provider.command).toBe(provider.name);
+      expect(provider.command).toBe(expectedCommand[provider.name]);
     }
   });
 
@@ -25,5 +31,6 @@ describe("ProviderExecutor wiring", () => {
     expect(names).toContain("gemini");
     expect(names).toContain("codex");
     expect(names).toContain("ollama");
+    expect(names).toContain("antigravity");
   });
 });

--- a/packages/claude-plugin/src/__tests__/skills-and-agents.test.ts
+++ b/packages/claude-plugin/src/__tests__/skills-and-agents.test.ts
@@ -139,13 +139,13 @@ describe("multi-review skill — load-bearing polish (ADR-064)", () => {
   });
 
   it("documents fallback dispatch via dist runner binaries", () => {
-    expect(body).toMatch(/dist\/run\.js/);
+    expect(body).toMatch(/dist\/antigravity-run\.js/);
     expect(body).toMatch(/dist\/codex-run\.js/);
   });
 
   it("includes the ADR-050 dispatch pattern (direct backgrounding + per-PID wait)", () => {
-    expect(body).toMatch(/&\s*\ngem_pid=\$!|& gem_pid=\$!/);
-    expect(body).toMatch(/wait \$gem_pid|wait "\$gem_pid"/);
+    expect(body).toMatch(/&\s*\nagy_pid=\$!|& agy_pid=\$!/);
+    expect(body).toMatch(/wait \$agy_pid|wait "\$agy_pid"/);
   });
 
   it("forbids raw provider CLI invocation (preserves quota fallback + stdin handling)", () => {
@@ -274,11 +274,12 @@ describe("brainstorm-coordinator agent", () => {
     expect(frontmatter.model).toBe("opus");
   });
 
-  it("has all three external provider MCP tools", () => {
+  it("has all four external provider MCP tools", () => {
     const tools = frontmatter.tools as string[];
     expect(tools).toContain("mcp__gemini__ask-gemini");
     expect(tools).toContain("mcp__codex__ask-codex");
     expect(tools).toContain("mcp__ollama__ask-ollama");
+    expect(tools).toContain("mcp__antigravity__ask-antigravity");
   });
 
   it("has WebFetch and WebSearch (Phase 3B research surface — ADR-049)", () => {

--- a/packages/claude-plugin/src/antigravity-run.ts
+++ b/packages/claude-plugin/src/antigravity-run.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+import { executeAntigravityCLI } from "ask-antigravity-mcp/executor";
+
+const args = process.argv.slice(2);
+const prompt = args.join(" ");
+
+async function readStdin(): Promise<string> {
+  if (process.stdin.isTTY) return "";
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString().trim();
+}
+
+async function main(): Promise<void> {
+  const stdin = await readStdin();
+
+  if (!prompt && !stdin) {
+    console.error("Usage: ask-antigravity-run <prompt>");
+    console.error("       echo 'diff' | ask-antigravity-run 'Review this diff'");
+    process.exit(1);
+  }
+
+  const fullPrompt = [prompt, stdin].filter(Boolean).join("\n\n");
+
+  try {
+    const result = await executeAntigravityCLI({ prompt: fullPrompt });
+    console.log(result.response);
+  } catch (error) {
+    console.error("ask-antigravity-run failed:", error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/claude-plugin/src/index.ts
+++ b/packages/claude-plugin/src/index.ts
@@ -32,4 +32,13 @@ export const providers: ProviderExecutor[] = [
       return result.response;
     },
   },
+  {
+    name: "antigravity",
+    command: "agy",
+    async execute(prompt: string) {
+      const { executeAntigravityCLI } = await import("ask-antigravity-mcp/executor");
+      const result = await executeAntigravityCLI({ prompt });
+      return result.response;
+    },
+  },
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,12 +219,14 @@ __metadata:
     "@ask-llm/shared": "workspace:*"
     "@biomejs/biome": "npm:^2.4.4"
     "@types/node": "npm:^22.19.13"
+    ask-antigravity-mcp: "workspace:*"
     ask-codex-mcp: "workspace:*"
     ask-gemini-mcp: "workspace:*"
     ask-ollama-mcp: "workspace:*"
     typescript: "npm:^5.0.0"
     vitest: "npm:^4.0.18"
   bin:
+    ask-antigravity-run: dist/antigravity-run.js
     ask-codex-run: dist/codex-run.js
     ask-gemini-run: dist/run.js
     ask-ollama-run: dist/ollama-run.js


### PR DESCRIPTION
## Summary
Makes Antigravity a first-class participant in the plugin's parallel-review and brainstorm skills, replacing gemini as the **default** pair member. Gemini stays available via `/gemini-review`, explicit `/brainstorm` args, and `/brainstorm-all`.

**Common infra**
- `src/antigravity-run.ts` runner + `ask-antigravity-run` bin + plugin dependency on `ask-antigravity-mcp` + a `ProviderExecutor` entry (`name: antigravity`, `command: agy`).

**`/multi-review`**
- Default pair is now **antigravity + codex** (was gemini + codex): `antigravity-reviewer` + `codex-reviewer` agents; `dist/antigravity-run.js` + `dist/codex-run.js` fallback.
- Degrades gracefully when `agy` is absent (surfaces "antigravity skipped" via Phase-4 handling rather than failing the whole review).

**`/brainstorm` + `/brainstorm-all`**
- `/brainstorm` default external set: `gemini,codex` → **`antigravity,codex`**; antigravity added to the valid-provider list.
- `brainstorm-coordinator`: gains the `mcp__antigravity__ask-antigravity` tool and a raw `agy -p` dispatch line in its Phase 3A template (the coordinator uses raw CLIs, not runner binaries).
- `/brainstorm-all`: now spans all four external providers (+Antigravity) → up to five participants.

**Tests & docs**
- `providers.test.ts`: 4 providers; antigravity's `command` (`agy`) ≠ `name` handled via an explicit map.
- `skills-and-agents.test.ts`: multi-review runner/PID assertions (`dist/antigravity-run.js`, `agy_pid`); coordinator now asserts 4 MCP tools.
- README + `plugin/overview` + `plugin/skills` + usage/concepts prose updated to the new default.

## Note on the default change
Antigravity is experimental and needs an `agy` login, so for users **without** `agy` these skills degrade to codex-only (surfaced, not silent). This is an intentional, maintainer-chosen default reflecting subscription economics; gemini is one command away.

## Verification
- **372 plugin tests pass**; `yarn lint` clean; `yarn docs:build` clean; plugin builds. Plugin is `private`, so no publish/bundling impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)