### PR TITLE
Fix Claude package release after npm name rejection

### DIFF
--- a/.changeset/scoped-claude-package.md
+++ b/.changeset/scoped-claude-package.md
@@ -1,0 +1,8 @@
+---
+"@anton-lykhoyda/ask-claude-mcp": patch
+"ask-llm-mcp": patch
+---
+
+Publish the Claude provider under the `@anton-lykhoyda` npm scope because npm
+rejects the unscoped name as too similar to an existing package. The executable
+remains `ask-claude-mcp`, and the unified server now imports the scoped package.

--- a/.github/verdaccio/config.yaml
+++ b/.github/verdaccio/config.yaml
@@ -9,6 +9,10 @@ uplinks:
   npmjs:
     url: https://registry.npmjs.org/
 packages:
+  '@anton-lykhoyda/*':
+    access: $all
+    publish: $all
+    # NO proxy: the scoped Claude tarball published locally must always win.
   'ask-*':
     access: $all
     publish: $all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,11 @@ jobs:
         set -eu
         npm cache clean --force
         for bin in ask-gemini-mcp ask-codex-mcp ask-claude-mcp ask-ollama-mcp ask-antigravity-mcp; do
-          npm install -g /tmp/tarballs/${bin}-*.tgz
+          tarball_prefix="$bin"
+          if [ "$bin" = "ask-claude-mcp" ]; then
+            tarball_prefix="anton-lykhoyda-ask-claude-mcp"
+          fi
+          npm install -g /tmp/tarballs/${tarball_prefix}-*.tgz
           printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0.0.0"}}}\n' \
             | timeout 20 "$bin" > /tmp/out.json 2> /tmp/err.txt || true
           if grep -q 'ERR_MODULE_NOT_FOUND' /tmp/err.txt; then echo "FAIL: $bin crashed at import"; cat /tmp/err.txt; exit 1; fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 permissions:
   contents: write       # changesets/action commits version bumps + creates tags; gh release create needs this too
   pull-requests: write  # changesets/action opens the Version Packages PR
+  issues: write         # failure reporter opens/comments on release-broken issues
   id-token: write       # OIDC for mcp-publisher (no token required)
 
 jobs:
@@ -186,11 +187,11 @@ jobs:
               ``,
               `Likely causes:`,
               `- NODE_AUTH_TOKEN expired, revoked, or wrong type (must be Classic "Automation" or 2FA-bypass Granular)`,
-              `- Package permission changed on npm (token no longer covers ask-gemini-mcp / ask-codex-mcp / ask-ollama-mcp / ask-antigravity-mcp / ask-llm-mcp)`,
+              `- Package permission changed on npm (token no longer covers ask-gemini-mcp / ask-codex-mcp / @anton-lykhoyda/ask-claude-mcp / ask-ollama-mcp / ask-antigravity-mcp / ask-llm-mcp)`,
               `- npm registry outage`,
               ``,
               `**Fix path:**`,
-              `1. Regenerate token at https://www.npmjs.com/settings/lykhoyda/tokens (Classic Automation or 2FA-bypass Granular)`,
+              `1. Regenerate token at https://www.npmjs.com/settings/anton-lykhoyda/tokens (Classic Automation or 2FA-bypass Granular)`,
               `2. Update NODE_AUTH_TOKEN at https://github.com/${context.repo.owner}/${context.repo.repo}/settings/secrets/actions`,
               `3. Re-trigger: gh workflow run release.yml`,
               `4. Close this issue once a release run succeeds.`,

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 |---------|------|---------|-----------|
 | [`ask-gemini-mcp`](https://www.npmjs.com/package/ask-gemini-mcp) | MCP Server | [![npm](https://img.shields.io/npm/v/ask-gemini-mcp)](https://www.npmjs.com/package/ask-gemini-mcp) | [![downloads](https://img.shields.io/npm/dt/ask-gemini-mcp)](https://www.npmjs.com/package/ask-gemini-mcp) |
 | [`ask-codex-mcp`](https://www.npmjs.com/package/ask-codex-mcp) | MCP Server | [![npm](https://img.shields.io/npm/v/ask-codex-mcp)](https://www.npmjs.com/package/ask-codex-mcp) | [![downloads](https://img.shields.io/npm/dt/ask-codex-mcp)](https://www.npmjs.com/package/ask-codex-mcp) |
-| [`ask-claude-mcp`](https://www.npmjs.com/package/ask-claude-mcp) | MCP Server | [![npm](https://img.shields.io/npm/v/ask-claude-mcp)](https://www.npmjs.com/package/ask-claude-mcp) | [![downloads](https://img.shields.io/npm/dt/ask-claude-mcp)](https://www.npmjs.com/package/ask-claude-mcp) |
+| [`@anton-lykhoyda/ask-claude-mcp`](https://www.npmjs.com/package/@anton-lykhoyda/ask-claude-mcp) | MCP Server | [![npm](https://img.shields.io/npm/v/@anton-lykhoyda/ask-claude-mcp)](https://www.npmjs.com/package/@anton-lykhoyda/ask-claude-mcp) | [![downloads](https://img.shields.io/npm/dt/@anton-lykhoyda/ask-claude-mcp)](https://www.npmjs.com/package/@anton-lykhoyda/ask-claude-mcp) |
 | [`ask-ollama-mcp`](https://www.npmjs.com/package/ask-ollama-mcp) | MCP Server | [![npm](https://img.shields.io/npm/v/ask-ollama-mcp)](https://www.npmjs.com/package/ask-ollama-mcp) | [![downloads](https://img.shields.io/npm/dt/ask-ollama-mcp)](https://www.npmjs.com/package/ask-ollama-mcp) |
 | [`ask-antigravity-mcp`](https://www.npmjs.com/package/ask-antigravity-mcp) | MCP Server | [![npm](https://img.shields.io/npm/v/ask-antigravity-mcp)](https://www.npmjs.com/package/ask-antigravity-mcp) | [![downloads](https://img.shields.io/npm/dt/ask-antigravity-mcp)](https://www.npmjs.com/package/ask-antigravity-mcp) |
 | [`ask-llm-mcp`](https://www.npmjs.com/package/ask-llm-mcp) | MCP Server | [![npm](https://img.shields.io/npm/v/ask-llm-mcp)](https://www.npmjs.com/package/ask-llm-mcp) | [![downloads](https://img.shields.io/npm/dt/ask-llm-mcp)](https://www.npmjs.com/package/ask-llm-mcp) |
@@ -128,7 +128,7 @@ args = ["-y", "ask-llm-mcp"]
 For the focused Codex → Claude second-opinion path:
 
 ```bash
-codex mcp add claude -- npx -y ask-claude-mcp
+codex mcp add claude -- npx -y @anton-lykhoyda/ask-claude-mcp
 ```
 
 **Any MCP Client** (STDIO transport):
@@ -136,7 +136,7 @@ codex mcp add claude -- npx -y ask-claude-mcp
 { "command": "npx", "args": ["-y", "ask-llm-mcp"] }
 ```
 
-Replace `ask-llm-mcp` with `ask-codex-mcp`, `ask-claude-mcp`, `ask-antigravity-mcp`, `ask-ollama-mcp`, or `ask-gemini-mcp` for a single provider.
+Replace `ask-llm-mcp` with `ask-codex-mcp`, `@anton-lykhoyda/ask-claude-mcp`, `ask-antigravity-mcp`, `ask-ollama-mcp`, or `ask-gemini-mcp` for a single provider.
 
 </details>
 
@@ -195,7 +195,7 @@ See the [plugin docs](https://lykhoyda.github.io/ask-llm/plugin/overview) for de
 | `ask-gemini-edit` | ask-gemini-mcp | Get structured OLD/NEW code edit blocks from Gemini |
 | `fetch-chunk` | ask-gemini-mcp | Retrieve chunks from cached large responses |
 | `ask-codex` | ask-codex-mcp | Send prompts to Codex CLI. GPT-5.6 Sol with Terra fallback; optional reasoning effort; native session resume via `sessionId` |
-| `ask-claude` | ask-claude-mcp | Send prompts to Claude Code CLI. Opus with Sonnet fallback; native sessions; Read/Glob/Grep-only workspace access |
+| `ask-claude` | @anton-lykhoyda/ask-claude-mcp | Send prompts to Claude Code CLI. Opus with Sonnet fallback; native sessions; Read/Glob/Grep-only workspace access |
 | `ask-ollama` | ask-ollama-mcp | Send prompts to local Ollama. Fully private, zero cost. Server-side conversation replay via `sessionId` |
 | `ask-antigravity` | ask-antigravity-mcp | Send a prompt to Google Antigravity (`agy`) for a subscription-backed second opinion. Experimental; one-shot |
 | `ask-llm` | ask-llm-mcp | Unified orchestrator — pick provider per call. Fan out to all installed providers |

--- a/apps/docs/.vitepress/components/SetupTabs.vue
+++ b/apps/docs/.vitepress/components/SetupTabs.vue
@@ -179,7 +179,7 @@ interface ProviderConfig {
 const providerConfigs: Record<string, ProviderConfig> = {
   gemini: { pkg: "ask-gemini-mcp", serverName: "gemini-cli" },
   codex: { pkg: "ask-codex-mcp", serverName: "codex-cli" },
-  claude: { pkg: "ask-claude-mcp", serverName: "claude" },
+  claude: { pkg: "@anton-lykhoyda/ask-claude-mcp", serverName: "claude" },
   ollama: { pkg: "ask-ollama-mcp", serverName: "ollama" },
   antigravity: { pkg: "ask-antigravity-mcp", serverName: "antigravity" },
   unified: { pkg: "ask-llm-mcp", serverName: "ask-llm" },

--- a/apps/docs/getting-started.md
+++ b/apps/docs/getting-started.md
@@ -45,7 +45,7 @@ You can install one or all of them. The MCP server auto-detects which providers 
 
 The recommended package is **`ask-llm-mcp`** — the unified orchestrator that auto-detects all installed providers and exposes them through a single `ask-llm` MCP tool plus `multi-llm`, `get-usage-stats`, `diagnose`, and `ping`.
 
-If you only want one provider, you can also install the per-provider packages directly: `ask-codex-mcp`, `ask-claude-mcp`, `ask-antigravity-mcp`, `ask-ollama-mcp`, `ask-gemini-mcp`. They expose provider-specific tools (`ask-codex`, `ask-claude`, `ask-antigravity` (subscription-backed via `agy`), `ask-ollama`, and `ask-gemini` with `@` file syntax + sandbox + edit mode).
+If you only want one provider, you can also install the per-provider packages directly: `ask-codex-mcp`, `@anton-lykhoyda/ask-claude-mcp`, `ask-antigravity-mcp`, `ask-ollama-mcp`, `ask-gemini-mcp`. They expose provider-specific tools (`ask-codex`, `ask-claude`, `ask-antigravity` (subscription-backed via `agy`), `ask-ollama`, and `ask-gemini` with `@` file syntax + sandbox + edit mode).
 
 ### Option A: Claude Code (Recommended)
 
@@ -60,7 +60,7 @@ claude mcp add --scope user ollama      -- npx -y ask-ollama-mcp
 claude mcp add --scope user gemini      -- npx -y ask-gemini-mcp
 ```
 
-Claude is not listed as a Claude Code per-provider registration because nested Claude sessions are unsupported. From Codex, register it with `codex mcp add claude -- npx -y ask-claude-mcp`.
+Claude is not listed as a Claude Code per-provider registration because nested Claude sessions are unsupported. From Codex, register it with `codex mcp add claude -- npx -y @anton-lykhoyda/ask-claude-mcp`.
 
 ### Option B: Claude Desktop
 

--- a/apps/docs/index.md
+++ b/apps/docs/index.md
@@ -47,7 +47,7 @@ hero:
   <a href="/ask-llm/providers/claude" class="provider-card" data-provider="claude">
     <span class="provider-name">Claude</span>
     <span class="provider-desc">Anthropic Claude Code CLI (Opus → Sonnet). The reverse path for Codex and other MCP clients to request a read-only Claude second opinion.</span>
-    <span class="provider-pkg">npx ask-claude-mcp</span>
+    <span class="provider-pkg">npx @anton-lykhoyda/ask-claude-mcp</span>
   </a>
   <a href="/ask-llm/providers/antigravity" class="provider-card" data-provider="antigravity">
     <span class="provider-name">Antigravity</span>

--- a/apps/docs/installation.md
+++ b/apps/docs/installation.md
@@ -23,7 +23,7 @@ Multiple ways to install Ask LLM, depending on whether you want the unified orch
 |---------|---------|---------------|
 | [`ask-llm-mcp`](https://www.npmjs.com/package/ask-llm-mcp) | **Unified orchestrator (recommended)** — auto-detects all installed providers | `ask-llm`, `multi-llm`, `get-usage-stats`, `diagnose`, `ping` |
 | [`ask-codex-mcp`](https://www.npmjs.com/package/ask-codex-mcp) | Codex-only | `ask-codex`, `get-usage-stats`, `ping` |
-| [`ask-claude-mcp`](https://www.npmjs.com/package/ask-claude-mcp) | Claude-only — designed for Codex and other non-Claude hosts; read-only file tools | `ask-claude`, `get-usage-stats`, `ping` |
+| [`@anton-lykhoyda/ask-claude-mcp`](https://www.npmjs.com/package/@anton-lykhoyda/ask-claude-mcp) | Claude-only — designed for Codex and other non-Claude hosts; read-only file tools | `ask-claude`, `get-usage-stats`, `ping` |
 | [`ask-antigravity-mcp`](https://www.npmjs.com/package/ask-antigravity-mcp) | Antigravity-only (experimental) — subscription-backed via `agy` | `ask-antigravity`, `get-usage-stats`, `ping` |
 | [`ask-ollama-mcp`](https://www.npmjs.com/package/ask-ollama-mcp) | Ollama-only (local) | `ask-ollama`, `get-usage-stats`, `ping` |
 | [`ask-gemini-mcp`](https://www.npmjs.com/package/ask-gemini-mcp) | Gemini-only — full feature set including `@` file syntax, sandbox, edit mode. [Enterprise-gated from 2026-06-18](/providers/gemini) | `ask-gemini`, `ask-gemini-edit`, `fetch-chunk`, `get-usage-stats`, `ping` |
@@ -68,7 +68,7 @@ The unified server suppresses its Claude provider when the MCP host is already C
 For the reverse collaboration path—Codex asking Claude for a second opinion:
 
 ```bash
-codex mcp add claude -- npx -y ask-claude-mcp
+codex mcp add claude -- npx -y @anton-lykhoyda/ask-claude-mcp
 ```
 
 Claude runs in safe mode with only `Read`, `Glob`, and `Grep`; Codex remains responsible for edits.

--- a/apps/docs/providers/claude.md
+++ b/apps/docs/providers/claude.md
@@ -4,7 +4,7 @@ description: Let Codex and other MCP clients consult Anthropic Claude Code CLI f
 
 # Claude
 
-Bridge Codex CLI, Cursor, OpenCode, or another MCP client with Anthropic's Claude Code CLI. This is the reverse collaboration path: Claude can ask Codex through `ask-codex-mcp`, while Codex can ask Claude through `ask-claude-mcp`.
+Bridge Codex CLI, Cursor, OpenCode, or another MCP client with Anthropic's Claude Code CLI. This is the reverse collaboration path: Claude can ask Codex through `ask-codex-mcp`, while Codex can ask Claude through `@anton-lykhoyda/ask-claude-mcp`.
 
 > **Best for:** getting an independent Claude review while Codex or another model is your primary agent.
 > **Not for:** use from inside Claude Code itself. Claude Code rejects nested Claude sessions, so the unified orchestrator suppresses this provider when Claude Code is the MCP host.
@@ -16,7 +16,7 @@ Bridge Codex CLI, Cursor, OpenCode, or another MCP client with Anthropic's Claud
 Or install globally:
 
 ```bash
-npm install -g ask-claude-mcp
+npm install -g @anton-lykhoyda/ask-claude-mcp
 ```
 
 ## Prerequisites
@@ -66,5 +66,5 @@ The JSON response includes Claude's `session_id`. Pass it back as `sessionId` on
 
 ## npm
 
-- **Package:** [ask-claude-mcp](https://www.npmjs.com/package/ask-claude-mcp)
+- **Package:** [@anton-lykhoyda/ask-claude-mcp](https://www.npmjs.com/package/@anton-lykhoyda/ask-claude-mcp)
 - **Binary:** `ask-claude-mcp`

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -12,7 +12,7 @@ Ask LLM is a monorepo with 6 published npm packages + 1 shared library + 1 Claud
 packages/shared/         @ask-llm/shared      Internal shared code (inlined into each MCP at build — registry, executor, sessions, usage)
 packages/gemini-mcp/     ask-gemini-mcp       MCP server for Google Gemini CLI
 packages/codex-mcp/      ask-codex-mcp        MCP server for OpenAI Codex CLI
-packages/claude-mcp/     ask-claude-mcp       MCP server for Anthropic Claude Code CLI
+packages/claude-mcp/     @anton-lykhoyda/ask-claude-mcp       MCP server for Anthropic Claude Code CLI
 packages/ollama-mcp/     ask-ollama-mcp       MCP server for local Ollama LLMs
 packages/antigravity-mcp ask-antigravity-mcp  MCP server for Google Antigravity CLI (agy)
 packages/llm-mcp/        ask-llm-mcp          Unified MCP server (auto-detects providers)
@@ -103,7 +103,7 @@ claude mcp add antigravity -- npx -y ask-antigravity-mcp
 ```toml
 [mcp_servers.claude]
 command = "npx"
-args = ["-y", "ask-claude-mcp"]
+args = ["-y", "@anton-lykhoyda/ask-claude-mcp"]
 ```
 
 The block above registers the focused Codex → Claude second-opinion path. Add a `[mcp_servers.<name>]` section per provider, or register the unified `ask-llm-mcp` to expose all installed providers through one server.
@@ -120,7 +120,7 @@ The block above registers the focused Codex → Claude second-opinion path. Add 
 }
 ```
 
-The `ask-gemini-mcp` argument above is just an example — the same STDIO block works for any package (`ask-codex-mcp`, `ask-claude-mcp`, `ask-ollama-mcp`, `ask-antigravity-mcp`, or the unified `ask-llm-mcp`).
+The `ask-gemini-mcp` argument above is just an example — the same STDIO block works for any package (`ask-codex-mcp`, `@anton-lykhoyda/ask-claude-mcp`, `ask-ollama-mcp`, `ask-antigravity-mcp`, or the unified `ask-llm-mcp`).
 
 ### Unified Server (all providers in one)
 
@@ -199,7 +199,7 @@ Get structured, read-only code edits from Codex via `--output-schema`. Codex ana
 
 Send prompts to Anthropic Claude Code CLI from Codex or another non-Claude MCP host. Claude runs in safe mode with only Read, Glob, and Grep tools; it cannot execute commands or modify files.
 
-- **Package:** ask-claude-mcp
+- **Package:** @anton-lykhoyda/ask-claude-mcp
 - **Parameters:**
   - `prompt` (string, required): The question, review, or analysis task. Delivered over stdin.
   - `model` (string, optional): Default `opus`; Claude Code natively falls back to `sonnet` when unavailable or overloaded.
@@ -442,7 +442,7 @@ All MCP servers handle errors gracefully:
 - Docs: https://lykhoyda.github.io/ask-llm/
 - npm (gemini): https://www.npmjs.com/package/ask-gemini-mcp
 - npm (codex): https://www.npmjs.com/package/ask-codex-mcp
-- npm (claude): https://www.npmjs.com/package/ask-claude-mcp
+- npm (claude): https://www.npmjs.com/package/@anton-lykhoyda/ask-claude-mcp
 - npm (ollama): https://www.npmjs.com/package/ask-ollama-mcp
 - npm (antigravity): https://www.npmjs.com/package/ask-antigravity-mcp
 - npm (unified): https://www.npmjs.com/package/ask-llm-mcp

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -8,7 +8,7 @@ Ask LLM provides Model Context Protocol (MCP) servers that let any MCP-compatibl
 
 - `ask-gemini-mcp`: MCP server for Google Gemini CLI. 1M+ token context. Default model: gemini-3.1-pro-preview → gemini-3.5-flash on quota. (Enterprise-gated since 2026-06-18.)
 - `ask-codex-mcp`: MCP server for OpenAI Codex CLI. Default model: gpt-5.6-sol → gpt-5.6-terra on quota.
-- `ask-claude-mcp`: MCP server for Anthropic Claude Code CLI, intended for Codex and other non-Claude hosts. Default: opus → sonnet. Native sessions; Read/Glob/Grep-only tools.
+- `@anton-lykhoyda/ask-claude-mcp`: MCP server for Anthropic Claude Code CLI, intended for Codex and other non-Claude hosts. Default: opus → sonnet. Native sessions; Read/Glob/Grep-only tools.
 - `ask-ollama-mcp`: MCP server for local Ollama. No API keys, fully private. Default model: qwen3.6:27b (no fallback).
 - `ask-antigravity-mcp`: MCP server for Google Antigravity CLI (`agy`). Subscription-backed second opinion. Default model: Gemini 3.1 Pro (High) → Gemini 3.5 Flash (High) on rate limit.
 - `ask-llm-mcp`: Unified server — auto-detects installed providers and registers all available tools.
@@ -25,7 +25,7 @@ claude mcp add antigravity -- npx -y ask-antigravity-mcp
 claude mcp add ask-llm -- npx -y ask-llm-mcp
 
 # Reverse path: Codex asks Claude
-codex mcp add claude -- npx -y ask-claude-mcp
+codex mcp add claude -- npx -y @anton-lykhoyda/ask-claude-mcp
 ```
 
 ## Tools
@@ -37,7 +37,7 @@ codex mcp add claude -- npx -y ask-claude-mcp
 | fetch-chunk | ask-gemini-mcp | cacheKey (required), chunkIndex (required) | Retrieve subsequent chunks from cached large responses. |
 | ask-codex | ask-codex-mcp | prompt (required), model (optional), reasoningEffort (optional), sessionId (optional), includeDirs (optional), preferred (optional) | Send prompts to Codex CLI. Defaults to gpt-5.6-sol at medium effort with gpt-5.6-terra quota fallback; /codex-review and /brainstorm use high. sessionId resumes a Codex thread. |
 | ask-codex-edit | ask-codex-mcp | prompt (required), model (optional), sessionId (optional), includeDirs (optional) | Get read-only structured code edits from Codex (`--output-schema`). |
-| ask-claude | ask-claude-mcp | prompt (required), model (optional), sessionId (optional), includeDirs (optional) | Send a read-only second-opinion request to Claude Code CLI. Not available from a Claude Code host because nested sessions are unsupported. |
+| ask-claude | @anton-lykhoyda/ask-claude-mcp | prompt (required), model (optional), sessionId (optional), includeDirs (optional) | Send a read-only second-opinion request to Claude Code CLI. Not available from a Claude Code host because nested sessions are unsupported. |
 | ask-ollama | ask-ollama-mcp | prompt (required), model (optional), sessionId (optional) | Send prompts to a local Ollama model. |
 | ask-antigravity | ask-antigravity-mcp | prompt (required), includeDirs (optional) | Subscription-backed second opinion via Google Antigravity (`agy`). Model is env-controlled (ASK_ANTIGRAVITY_MODEL), not a per-call param. |
 | ask-llm | ask-llm-mcp | prompt (required), provider (required), model (optional), sessionId (optional) | Route a prompt to a chosen installed provider (gemini/codex/claude/ollama/antigravity). |
@@ -66,7 +66,7 @@ Skills: /multi-review, /gemini-review, /codex-review, /ollama-review, /antigravi
 - Full reference for AI agents: https://lykhoyda.github.io/ask-llm/llms-full.txt
 - npm (gemini): https://www.npmjs.com/package/ask-gemini-mcp
 - npm (codex): https://www.npmjs.com/package/ask-codex-mcp
-- npm (claude): https://www.npmjs.com/package/ask-claude-mcp
+- npm (claude): https://www.npmjs.com/package/@anton-lykhoyda/ask-claude-mcp
 - npm (ollama): https://www.npmjs.com/package/ask-ollama-mcp
 - npm (antigravity): https://www.npmjs.com/package/ask-antigravity-mcp
 - npm (unified): https://www.npmjs.com/package/ask-llm-mcp

--- a/apps/docs/resources/faq.md
+++ b/apps/docs/resources/faq.md
@@ -68,7 +68,7 @@ Yes — any STDIO MCP client works. See [Installation](/installation) for client
 
 ### Can Codex ask Claude for a second opinion?
 
-Yes. Register the dedicated provider with `codex mcp add claude -- npx -y ask-claude-mcp`, then ask Codex to call `ask-claude`. The Claude subprocess is restricted to Read, Glob, and Grep; Codex applies any resulting changes. The provider is not exposed when Claude Code itself is the host because Claude Code rejects nested sessions.
+Yes. Register the dedicated provider with `codex mcp add claude -- npx -y @anton-lykhoyda/ask-claude-mcp`, then ask Codex to call `ask-claude`. The Claude subprocess is restricted to Read, Glob, and Grep; Codex applies any resulting changes. The provider is not exposed when Claude Code itself is the host because Claude Code rejects nested sessions.
 
 ---
 

--- a/apps/docs/usage/how-to-ask.md
+++ b/apps/docs/usage/how-to-ask.md
@@ -84,7 +84,7 @@ Self-diagnosis: Node version, PATH resolution, provider CLI presence + versions.
 
 Zero-cost connection test. Lists detected providers.
 
-### Per-provider servers (`ask-gemini-mcp`, `ask-codex-mcp`, `ask-claude-mcp`, `ask-ollama-mcp`, `ask-antigravity-mcp`)
+### Per-provider servers (`ask-gemini-mcp`, `ask-codex-mcp`, `@anton-lykhoyda/ask-claude-mcp`, `ask-ollama-mcp`, `ask-antigravity-mcp`)
 
 Each per-provider server exposes its provider's `ask-*` tool with the richer per-provider parameter set, plus the shared `get-usage-stats` and `ping`.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -79,7 +79,7 @@ Interactive prompt asks (a) which packages your change affects, (b) the bump typ
 
 **You don't need to manually bump `package.json` versions.** The bot does that.
 
-You can pick "patch" for any package even if your change doesn't directly touch it. IMPORTANT (ADR-119): `@ask-llm/shared` is private and INLINED into each MCP's `dist/` at build time by tsdown — and because shared is only a devDependency of the MCPs, the changesets internal-dependents cascade does NOT fire for it (verified empirically 2026-06-10). Any change to `packages/shared/src/**` MUST ship with a changeset that explicitly lists all six publishable packages (`ask-gemini-mcp`, `ask-codex-mcp`, `ask-claude-mcp`, `ask-ollama-mcp`, `ask-antigravity-mcp`, `ask-llm-mcp`) — otherwise the fix never reaches npm. CI enforces this via `scripts/check-shared-changeset.mjs`.
+You can pick "patch" for any package even if your change doesn't directly touch it. IMPORTANT (ADR-119): `@ask-llm/shared` is private and INLINED into each MCP's `dist/` at build time by tsdown — and because shared is only a devDependency of the MCPs, the changesets internal-dependents cascade does NOT fire for it (verified empirically 2026-06-10). Any change to `packages/shared/src/**` MUST ship with a changeset that explicitly lists all six publishable packages (`ask-gemini-mcp`, `ask-codex-mcp`, `@anton-lykhoyda/ask-claude-mcp`, `ask-ollama-mcp`, `ask-antigravity-mcp`, `ask-llm-mcp`) — otherwise the fix never reaches npm. CI enforces this via `scripts/check-shared-changeset.mjs`.
 
 `@ask-llm/plugin` is excluded from changesets (it's distributed via the Claude Code plugin marketplace, not npm; tracked in `.claude-plugin/marketplace.json`).
 

--- a/packages/antigravity-mcp/CHANGELOG.md
+++ b/packages/antigravity-mcp/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Patch Changes
 
 - [#222](https://github.com/Lykhoyda/ask-llm/pull/222) [`ae7780c`](https://github.com/Lykhoyda/ask-llm/commit/ae7780c67327224eea760ade42b61df3d9a32b54) Thanks [@Lykhoyda](https://github.com/Lykhoyda)! - Add a first-class Claude Code CLI provider so Codex and other MCP clients can
-  ask Claude for a read-only second opinion. The new `ask-claude-mcp` package
+  ask Claude for a read-only second opinion. The new `@anton-lykhoyda/ask-claude-mcp` package
   supports native sessions, Opus-to-Sonnet fallback, usage reporting, relative
   context directories, and a hard Read/Glob/Grep-only tool boundary. The unified
   orchestrator now auto-detects Claude and can include it in `ask-llm`,

--- a/packages/claude-mcp/CHANGELOG.md
+++ b/packages/claude-mcp/CHANGELOG.md
@@ -1,11 +1,11 @@
-# ask-claude-mcp
+# @anton-lykhoyda/ask-claude-mcp
 
 ## 0.1.0
 
 ### Minor Changes
 
 - [#222](https://github.com/Lykhoyda/ask-llm/pull/222) [`ae7780c`](https://github.com/Lykhoyda/ask-llm/commit/ae7780c67327224eea760ade42b61df3d9a32b54) Thanks [@Lykhoyda](https://github.com/Lykhoyda)! - Add a first-class Claude Code CLI provider so Codex and other MCP clients can
-  ask Claude for a read-only second opinion. The new `ask-claude-mcp` package
+  ask Claude for a read-only second opinion. The new `@anton-lykhoyda/ask-claude-mcp` package
   supports native sessions, Opus-to-Sonnet fallback, usage reporting, relative
   context directories, and a hard Read/Glob/Grep-only tool boundary. The unified
   orchestrator now auto-detects Claude and can include it in `ask-llm`,

--- a/packages/claude-mcp/README.md
+++ b/packages/claude-mcp/README.md
@@ -1,14 +1,14 @@
-# ask-claude-mcp
+# @anton-lykhoyda/ask-claude-mcp
 
 MCP server for consulting Anthropic Claude Code CLI from Codex CLI, Cursor,
 OpenCode, and other MCP clients. It fills the reverse collaboration path:
 Claude can ask Codex through `ask-codex-mcp`, and Codex can ask Claude through
-`ask-claude-mcp`.
+`@anton-lykhoyda/ask-claude-mcp`.
 
 ## Install for Codex CLI
 
 ```bash
-codex mcp add claude -- npx -y ask-claude-mcp
+codex mcp add claude -- npx -y @anton-lykhoyda/ask-claude-mcp
 ```
 
 Then ask Codex to use `ask-claude` for an independent review or second opinion.

--- a/packages/claude-mcp/package.json
+++ b/packages/claude-mcp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ask-claude-mcp",
+  "name": "@anton-lykhoyda/ask-claude-mcp",
   "version": "0.1.0",
   "mcpName": "io.github.Lykhoyda/ask-claude",
   "description": "MCP server for consulting Anthropic Claude Code CLI from Codex and other MCP clients",

--- a/packages/claude-mcp/server.json
+++ b/packages/claude-mcp/server.json
@@ -10,7 +10,7 @@
   "packages": [
     {
       "registryType": "npm",
-      "identifier": "ask-claude-mcp",
+      "identifier": "@anton-lykhoyda/ask-claude-mcp",
       "version": "0.0.1",
       "transport": {
         "type": "stdio"

--- a/packages/claude-mcp/src/__tests__/smoke.test.ts
+++ b/packages/claude-mcp/src/__tests__/smoke.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { MODELS } from "../constants.js";
 import { toolRegistry } from "../tools/index.js";
 
-describe("ask-claude-mcp smoke", () => {
+describe("@anton-lykhoyda/ask-claude-mcp smoke", () => {
   it("registers ask-claude and ping", () => {
     expect(toolRegistry.map((tool) => tool.name).sort()).toEqual(["ask-claude", "ping"]);
   });

--- a/packages/claude-mcp/src/index.ts
+++ b/packages/claude-mcp/src/index.ts
@@ -15,7 +15,7 @@ function readPackageJson(): { name: string; version: string } {
     const require = createRequire(import.meta.url);
     return require("../package.json") as { name: string; version: string };
   } catch {
-    return { name: "ask-claude-mcp", version: "0.0.0" };
+    return { name: "@anton-lykhoyda/ask-claude-mcp", version: "0.0.0" };
   }
 }
 
@@ -44,9 +44,9 @@ registerTools({
 registerSessionUsageResource(server, sessionUsage);
 
 export async function startServer() {
-  Logger.debug("init ask-claude-mcp");
+  Logger.debug("init @anton-lykhoyda/ask-claude-mcp");
   Logger.checkNodeVersion();
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  Logger.debug("ask-claude-mcp listening on stdio");
+  Logger.debug("@anton-lykhoyda/ask-claude-mcp listening on stdio");
 }

--- a/packages/codex-mcp/CHANGELOG.md
+++ b/packages/codex-mcp/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Patch Changes
 
 - [#222](https://github.com/Lykhoyda/ask-llm/pull/222) [`ae7780c`](https://github.com/Lykhoyda/ask-llm/commit/ae7780c67327224eea760ade42b61df3d9a32b54) Thanks [@Lykhoyda](https://github.com/Lykhoyda)! - Add a first-class Claude Code CLI provider so Codex and other MCP clients can
-  ask Claude for a read-only second opinion. The new `ask-claude-mcp` package
+  ask Claude for a read-only second opinion. The new `@anton-lykhoyda/ask-claude-mcp` package
   supports native sessions, Opus-to-Sonnet fallback, usage reporting, relative
   context directories, and a hard Read/Glob/Grep-only tool boundary. The unified
   orchestrator now auto-detects Claude and can include it in `ask-llm`,

--- a/packages/gemini-mcp/CHANGELOG.md
+++ b/packages/gemini-mcp/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Patch Changes
 
 - [#222](https://github.com/Lykhoyda/ask-llm/pull/222) [`ae7780c`](https://github.com/Lykhoyda/ask-llm/commit/ae7780c67327224eea760ade42b61df3d9a32b54) Thanks [@Lykhoyda](https://github.com/Lykhoyda)! - Add a first-class Claude Code CLI provider so Codex and other MCP clients can
-  ask Claude for a read-only second opinion. The new `ask-claude-mcp` package
+  ask Claude for a read-only second opinion. The new `@anton-lykhoyda/ask-claude-mcp` package
   supports native sessions, Opus-to-Sonnet fallback, usage reporting, relative
   context directories, and a hard Read/Glob/Grep-only tool boundary. The unified
   orchestrator now auto-detects Claude and can include it in `ask-llm`,

--- a/packages/llm-mcp/CHANGELOG.md
+++ b/packages/llm-mcp/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Minor Changes
 
 - [#222](https://github.com/Lykhoyda/ask-llm/pull/222) [`ae7780c`](https://github.com/Lykhoyda/ask-llm/commit/ae7780c67327224eea760ade42b61df3d9a32b54) Thanks [@Lykhoyda](https://github.com/Lykhoyda)! - Add a first-class Claude Code CLI provider so Codex and other MCP clients can
-  ask Claude for a read-only second opinion. The new `ask-claude-mcp` package
+  ask Claude for a read-only second opinion. The new `@anton-lykhoyda/ask-claude-mcp` package
   supports native sessions, Opus-to-Sonnet fallback, usage reporting, relative
   context directories, and a hard Read/Glob/Grep-only tool boundary. The unified
   orchestrator now auto-detects Claude and can include it in `ask-llm`,
@@ -21,7 +21,7 @@
   `reasoningEffort`; general calls preserve `medium`, while `/codex-review` and
   `/brainstorm` use `high`.
 - Updated dependencies [[`ae7780c`](https://github.com/Lykhoyda/ask-llm/commit/ae7780c67327224eea760ade42b61df3d9a32b54), [`ae7780c`](https://github.com/Lykhoyda/ask-llm/commit/ae7780c67327224eea760ade42b61df3d9a32b54)]:
-  - ask-claude-mcp@0.1.0
+  - @anton-lykhoyda/ask-claude-mcp@0.1.0
   - ask-gemini-mcp@1.6.14
   - ask-codex-mcp@0.6.1
   - ask-ollama-mcp@0.5.1

--- a/packages/llm-mcp/package.json
+++ b/packages/llm-mcp/package.json
@@ -60,9 +60,9 @@
     "LICENSE"
   ],
   "dependencies": {
+    "@anton-lykhoyda/ask-claude-mcp": "^0.1.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "ask-antigravity-mcp": "^0.4.1",
-    "ask-claude-mcp": "^0.1.0",
     "ask-codex-mcp": "^0.6.1",
     "ask-gemini-mcp": "^1.6.14",
     "ask-ollama-mcp": "^0.5.1",

--- a/packages/llm-mcp/src/__tests__/availability.test.ts
+++ b/packages/llm-mcp/src/__tests__/availability.test.ts
@@ -22,7 +22,7 @@ describe("PROVIDERS registry", () => {
   it("registers Claude as a Claude Code CLI-backed provider", () => {
     expect(PROVIDERS.claude).toBeDefined();
     expect(PROVIDERS.claude.command).toBe("claude");
-    expect(PROVIDERS.claude.executorModule).toBe("ask-claude-mcp/executor");
+    expect(PROVIDERS.claude.executorModule).toBe("@anton-lykhoyda/ask-claude-mcp/executor");
     expect(PROVIDERS.claude.executorFn).toBe("executeClaudeCLI");
     expect(PROVIDERS.claude.disabledWhenEnvVar).toBe("CLAUDECODE");
   });

--- a/packages/llm-mcp/src/__tests__/constants.test.ts
+++ b/packages/llm-mcp/src/__tests__/constants.test.ts
@@ -15,7 +15,7 @@ describe("provider registry drift guard", () => {
   it("registers Claude Code as the Claude provider executor", () => {
     expect(PROVIDERS.claude).toMatchObject({
       command: "claude",
-      executorModule: "ask-claude-mcp/executor",
+      executorModule: "@anton-lykhoyda/ask-claude-mcp/executor",
       executorFn: "executeClaudeCLI",
       defaultModel: "opus",
       disabledWhenEnvVar: "CLAUDECODE",

--- a/packages/llm-mcp/src/__tests__/smoke.test.ts
+++ b/packages/llm-mcp/src/__tests__/smoke.test.ts
@@ -12,7 +12,7 @@ vi.mock("ask-codex-mcp/executor", () => ({
   executeCodexCLI: vi.fn().mockResolvedValue({ response: "codex response", threadId: undefined }),
 }));
 
-vi.mock("ask-claude-mcp/executor", () => ({
+vi.mock("@anton-lykhoyda/ask-claude-mcp/executor", () => ({
   executeClaudeCLI: vi.fn().mockResolvedValue({ response: "claude response", sessionId: undefined }),
 }));
 
@@ -25,7 +25,7 @@ vi.mock("ask-antigravity-mcp/executor", () => ({
   executeAntigravityCLI: vi.fn().mockResolvedValue({ response: "antigravity response" }),
 }));
 
-import { executeClaudeCLI } from "ask-claude-mcp/executor";
+import { executeClaudeCLI } from "@anton-lykhoyda/ask-claude-mcp/executor";
 import { executeCodexCLI } from "ask-codex-mcp/executor";
 import { executeGeminiCLI } from "ask-gemini-mcp/executor";
 import { executeOllamaCLI, isProviderAvailable as mockIsOllamaAvailable } from "ask-ollama-mcp/executor";

--- a/packages/llm-mcp/src/constants.ts
+++ b/packages/llm-mcp/src/constants.ts
@@ -31,7 +31,7 @@ export const PROVIDERS: Record<string, ProviderConfig> = {
   claude: {
     name: "Claude",
     command: "claude",
-    executorModule: "ask-claude-mcp/executor",
+    executorModule: "@anton-lykhoyda/ask-claude-mcp/executor",
     executorFn: "executeClaudeCLI",
     defaultModel: "opus",
     disabledWhenEnvVar: "CLAUDECODE",

--- a/packages/llm-mcp/tsdown.config.ts
+++ b/packages/llm-mcp/tsdown.config.ts
@@ -10,6 +10,6 @@ export default defineConfig({
   fixedExtension: false,
   deps: {
     alwaysBundle: ["@ask-llm/shared"],
-    neverBundle: ["ask-gemini-mcp", "ask-codex-mcp", "ask-claude-mcp", "ask-ollama-mcp", "ask-antigravity-mcp"],
+    neverBundle: ["ask-gemini-mcp", "ask-codex-mcp", "@anton-lykhoyda/ask-claude-mcp", "ask-ollama-mcp", "ask-antigravity-mcp"],
   },
 });

--- a/packages/ollama-mcp/CHANGELOG.md
+++ b/packages/ollama-mcp/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Patch Changes
 
 - [#222](https://github.com/Lykhoyda/ask-llm/pull/222) [`ae7780c`](https://github.com/Lykhoyda/ask-llm/commit/ae7780c67327224eea760ade42b61df3d9a32b54) Thanks [@Lykhoyda](https://github.com/Lykhoyda)! - Add a first-class Claude Code CLI provider so Codex and other MCP clients can
-  ask Claude for a read-only second opinion. The new `ask-claude-mcp` package
+  ask Claude for a read-only second opinion. The new `@anton-lykhoyda/ask-claude-mcp` package
   supports native sessions, Opus-to-Sonnet fallback, usage reporting, relative
   context directories, and a hard Read/Glob/Grep-only tool boundary. The unified
   orchestrator now auto-detects Claude and can include it in `ask-llm`,

--- a/scripts/check-shared-changeset.mjs
+++ b/scripts/check-shared-changeset.mjs
@@ -8,7 +8,7 @@ import fs from "node:fs";
 const REQUIRED = [
   "ask-gemini-mcp",
   "ask-codex-mcp",
-  "ask-claude-mcp",
+  "@anton-lykhoyda/ask-claude-mcp",
   "ask-ollama-mcp",
   "ask-antigravity-mcp",
   "ask-llm-mcp",

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -100,6 +100,6 @@ echo ""
 run_smoke "Ollama"      "ask-ollama-mcp"
 run_smoke "Antigravity" "ask-antigravity-mcp"
 run_smoke "Codex"       "ask-codex-mcp"
-run_smoke "Claude"      "ask-claude-mcp"
+run_smoke "Claude"      "@anton-lykhoyda/ask-claude-mcp"
 
 echo "=== Smoke tests done (any quota-skipped providers were warned above) ==="

--- a/yarn.lock
+++ b/yarn.lock
@@ -212,6 +212,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@anton-lykhoyda/ask-claude-mcp@npm:^0.1.0, @anton-lykhoyda/ask-claude-mcp@workspace:packages/claude-mcp":
+  version: 0.0.0-use.local
+  resolution: "@anton-lykhoyda/ask-claude-mcp@workspace:packages/claude-mcp"
+  dependencies:
+    "@ask-llm/shared": "workspace:*"
+    "@biomejs/biome": "npm:^2.4.4"
+    "@modelcontextprotocol/sdk": "npm:^1.27.1"
+    "@types/node": "npm:^22.19.13"
+    tsdown: "npm:^0.22.2"
+    typescript: "npm:^5.0.0"
+    vitest: "npm:^4.0.18"
+    zod: "npm:^4.3.6"
+  bin:
+    ask-claude-mcp: dist/cli.js
+  languageName: unknown
+  linkType: soft
+
 "@ask-llm/plugin@workspace:packages/claude-plugin":
   version: 0.0.0-use.local
   resolution: "@ask-llm/plugin@workspace:packages/claude-plugin"
@@ -2840,23 +2857,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"ask-claude-mcp@npm:^0.1.0, ask-claude-mcp@workspace:packages/claude-mcp":
-  version: 0.0.0-use.local
-  resolution: "ask-claude-mcp@workspace:packages/claude-mcp"
-  dependencies:
-    "@ask-llm/shared": "workspace:*"
-    "@biomejs/biome": "npm:^2.4.4"
-    "@modelcontextprotocol/sdk": "npm:^1.27.1"
-    "@types/node": "npm:^22.19.13"
-    tsdown: "npm:^0.22.2"
-    typescript: "npm:^5.0.0"
-    vitest: "npm:^4.0.18"
-    zod: "npm:^4.3.6"
-  bin:
-    ask-claude-mcp: dist/cli.js
-  languageName: unknown
-  linkType: soft
-
 "ask-codex-mcp@npm:^0.6.1, ask-codex-mcp@workspace:*, ask-codex-mcp@workspace:packages/codex-mcp":
   version: 0.0.0-use.local
   resolution: "ask-codex-mcp@workspace:packages/codex-mcp"
@@ -2895,12 +2895,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ask-llm-mcp@workspace:packages/llm-mcp"
   dependencies:
+    "@anton-lykhoyda/ask-claude-mcp": "npm:^0.1.0"
     "@ask-llm/shared": "workspace:*"
     "@biomejs/biome": "npm:^2.4.4"
     "@modelcontextprotocol/sdk": "npm:^1.27.1"
     "@types/node": "npm:^22.19.13"
     ask-antigravity-mcp: "npm:^0.4.1"
-    ask-claude-mcp: "npm:^0.1.0"
     ask-codex-mcp: "npm:^0.6.1"
     ask-gemini-mcp: "npm:^1.6.14"
     ask-ollama-mcp: "npm:^0.5.1"


### PR DESCRIPTION
## Root cause

npm rejected the new unscoped ask-claude-mcp package because its name is too similar to the existing askclaude-mcp package. The same failed release also could not open its tracking issue because the workflow lacked issues: write.

## Fix

- publish the provider as @anton-lykhoyda/ask-claude-mcp while retaining the ask-claude-mcp executable
- update the unified package import, lockfile, MCP Registry manifest, docs, changeset guard, smoke runner, and local Verdaccio configuration
- map the scoped tarball filename in the global-install CI smoke
- grant the release failure reporter issues: write

## Verification

- corepack yarn changeset status --verbose
- corepack yarn build
- corepack yarn lint
- corepack yarn test
- git diff --check
- npm pack --dry-run --json --workspace packages/claude-mcp
- local Verdaccio publish plus global install and ask-llm-mcp doctor smoke