### PR TITLE
Ensure the scoped Claude package is public on npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 
+      # Scoped packages default to restricted visibility. Keep this explicit even
+      # though the manifest requests public access: the first 0.1.1 publish was
+      # accepted by npm but remained invisible to unauthenticated installs.
+      - name: Ensure ask-claude is public on npm
+        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+        run: |
+          npm access set status=public @anton-lykhoyda/ask-claude-mcp
+          test "$(npm access get status @anton-lykhoyda/ask-claude-mcp --json | jq -r '."@anton-lykhoyda/ask-claude-mcp"')" = "public"
+
       # Everything below this line runs ONLY when changesets actually published to npm
       # (i.e., the Version Packages PR just merged). On every other push to main —
       # including "pending changesets but no version commit yet" — these steps skip.


### PR DESCRIPTION
## Root cause

npm accepted @anton-lykhoyda/ask-claude-mcp@0.1.1 but left the first scoped publication invisible to unauthenticated registry clients. ask-llm-mcp@0.5.1 published normally, so this is scoped-package access state rather than registry propagation.

## Fix

- explicitly set the scoped package status to public after successful Changesets publication
- verify npm reports public status
- allow workflow_dispatch to repair the already-published 0.1.1 without another version bump

## Verification

- release workflow YAML parse
- corepack yarn lint
- git diff --check