### PR TITLE
fix(smoke): run under bash (pipefail portability) + let agy executor own its timeout

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 echo "Running smoke tests..."
 echo ""
 
-sh scripts/smoke-test.sh
+bash scripts/smoke-test.sh

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "yarn workspaces foreach -A --topological-dev run build",
     "test": "yarn workspaces foreach -A run test",
     "lint": "yarn workspaces foreach -A run lint",
-    "smoke": "sh scripts/smoke-test.sh",
+    "smoke": "bash scripts/smoke-test.sh",
     "docs:dev": "yarn workspace docs run dev",
     "docs:build": "yarn workspace docs run build",
     "docs:preview": "yarn workspace docs run preview",

--- a/packages/antigravity-mcp/src/__tests__/integration.test.ts
+++ b/packages/antigravity-mcp/src/__tests__/integration.test.ts
@@ -1,12 +1,26 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { executeAntigravityCLI } from "../utils/antigravityExecutor.js";
 
 const SMOKE = !!process.env.SMOKE_TEST;
-// agy spawns a full agent (transcript-scraped response), so it's the slowest
-// provider — give it a generous ceiling under the executor's 300s default.
-const TIMEOUT = 240_000;
+// Cap the executor's OWN timeout below the vitest ceiling so executeCommand owns
+// cancellation (SIGTERM→SIGKILL of agy) on a slow run. Without this, vitest's
+// default (or a ceiling under the executor's 300s default) would abort the test
+// first and leave the agy agent process running. agy spawns a full agent, so
+// it's the slowest provider — 180s is generous for a trivial prompt.
+const EXECUTOR_TIMEOUT_MS = 180_000;
+const TIMEOUT = EXECUTOR_TIMEOUT_MS + 20_000;
 
 describe.skipIf(!SMOKE)("Antigravity (agy) CLI integration", () => {
+  let prevTimeout: string | undefined;
+  beforeEach(() => {
+    prevTimeout = process.env.ASK_ANTIGRAVITY_TIMEOUT_MS;
+    process.env.ASK_ANTIGRAVITY_TIMEOUT_MS = String(EXECUTOR_TIMEOUT_MS);
+  });
+  afterEach(() => {
+    if (prevTimeout === undefined) delete process.env.ASK_ANTIGRAVITY_TIMEOUT_MS;
+    else process.env.ASK_ANTIGRAVITY_TIMEOUT_MS = prevTimeout;
+  });
+
   it(
     "returns a non-empty response for a simple prompt",
     async () => {

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,4 +1,9 @@
-#!/bin/sh
+#!/usr/bin/env bash
+# bash (not /bin/sh): `set -o pipefail` is a bash builtin — under a POSIX
+# /bin/sh like Debian/Ubuntu dash it errors out ("illegal option -o pipefail")
+# and, with `set -e`, aborts before any smoke runs. pipefail is load-bearing
+# here: the `yarn … | tee` pipeline below relies on it to surface yarn's exit
+# code. Callers (.husky/pre-push, package.json "smoke") invoke via `bash` too.
 set -e
 set -o pipefail
 


### PR DESCRIPTION
Two smoke-test robustness fixes from the codex-pair review of PR #216.

### 1. Bash so `pipefail` is portable (HIGH)
`scripts/smoke-test.sh` used `set -o pipefail` (a bash builtin) under `#!/bin/sh`, and both `.husky/pre-push` and the `package.json` `"smoke"` script invoked it as `sh scripts/smoke-test.sh`. Under a POSIX `/bin/sh` (Debian/Ubuntu `dash`) that errors `illegal option -o pipefail` and, with `set -e`, **aborts before any smoke runs**. `pipefail` is load-bearing — the `yarn … | tee` pipeline needs it to surface yarn's exit code (else a failing yarn + succeeding tee reports success). Works on macOS only because `/bin/sh` is bash there.
- Shebang → `#!/usr/bin/env bash`; both call sites → `bash`.

### 2. Antigravity test lets the executor own cancellation (MED)
The vitest ceiling (240s) was below `executeAntigravityCLI`'s 300s default, so a slow `agy` run would be aborted by vitest before `executeCommand` could SIGTERM/SIGKILL — leaking the agent process and yielding a bare "Test timed out" that `QUOTA_PATTERN` can't classify. Cap `ASK_ANTIGRAVITY_TIMEOUT_MS` (180s) below the vitest timeout (200s) so the executor's own timeout fires first and cleans up.

### Verification
- `bash -n` clean; `pipefail` confirmed under bash.
- CI mode: antigravity integration test still `describe.skipIf`-skipped (1 skipped).
- Live: `SMOKE_TEST=1` antigravity 44/44 green with the capped timeout.
- **Full pre-push smoke passed** — this branch pushed **without** `--no-verify`, now via `bash scripts/smoke-test.sh`.
- Repo lint (biome + tsc) clean.

No changeset (dev-tooling + test-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)