### PR TITLE
feat(ollama): default to qwen3.6:27b, remove automatic model fallback

### DIFF
--- a/.changeset/ollama-default-qwen3-6-no-fallback.md
+++ b/.changeset/ollama-default-qwen3-6-no-fallback.md
@@ -1,0 +1,10 @@
+---
+"ask-ollama-mcp": minor
+"ask-llm-mcp": patch
+---
+
+Bump the default Ollama model to `qwen3.6:27b` (was `qwen2.5-coder:7b`) and remove the automatic model fallback.
+
+Ollama runs locally, where you explicitly pull the model you want — so silently substituting a *different* model on "model not found" was a footgun. The executor now surfaces a clear, actionable error (`Ollama model "<model>" is not available locally. Pull it first: ollama pull <model>`) instead of falling back to another model. The `ASK_OLLAMA_FALLBACK_MODEL` env var and the `FALLBACK` constant are removed; `ASK_OLLAMA_MODEL` still overrides the default, and `usage.fellBack` is now always `false` for Ollama.
+
+Note: qwen3.6's smallest Ollama variant is ~17 GB and needs a capable GPU / plenty of RAM — set `ASK_OLLAMA_MODEL` to a lighter tag (e.g. a `qwen2.5-coder` size) if your machine can't run it.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Replace `ask-llm-mcp` with `ask-codex-mcp`, `ask-antigravity-mcp`, `ask-ollama-m
 |----------|----------|----------------------------|-------|
 | **Codex** | Code reasoning, targeted reviews, architecture critique | `gpt-5.5` → `gpt-5.5-mini` | Requires an OpenAI/Codex account |
 | **Antigravity** | A subscription-backed second opinion; larger-context reads | `Gemini 3.5 Flash (High)` | Google AI Pro/Ultra plan; one-shot, experimental |
-| **Ollama** | Private/local review, zero cost, offline | `qwen2.5-coder:7b` → `:1.5b` | Runs entirely on your machine |
+| **Ollama** | Private/local review, zero cost, offline | `qwen3.6:27b` (no auto-fallback) | Runs entirely on your machine |
 | **Gemini** | Whole-codebase reads (1M+ tokens) | `gemini-3.1-pro-preview` → `gemini-3.5-flash` | ⚠️ Enterprise-gated from 2026-06-18 |
 | **Unified (`ask-llm`)** | One install for all of the above; fan out in parallel | routes per call | **Recommended** |
 
@@ -175,7 +175,7 @@ See the [plugin docs](https://lykhoyda.github.io/ask-llm/plugin/overview) for de
 - **At least one provider:**
   - [Codex CLI](https://github.com/openai/codex) — installed and authenticated
   - [Antigravity CLI](https://antigravity.google) (`agy`) — installed and logged in once (Google AI Pro/Ultra)
-  - [Ollama](https://ollama.com) — running locally with a model pulled (`ollama pull qwen2.5-coder:7b`)
+  - [Ollama](https://ollama.com) — running locally with a model pulled (`ollama pull qwen3.6:27b`)
   - [Gemini CLI](https://github.com/google-gemini/gemini-cli) — `npm install -g @google/gemini-cli && gemini login` (enterprise-gated from 2026-06-18)
 
 ## MCP Tools
@@ -227,9 +227,9 @@ The REPL ships sessions per provider (`/provider gemini`, `/provider codex`, `/n
 |----------|---------|----------|
 | Gemini | `gemini-3.1-pro-preview` | `gemini-3.5-flash` (on quota) |
 | Codex | `gpt-5.5` | `gpt-5.5-mini` (on quota) |
-| Ollama | `qwen2.5-coder:7b` | `qwen2.5-coder:1.5b` (if not found) |
+| Ollama | `qwen3.6:27b` | — (local; errors if the model isn't pulled) |
 
-All providers automatically fall back to a lighter model on errors.
+Gemini and Codex automatically fall back to a lighter model on quota errors. Ollama runs locally and never substitutes a model — if the requested model isn't pulled, it returns a clear `ollama pull` error.
 
 ## Documentation
 

--- a/apps/docs/concepts/models.md
+++ b/apps/docs/concepts/models.md
@@ -1,10 +1,10 @@
 ---
-description: Choose the right model across providers. Default models, fallback chains, and overrides for Gemini, Codex, and Ollama.
+description: Choose the right model across providers. Default models, fallback behavior (Gemini/Codex), and per-provider overrides.
 ---
 
 # Model Selection
 
-Each provider auto-selects a sensible default model with automatic fallback to a lighter model on quota or availability errors. **Most users should never override the model parameter** — the defaults are tuned for quality and the fallback chain handles failures.
+Hosted providers (Gemini, Codex) auto-select a sensible default model with automatic fallback to a lighter model on quota errors. Ollama runs locally and uses exactly the model you pull — it never substitutes another. **Most users should never override the model parameter** — the defaults are tuned for quality.
 
 ## Defaults & Fallbacks
 
@@ -12,9 +12,9 @@ Each provider auto-selects a sensible default model with automatic fallback to a
 |---|---|---|---|
 | Gemini | `gemini-3.1-pro-preview` | `gemini-3.5-flash` | `RESOURCE_EXHAUSTED` quota error or "exhausted your capacity" pattern ([ADR-044](https://github.com/Lykhoyda/ask-llm/blob/main/docs/DECISIONS.md)) |
 | Codex | `gpt-5.5` | `gpt-5.5-mini` | Quota errors (`rate_limit_exceeded`, `429`, `insufficient_quota`) ([ADR-028](https://github.com/Lykhoyda/ask-llm/blob/main/docs/DECISIONS.md), bumped per [ADR-067](https://github.com/Lykhoyda/ask-llm/blob/main/docs/DECISIONS.md)) |
-| Ollama | `qwen2.5-coder:7b` | `qwen2.5-coder:1.5b` | Model-not-found error (e.g., 7b not pulled but 1.5b is) |
+| Ollama | `qwen3.6:27b` | — (none) | Local — no fallback; a missing model returns a clear `ollama pull` error |
 
-The fallback fires automatically inside the executor — your client sees a successful response with `usage.fellBack: true` in the structured output, and a `[Gemini stats: ... fell back]` annotation in the formatted text.
+For Gemini and Codex, the fallback fires automatically inside the executor — your client sees a successful response with `usage.fellBack: true` in the structured output, and a `[Gemini stats: ... fell back]` annotation in the formatted text. Ollama never falls back, so its `fellBack` is always `false`.
 
 ## Choosing a Provider
 
@@ -67,7 +67,7 @@ Use ask-ollama with model deepseek-coder:6.7b to review this implementation
 | Gemini Flash | ~1M tokens | Cheaper than Pro; fallback target for quota relief |
 | Codex GPT-5.5 | Per OpenAI's published context window | Per OpenAI billing |
 | Codex GPT-5.5-mini | Smaller context | Cheaper; fallback target |
-| Ollama | Per model (e.g., 32k for qwen2.5-coder) | Free — runs locally |
+| Ollama | Per model (e.g., 256k for qwen3.6) | Free — runs locally |
 
 ## Track What You're Spending
 

--- a/apps/docs/getting-started.md
+++ b/apps/docs/getting-started.md
@@ -28,7 +28,7 @@ npm install -g @openai/codex
 
 # Ollama
 # install from https://ollama.com, then:
-ollama pull qwen2.5-coder:7b
+ollama pull qwen3.6:27b
 
 # Gemini (enterprise seats only from 2026-06-18)
 npm install -g @google/gemini-cli && gemini login

--- a/apps/docs/installation.md
+++ b/apps/docs/installation.md
@@ -13,7 +13,7 @@ Multiple ways to install Ask LLM, depending on whether you want the unified orch
 - **At least one provider CLI** installed and authenticated:
   - `npm install -g @openai/codex` (then follow CLI auth) for Codex
   - [Antigravity CLI](https://antigravity.google) (`agy`) installed and logged in once for Antigravity
-  - [Ollama](https://ollama.com) running locally with a model pulled (`ollama pull qwen2.5-coder:7b`)
+  - [Ollama](https://ollama.com) running locally with a model pulled (`ollama pull qwen3.6:27b`)
   - `npm install -g @google/gemini-cli && gemini login` for Gemini ([enterprise-gated from 2026-06-18](/providers/gemini))
 
 ## Packages

--- a/apps/docs/plugin/skills.md
+++ b/apps/docs/plugin/skills.md
@@ -46,7 +46,7 @@ Get a second opinion from a local Ollama model. No API keys needed — all proce
 /ollama-review
 ```
 
-Requires Ollama running locally with a model pulled (e.g., `qwen2.5-coder:7b`).
+Requires Ollama running locally with a model pulled (e.g., `qwen3.6:27b`).
 
 ### `/antigravity-review`
 

--- a/apps/docs/providers/ollama.md
+++ b/apps/docs/providers/ollama.md
@@ -26,7 +26,7 @@ npm install -g ask-ollama-mcp
 3. **A model pulled:**
 
 ```bash
-ollama pull qwen2.5-coder:7b
+ollama pull qwen3.6:27b
 ```
 
 ## Tools
@@ -41,8 +41,8 @@ ollama pull qwen2.5-coder:7b
 
 ## Models
 
-- **Default:** `qwen2.5-coder:7b` (good balance of speed and capability)
-- **Fallback:** `qwen2.5-coder:1.5b` (automatic on model-not-found)
+- **Default:** `qwen3.6:27b` — Qwen's flagship-level local coding model (~17 GB; needs a capable GPU / plenty of RAM). Set `ASK_OLLAMA_MODEL` to pick a lighter model.
+- **No fallback.** Ollama is local — you pull the model you want, so the server never silently substitutes another. If the model isn't installed, you get a clear `ollama pull <model>` error.
 
 ## Configuration
 
@@ -67,7 +67,7 @@ Each turn replays the full prior conversation (input tokens grow linearly with d
 - **Zero cost** per query
 - **Server-side session continuity** with hardened storage
 - **Model auto-detection** via `/api/tags` endpoint
-- **Automatic model fallback** from 7b to 1.5b
+- **No silent model substitution** — a clear "pull it first" error if a model isn't installed
 - **Structured AskResponse** via outputSchema for programmatic clients
 
 ## npm

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -166,7 +166,7 @@ Send prompts to a local Ollama LLM via HTTP. No API keys or network calls needed
 - **Package:** ask-ollama-mcp
 - **Parameters:**
   - `prompt` (string, required): The question, code review request, or analysis task.
-  - `model` (string, optional): Do not set unless user explicitly requests it. Default: qwen2.5-coder:7b. Falls back to qwen2.5-coder:1.5b if not found.
+  - `model` (string, optional): Do not set unless user explicitly requests it. Default: qwen3.6:27b. No fallback — returns a clear "ollama pull" error if the model isn't installed.
 - **Returns:** Ollama's text response.
 - **Annotations:** readOnlyHint=false, destructiveHint=false, openWorldHint=false
 - **Environment:** Set OLLAMA_HOST to customize the Ollama server address (default: http://localhost:11434).
@@ -197,8 +197,9 @@ Test MCP server connectivity. Available in all packages.
 ### Ollama
 | Model | Use Case |
 |-------|----------|
-| qwen2.5-coder:7b | Default — good balance of speed and capability |
-| qwen2.5-coder:1.5b | Automatic fallback if 7b not available |
+| qwen3.6:27b | Default — Qwen's flagship-level local coding model (~17 GB) |
+
+Ollama is local — no automatic fallback. Override with `ASK_OLLAMA_MODEL`; a model that isn't pulled returns a clear `ollama pull` error.
 
 ## Usage Patterns
 
@@ -267,7 +268,7 @@ Launches Gemini and Codex reviews in parallel with consensus highlighting.
 ## Error Handling
 
 All MCP servers handle errors gracefully:
-- **Quota errors:** Automatic fallback to cheaper model (Pro→Flash, gpt-5.5→mini, 7b→1.5b)
+- **Quota errors:** Automatic fallback to a cheaper model for hosted providers (Pro→Flash, gpt-5.5→mini). Ollama is local and never substitutes — a missing model returns a clear "ollama pull" error.
 - **CLI not found:** Clear error message with installation instructions
 - **Timeout:** 5-minute default, configurable via GMCPT_TIMEOUT_MS environment variable
 - **Large responses:** Automatic chunking with fetch-chunk retrieval (Gemini only)

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -8,7 +8,7 @@ Ask LLM provides Model Context Protocol (MCP) servers that let any MCP-compatibl
 
 - `ask-gemini-mcp`: MCP server for Google Gemini CLI. 1M+ token context. Default model: gemini-3.1-pro-preview.
 - `ask-codex-mcp`: MCP server for OpenAI Codex CLI. Default model: gpt-5.5.
-- `ask-ollama-mcp`: MCP server for local Ollama. No API keys, fully private. Default model: qwen2.5-coder:7b.
+- `ask-ollama-mcp`: MCP server for local Ollama. No API keys, fully private. Default model: qwen3.6:27b.
 - `ask-llm-mcp`: Unified server — auto-detects installed providers and registers all available tools.
 
 ## Installation

--- a/apps/docs/resources/troubleshooting.md
+++ b/apps/docs/resources/troubleshooting.md
@@ -33,7 +33,7 @@ npm install -g @openai/codex
 # then follow the codex CLI's auth instructions
 
 # Ollama (https://ollama.com)
-ollama pull qwen2.5-coder:7b
+ollama pull qwen3.6:27b
 ```
 
 Verify:

--- a/packages/claude-plugin/agents/brainstorm-coordinator.md
+++ b/packages/claude-plugin/agents/brainstorm-coordinator.md
@@ -145,7 +145,7 @@ codex exec --sandbox workspace-write - < "$workdir/prompt.md" > "$workdir/codex.
 pid_codex=$!
 
 # Only include this line if ollama was requested:
-ollama run qwen3.6:27b < "$workdir/prompt.md" > "$workdir/ollama.out" 2> "$workdir/ollama.err" &
+ollama run "${ASK_OLLAMA_MODEL:-qwen3.6:27b}" < "$workdir/prompt.md" > "$workdir/ollama.out" 2> "$workdir/ollama.err" &
 pid_ollama=$!
 
 # Wait for each by PID so we capture per-provider exit codes independently.

--- a/packages/claude-plugin/agents/brainstorm-coordinator.md
+++ b/packages/claude-plugin/agents/brainstorm-coordinator.md
@@ -145,7 +145,7 @@ codex exec --sandbox workspace-write - < "$workdir/prompt.md" > "$workdir/codex.
 pid_codex=$!
 
 # Only include this line if ollama was requested:
-ollama run qwen2.5-coder:7b < "$workdir/prompt.md" > "$workdir/ollama.out" 2> "$workdir/ollama.err" &
+ollama run qwen3.6:27b < "$workdir/prompt.md" > "$workdir/ollama.out" 2> "$workdir/ollama.err" &
 pid_ollama=$!
 
 # Wait for each by PID so we capture per-provider exit codes independently.

--- a/packages/llm-mcp/src/__tests__/smoke.test.ts
+++ b/packages/llm-mcp/src/__tests__/smoke.test.ts
@@ -13,7 +13,7 @@ vi.mock("ask-codex-mcp/executor", () => ({
 }));
 
 vi.mock("ask-ollama-mcp/executor", () => ({
-  executeOllamaCLI: vi.fn().mockResolvedValue({ response: "ollama response", model: "qwen2.5-coder:7b" }),
+  executeOllamaCLI: vi.fn().mockResolvedValue({ response: "ollama response", model: "qwen3.6:27b" }),
   isProviderAvailable: vi.fn().mockResolvedValue(false),
 }));
 
@@ -35,7 +35,7 @@ beforeEach(() => {
   vi.mocked(mockIsOllamaAvailable).mockResolvedValue(false);
   vi.mocked(executeGeminiCLI).mockResolvedValue({ response: "gemini response", sessionId: undefined });
   vi.mocked(executeCodexCLI).mockResolvedValue({ response: "codex response", threadId: undefined });
-  vi.mocked(executeOllamaCLI).mockResolvedValue({ response: "ollama response", model: "qwen2.5-coder:7b" });
+  vi.mocked(executeOllamaCLI).mockResolvedValue({ response: "ollama response", model: "qwen3.6:27b" });
 });
 
 describe("detectProviders", () => {

--- a/packages/llm-mcp/src/constants.ts
+++ b/packages/llm-mcp/src/constants.ts
@@ -32,7 +32,7 @@ export const PROVIDERS: Record<string, ProviderConfig> = {
     command: "ollama",
     executorModule: "ask-ollama-mcp/executor",
     executorFn: "executeOllamaCLI",
-    defaultModel: "qwen2.5-coder:7b",
+    defaultModel: "qwen3.6:27b",
     availabilityModule: "ask-ollama-mcp/executor",
     availabilityFn: "isProviderAvailable",
   },
@@ -48,6 +48,6 @@ export const PROVIDERS: Record<string, ProviderConfig> = {
 export const INSTALL_HINTS: Record<string, string> = {
   gemini: "npm install -g @google/gemini-cli",
   codex: "npm install -g @openai/codex",
-  ollama: "https://ollama.com — then: ollama pull qwen2.5-coder:7b",
+  ollama: "https://ollama.com — then: ollama pull qwen3.6:27b",
   antigravity: "Install Google Antigravity (agy) from https://antigravity.google, then run `agy` once to log in",
 };

--- a/packages/ollama-mcp/README.md
+++ b/packages/ollama-mcp/README.md
@@ -50,21 +50,22 @@ Add to `claude_desktop_config.json`:
 
 - **[Node.js](https://nodejs.org/)** v20.0.0 or higher
 - **[Ollama](https://ollama.com)** installed and running locally
-- **A model pulled:** `ollama pull qwen2.5-coder:7b`
+- **A model pulled:** `ollama pull qwen3.6:27b`
 
 ## Tools
 
 | Tool | Purpose |
 |------|---------|
-| `ask-ollama` | Send prompts to local Ollama via HTTP. Defaults to qwen2.5-coder:7b |
+| `ask-ollama` | Send prompts to local Ollama via HTTP. Defaults to qwen3.6:27b |
 | `ping` | Lists locally available Ollama models via /api/tags |
 
 ## Models
 
 | Model | Use Case |
 |-------|----------|
-| `qwen2.5-coder:7b` | Default — good balance of speed and capability |
-| `qwen2.5-coder:1.5b` | Automatic fallback if 7b not available |
+| `qwen3.6:27b` | Default — Qwen's flagship-level local coding model (~17 GB) |
+
+Override with `ASK_OLLAMA_MODEL`. Ollama is local, so there's no automatic fallback — you pull the model you want, and a missing model returns a clear `ollama pull <model>` error.
 
 ## Configuration
 

--- a/packages/ollama-mcp/src/constants.ts
+++ b/packages/ollama-mcp/src/constants.ts
@@ -2,8 +2,9 @@ export const OLLAMA_HOST_ENV = "OLLAMA_HOST";
 export const DEFAULT_BASE_URL = "http://localhost:11434";
 
 export const MODELS = {
-  DEFAULT: process.env.ASK_OLLAMA_MODEL || "qwen2.5-coder:7b",
-  FALLBACK: process.env.ASK_OLLAMA_FALLBACK_MODEL || "qwen2.5-coder:1.5b",
+  // Ollama is local — the user explicitly pulls the model they want, so there is no
+  // automatic fallback to a different model. Override the default via ASK_OLLAMA_MODEL.
+  DEFAULT: process.env.ASK_OLLAMA_MODEL || "qwen3.6:27b",
 };
 
 export const API = {
@@ -20,9 +21,6 @@ export const ERROR_MESSAGES = {
 } as const;
 
 export const STATUS_MESSAGES = {
-  MODEL_NOT_FOUND_SWITCHING: "Ollama model not found, switching to fallback model...",
-  FALLBACK_RETRY: "Retrying with fallback model...",
-  FALLBACK_SUCCESS: "Fallback model completed successfully",
   OLLAMA_RESPONSE: "Ollama response:",
 } as const;
 

--- a/packages/ollama-mcp/src/tools/ask-ollama.tool.ts
+++ b/packages/ollama-mcp/src/tools/ask-ollama.tool.ts
@@ -13,7 +13,7 @@ const askOllamaArgsSchema = z.object({
     .string()
     .optional()
     .describe(
-      `DO NOT set this parameter. The tool automatically uses ${MODELS.DEFAULT} and falls back to ${MODELS.FALLBACK} if not found. Only set this if the user explicitly requests a specific model.`,
+      `DO NOT set this parameter unless the user explicitly requests a specific model. The tool uses ${MODELS.DEFAULT} by default; if the model isn't pulled locally it returns a clear "ollama pull" error rather than substituting another model.`,
     ),
   sessionId: z
     .string()
@@ -26,7 +26,7 @@ const askOllamaArgsSchema = z.object({
 export const askOllamaTool: UnifiedTool = {
   name: "ask-ollama",
   description:
-    "Send a prompt to a local Ollama LLM (defaults to qwen2.5-coder:7b with automatic fallback). Use for code review, second opinions, analysis, and AI-to-AI collaboration. Runs entirely locally — no API keys or network calls needed. Returns both human-readable text and a structured response (provider, model, sessionId, usage) via outputSchema.",
+    "Send a prompt to a local Ollama LLM (defaults to qwen3.6:27b; errors with a 'pull it first' message if the model isn't installed — no automatic substitution). Use for code review, second opinions, analysis, and AI-to-AI collaboration. Runs entirely locally — no API keys or network calls needed. Returns both human-readable text and a structured response (provider, model, sessionId, usage) via outputSchema.",
   zodSchema: askOllamaArgsSchema,
   outputSchema: askResponseSchema,
   annotations: {

--- a/packages/ollama-mcp/src/tools/simple-tools.ts
+++ b/packages/ollama-mcp/src/tools/simple-tools.ts
@@ -1,5 +1,6 @@
 import type { UnifiedTool } from "@ask-llm/shared";
 import { z } from "zod";
+import { MODELS } from "../constants.js";
 import { listModels } from "../utils/ollamaExecutor.js";
 
 const pingArgsSchema = z.object({
@@ -25,7 +26,7 @@ export const pingTool: UnifiedTool = {
     if (message) return message as string;
 
     const models = await listModels();
-    const modelList = models.length > 0 ? models.join(", ") : "none (run: ollama pull qwen3.6:27b)";
+    const modelList = models.length > 0 ? models.join(", ") : `none (run: ollama pull ${MODELS.DEFAULT})`;
     return `Pong from Ollama MCP Server! Available models: ${modelList}`;
   },
 };

--- a/packages/ollama-mcp/src/tools/simple-tools.ts
+++ b/packages/ollama-mcp/src/tools/simple-tools.ts
@@ -25,7 +25,7 @@ export const pingTool: UnifiedTool = {
     if (message) return message as string;
 
     const models = await listModels();
-    const modelList = models.length > 0 ? models.join(", ") : "none (run: ollama pull qwen2.5-coder:7b)";
+    const modelList = models.length > 0 ? models.join(", ") : "none (run: ollama pull qwen3.6:27b)";
     return `Pong from Ollama MCP Server! Available models: ${modelList}`;
   },
 };

--- a/packages/ollama-mcp/src/utils/__tests__/ollamaExecutor.test.ts
+++ b/packages/ollama-mcp/src/utils/__tests__/ollamaExecutor.test.ts
@@ -133,6 +133,15 @@ describe("model-not-found handling (no fallback)", () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
+  it("names the default model in the error when no model is specified", async () => {
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve(errorResponse(404, "model not found, try pulling it first")),
+    );
+
+    await expect(executeOllamaCLI({ prompt: "test" })).rejects.toThrow(new RegExp(`ollama pull ${MODELS.DEFAULT}`));
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
   it("does not retry on non-model errors (500)", async () => {
     mockFetch.mockImplementationOnce(() => Promise.resolve(errorResponse(500, "internal server error")));
 

--- a/packages/ollama-mcp/src/utils/__tests__/ollamaExecutor.test.ts
+++ b/packages/ollama-mcp/src/utils/__tests__/ollamaExecutor.test.ts
@@ -120,38 +120,17 @@ describe("response parsing", () => {
   });
 });
 
-describe("model-not-found fallback", () => {
-  it("retries with fallback model on 'not found' error", async () => {
-    mockFetch
-      .mockImplementationOnce(() =>
-        Promise.resolve(errorResponse(404, "model 'qwen2.5-coder:7b' not found, try pulling it first")),
-      )
-      .mockImplementationOnce(() => Promise.resolve(okResponse("Fallback response", MODELS.FALLBACK)));
-
-    const result = await executeOllamaCLI({ prompt: "test" });
-    expect(result.response).toContain("Fallback response");
-    expect(result.model).toBe(MODELS.FALLBACK);
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-
-    const secondBody = JSON.parse(mockFetch.mock.calls[1][1].body);
-    expect(secondBody.model).toBe(MODELS.FALLBACK);
-  });
-
-  it("does not retry if already using fallback model", async () => {
-    mockFetch.mockImplementationOnce(() => Promise.resolve(errorResponse(404, "model not found")));
-
-    await expect(executeOllamaCLI({ prompt: "test", model: MODELS.FALLBACK })).rejects.toThrow("model not found");
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-  });
-
-  it("throws combined error when both models fail", async () => {
-    mockFetch
-      .mockImplementationOnce(() => Promise.resolve(errorResponse(404, "model not found")))
-      .mockImplementationOnce(() => Promise.resolve(errorResponse(404, "fallback also missing")));
-
-    await expect(executeOllamaCLI({ prompt: "test" })).rejects.toThrow(
-      `${MODELS.DEFAULT} model not found, ${MODELS.FALLBACK} fallback also failed: fallback also missing`,
+describe("model-not-found handling (no fallback)", () => {
+  it("throws an actionable 'ollama pull' error on 'not found', without retrying", async () => {
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve(errorResponse(404, "model 'qwen3.6:27b' not found, try pulling it first")),
     );
+
+    await expect(executeOllamaCLI({ prompt: "test", model: "qwen3.6:27b" })).rejects.toThrow(
+      /ollama pull qwen3\.6:27b/,
+    );
+    // Exactly one request — no substitution to a different model.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   it("does not retry on non-model errors (500)", async () => {
@@ -191,22 +170,6 @@ describe("response caching", () => {
     await executeOllamaCLI({ prompt: "test", model: "model-b" });
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
-  });
-
-  it("does not cache fallback responses", async () => {
-    mockFetch
-      .mockImplementationOnce(() => Promise.resolve(errorResponse(404, "model not found")))
-      .mockImplementationOnce(() => Promise.resolve(okResponse("Fallback", MODELS.FALLBACK)));
-
-    await executeOllamaCLI({ prompt: "test" });
-
-    mockFetch
-      .mockImplementationOnce(() => Promise.resolve(errorResponse(404, "model not found")))
-      .mockImplementationOnce(() => Promise.resolve(okResponse("Fallback again", MODELS.FALLBACK)));
-
-    await executeOllamaCLI({ prompt: "test" });
-
-    expect(mockFetch).toHaveBeenCalledTimes(4);
   });
 });
 

--- a/packages/ollama-mcp/src/utils/ollamaExecutor.ts
+++ b/packages/ollama-mcp/src/utils/ollamaExecutor.ts
@@ -14,7 +14,6 @@ import {
   ERROR_MESSAGES,
   MODELS,
   OLLAMA_HOST_ENV,
-  STATUS_MESSAGES,
 } from "../constants.js";
 
 interface OllamaChatResponse {
@@ -47,12 +46,7 @@ export interface OllamaExecutorResult {
   usage: UsageStats | undefined;
 }
 
-function buildUsageStats(
-  data: OllamaChatResponse,
-  resolvedModel: string,
-  durationMs: number,
-  fellBack: boolean,
-): UsageStats {
+function buildUsageStats(data: OllamaChatResponse, resolvedModel: string, durationMs: number): UsageStats {
   return {
     provider: "ollama",
     model: data.model ?? resolvedModel,
@@ -61,7 +55,8 @@ function buildUsageStats(
     cachedTokens: undefined,
     thinkingTokens: undefined,
     durationMs,
-    fellBack,
+    // Local inference has no quota/model fallback, so this is always false.
+    fellBack: false,
   };
 }
 
@@ -178,7 +173,7 @@ export async function executeOllamaCLI(options: OllamaExecutorOptions): Promise<
         response: raw,
         model: data.model ?? model,
         sessionId: undefined,
-        usage: buildUsageStats(data, model, durationMs, false),
+        usage: buildUsageStats(data, model, durationMs),
       };
     }
 
@@ -199,46 +194,15 @@ export async function executeOllamaCLI(options: OllamaExecutorOptions): Promise<
       response,
       model: data.model ?? model,
       sessionId: stored?.id,
-      usage: buildUsageStats(data, model, durationMs, false),
+      usage: buildUsageStats(data, model, durationMs),
     };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
 
-    if (isModelNotFoundError(errorMessage) && model !== MODELS.FALLBACK) {
-      Logger.warn(`${STATUS_MESSAGES.MODEL_NOT_FOUND_SWITCHING} Falling back to ${MODELS.FALLBACK}.`);
-      Logger.debug(`Status: ${STATUS_MESSAGES.FALLBACK_RETRY}`);
-
-      const fallbackStartedAt = Date.now();
-      try {
-        const data = await callOllama(baseUrl, MODELS.FALLBACK, messages);
-        const content = data.message?.content ?? "";
-        const stored =
-          sessionId !== undefined
-            ? appendAndSaveSession(sessionId, "ollama", data.model ?? MODELS.FALLBACK, prompt, content)
-            : undefined;
-
-        const sessionLine = stored ? `\n\n[Session ID: ${stored.id}${stored.created ? " (new)" : ""}]` : "";
-        const response =
-          content + formatStats(data.prompt_eval_count, data.eval_count, data.model ?? MODELS.FALLBACK) + sessionLine;
-        const durationMs = Date.now() - fallbackStartedAt;
-
-        Logger.warn(`Successfully executed with ${MODELS.FALLBACK} fallback.`);
-        Logger.debug(`Status: ${STATUS_MESSAGES.FALLBACK_SUCCESS}`);
-
-        if (onProgress) {
-          onProgress(content.slice(-150));
-        }
-
-        return {
-          response,
-          model: data.model ?? MODELS.FALLBACK,
-          sessionId: stored?.id,
-          usage: buildUsageStats(data, MODELS.FALLBACK, durationMs, true),
-        };
-      } catch (fallbackError) {
-        const fallbackMsg = fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
-        throw new Error(`${MODELS.DEFAULT} model not found, ${MODELS.FALLBACK} fallback also failed: ${fallbackMsg}`);
-      }
+    if (isModelNotFoundError(errorMessage)) {
+      // Local inference: no automatic fallback to a different model — surface a clear,
+      // actionable error so the user pulls the model they actually intend to run.
+      throw new Error(`Ollama model "${model}" is not available locally. Pull it first: ollama pull ${model}`);
     }
 
     throw error;


### PR DESCRIPTION
## Summary

Two related changes to the Ollama provider:

1. **Default model bump:** `qwen2.5-coder:7b` → **`qwen3.6:27b`** (Qwen3.6 is the flagship-level local coding model; `27b` is its lightest Ollama variant, ~17 GB). Override via `ASK_OLLAMA_MODEL`.
2. **Remove the automatic model fallback.** Ollama is local — you explicitly pull the model you want, so silently substituting a *different* model on "model not found" was a footgun. The executor now throws a clear, actionable error (`Ollama model "<model>" is not available locally. Pull it first: ollama pull <model>`) instead of falling back.

### Behavior / API changes
- Removed the `FALLBACK` constant and the `ASK_OLLAMA_FALLBACK_MODEL` env var.
- Removed the fallback `STATUS_MESSAGES`; `buildUsageStats` no longer takes `fellBack` (Ollama's `usage.fellBack` is now always `false`).
- `ASK_OLLAMA_MODEL` still overrides the default.

> **Note:** qwen3.6's smallest variant is ~17 GB and needs a capable GPU / plenty of RAM — set `ASK_OLLAMA_MODEL` to a lighter tag if your machine can't run it.

### Tests
Rewrote the executor's fallback tests (`ollamaExecutor.test.ts`) to the new contract: model-not-found yields an `ollama pull` error and makes exactly **one** request (no substitution). Removed the obsolete fallback/combined-error tests. Docs swept (README, provider/concept/getting-started/troubleshooting pages, package READMEs). Changeset: `ask-ollama-mcp` minor, `ask-llm-mcp` patch.

## Test plan
- [x] `yarn test` — all packages green (incl. rewritten ollama executor tests)
- [x] `yarn lint` — clean (1 pre-existing unrelated `claude-plugin` warning)
- [x] Builds green; pre-push smoke passed against a locally-pulled model (`ASK_OLLAMA_MODEL` override, since the 17 GB default isn't pulled on the dev box)

🤖 Generated with [Claude Code](https://claude.com/claude-code)