### PR TITLE
fix(llm-mcp): include Antigravity in ask-llm/multi-llm tool descriptions

### DIFF
--- a/.changeset/llm-mcp-antigravity-descriptions.md
+++ b/.changeset/llm-mcp-antigravity-descriptions.md
@@ -1,0 +1,5 @@
+---
+"ask-llm-mcp": patch
+---
+
+Include Antigravity in the `ask-llm` and `multi-llm` tool descriptions. The unified orchestrator has supported Antigravity as a fourth provider for a while (it's in the `PROVIDERS` registry and the `provider` enum), but the two top-level tool-description strings still enumerated only "Gemini, Codex, Ollama" — so MCP clients listing the tools saw a stale, incomplete provider list. Both descriptions now read "Codex, Antigravity, Ollama, Gemini" (the canonical order). The runtime `provider` enum was already dynamic and unaffected.

--- a/packages/llm-mcp/src/index.ts
+++ b/packages/llm-mcp/src/index.ts
@@ -149,7 +149,7 @@ export async function startServer() {
     "ask-llm",
     {
       description:
-        "Send a prompt to an LLM provider (Gemini, Codex, Ollama). Specify which provider to use. Each provider auto-selects its best model with fallback on errors. Returns both human-readable text and a structured response (provider, model, sessionId, usage) via outputSchema.",
+        "Send a prompt to an LLM provider (Codex, Antigravity, Ollama, Gemini). Specify which provider to use. Each provider auto-selects its best model with fallback on errors. Returns both human-readable text and a structured response (provider, model, sessionId, usage) via outputSchema.",
       inputSchema: askLlmSchema.shape,
       outputSchema: (askResponseSchema as z.ZodObject<z.ZodRawShape>).shape,
       annotations: { title: "Ask LLM", readOnlyHint: false, destructiveHint: false, openWorldHint: true },
@@ -258,7 +258,7 @@ export async function startServer() {
     "multi-llm",
     {
       description:
-        "Dispatch the same prompt to multiple LLM providers in parallel and return all responses in one structured payload. Use when you want to compare answers across Gemini, Codex, and Ollama, or when you want a multi-provider sanity check on a question. Returns per-provider success/failure, response text, model, sessionId, and token usage. Each call is fresh — no session continuity (use ask-llm for individual session-bearing calls).",
+        "Dispatch the same prompt to multiple LLM providers in parallel and return all responses in one structured payload. Use when you want to compare answers across Codex, Antigravity, Ollama, and Gemini, or when you want a multi-provider sanity check on a question. Returns per-provider success/failure, response text, model, sessionId, and token usage. Each call is fresh — no session continuity (use ask-llm for individual session-bearing calls).",
       inputSchema: multiLlmInputSchema.shape,
       outputSchema: (multiLlmReportSchema as z.ZodObject<z.ZodRawShape>).shape,
       annotations: {


### PR DESCRIPTION
## Summary

The unified orchestrator (`ask-llm-mcp`) has supported Antigravity as a fourth provider for a while — it's in the `PROVIDERS` registry and the dynamic `provider` enum — but the two top-level MCP **tool descriptions** still enumerated only "Gemini, Codex, Ollama". MCP clients listing the tools therefore saw a stale, incomplete provider list.

- `ask-llm` description: `(Gemini, Codex, Ollama)` → `(Codex, Antigravity, Ollama, Gemini)`
- `multi-llm` description: `compare answers across Gemini, Codex, and Ollama` → `…across Codex, Antigravity, Ollama, and Gemini`

Canonical order matches the docs reposition (#188). The runtime `provider` enum was already dynamic and is unaffected — this is a description-string fix only. Surfaced by the #188 review.

## Test plan
- [x] `yarn workspace ask-llm-mcp run test` — 56 passed
- [x] `biome check` clean on the changed file
- [x] `yarn workspace ask-llm-mcp run build` — succeeds
- [x] Patch changeset added (`ask-llm-mcp`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)