### PR TITLE
chore(smoke): swap Gemini smoke leg for Antigravity (agy)

### DIFF
--- a/packages/antigravity-mcp/src/__tests__/integration.test.ts
+++ b/packages/antigravity-mcp/src/__tests__/integration.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { executeAntigravityCLI } from "../utils/antigravityExecutor.js";
+
+const SMOKE = !!process.env.SMOKE_TEST;
+// agy spawns a full agent (transcript-scraped response), so it's the slowest
+// provider — give it a generous ceiling under the executor's 300s default.
+const TIMEOUT = 240_000;
+
+describe.skipIf(!SMOKE)("Antigravity (agy) CLI integration", () => {
+  it(
+    "returns a non-empty response for a simple prompt",
+    async () => {
+      const result = await executeAntigravityCLI({
+        prompt: "What is 2+2? Reply with just the number.",
+      });
+
+      expect(result.response).toBeTruthy();
+      expect(result.response.length).toBeGreaterThan(0);
+      expect(result.response).toMatch(/4/);
+    },
+    TIMEOUT,
+  );
+});

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -2,17 +2,17 @@
 set -e
 set -o pipefail
 
-# When the smoke test itself burns the very Gemini/Codex quota that the next
-# push needs, we get a rate-limit-self-defeating loop: push N fails because
-# pushes 1..N-1 consumed the window. Detect quota/rate-limit errors and treat
-# them as skip-with-warning rather than a hard failure. Set FORCE_SMOKE=1 to
-# disable the escape and require all smokes to pass regardless. See ADR-051.
-# Match both raw CLI quota phrasings (gemini RESOURCE_EXHAUSTED; codex 0.137
-# "usage limit") AND the executors' OWN quota status text ("quota exceeded",
-# logged whenever isQuotaError fires + the fallback). The executor signal is
-# the robust anchor — the raw CLI message is caught internally during fallback
-# and may not reach the smoke output (ADR-117).
-QUOTA_PATTERN='rateLimitExceeded|RESOURCE_EXHAUSTED|TerminalQuotaError|exhausted your capacity|code=429|usage limit|quota exceeded'
+# When the smoke test itself burns the very provider quota that the next push
+# needs, we get a rate-limit-self-defeating loop: push N fails because pushes
+# 1..N-1 consumed the window. Detect quota/rate-limit errors and treat them as
+# skip-with-warning rather than a hard failure. Set FORCE_SMOKE=1 to disable the
+# escape and require all smokes to pass regardless. See ADR-051.
+# Match both raw CLI quota phrasings (codex 0.137 "usage limit"; antigravity
+# "subscription rate limit" / "too many requests") AND the executors' OWN quota
+# status text ("quota exceeded", logged whenever isQuotaError fires + the
+# fallback). The executor signal is the robust anchor — the raw CLI message is
+# caught internally during fallback and may not reach the smoke output (ADR-117).
+QUOTA_PATTERN='rateLimitExceeded|RESOURCE_EXHAUSTED|TerminalQuotaError|exhausted your capacity|code=429|usage limit|quota exceeded|rate limit|too many requests'
 
 # Live API calls occasionally fail with transient errors (network blips, brief
 # 5xx, upstream-API hiccups) that succeed on retry. Default behavior: one
@@ -92,8 +92,8 @@ fi
 echo "=== Smoke Tests ==="
 echo ""
 
-run_smoke "Ollama" "ask-ollama-mcp"
-run_smoke "Gemini" "ask-gemini-mcp"
-run_smoke "Codex"  "ask-codex-mcp"
+run_smoke "Ollama"      "ask-ollama-mcp"
+run_smoke "Antigravity" "ask-antigravity-mcp"
+run_smoke "Codex"       "ask-codex-mcp"
 
 echo "=== Smoke tests done (any quota-skipped providers were warned above) ==="


### PR DESCRIPTION
## Why
Gemini's individual Code Assist tier was **discontinued 2026-06-18** — an `oauth-personal` account now gets `IneligibleTierError` ("migrate to the Antigravity suite"). So the live Gemini smoke leg can never pass locally; the pre-push hook has effectively required `--no-verify` since then. Root-caused via systematic debugging: the claude-mem `SessionStart` hook banner (visible in `~/.gemini/settings.json`) was a *secondary symptom* masking the real auth failure — bypassing the hook still yields `IneligibleTierError`.

Replace the dead Gemini leg with **Antigravity (`agy`)** — the second-opinion provider the maintainer actually uses (`ask-antigravity-mcp`).

## Changes
- `scripts/smoke-test.sh`: `run_smoke "Antigravity" ask-antigravity-mcp` in place of Gemini. Extended `QUOTA_PATTERN` with `rate limit` / `too many requests` so an `agy` subscription rate limit is treated as skip-with-warning (ADR-051) rather than a hard failure — matching how Codex/quota errors are handled.
- New `packages/antigravity-mcp/src/__tests__/integration.test.ts` — `SMOKE_TEST`-gated live `agy` call (mirrors the ollama/codex integration tests; asserts the reply contains "4"). This package previously had no live smoke.

## Verification
- CI mode (`SMOKE_TEST` unset): the new integration test is `describe.skipIf`-skipped — **CI is unaffected** (it never runs live smoke legs anyway).
- Live locally: `SMOKE_TEST=1` antigravity suite **44/44 green** (real `agy` call).
- **Full pre-push smoke passed end-to-end** (Ollama 1.5b + Antigravity + Codex) — this branch was pushed **without** `--no-verify`.
- Repo lint (biome + `tsc --noEmit`) clean.

No changeset (dev-tooling + a new test file; no published runtime code changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)