### PR TITLE
feat(plugin): add Fable and Sol review skills

### DIFF
--- a/.changeset/add-native-model-review-skills.md
+++ b/.changeset/add-native-model-review-skills.md
@@ -1,0 +1,8 @@
+---
+"@ask-llm/plugin": minor
+---
+
+Add `/fable-review` and `/sol-review`, two read-only review skills that launch
+isolated reviewer agents pinned to native Fable and OpenAI GPT-5.6 Sol,
+respectively. Both workflows validate findings against the source and report
+only high-confidence issues.

--- a/.changeset/add-native-model-review-skills.md
+++ b/.changeset/add-native-model-review-skills.md
@@ -3,6 +3,6 @@
 ---
 
 Add `/fable-review` and `/sol-review`, two read-only review skills that launch
-isolated reviewer agents pinned to native Fable and OpenAI GPT-5.6 Sol,
+isolated reviewer agents that request native Fable and explicitly pin OpenAI GPT-5.6 Sol,
 respectively. Both workflows validate findings against the source and report
 only high-confidence issues.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ The **Ask LLM plugin** adds multi-provider code review, brainstorming, and autom
 | <nobr>`/multi-review`</nobr> | Parallel Antigravity + Codex review with 4-phase validation pipeline and consensus highlighting (gemini via `/gemini-review`) |
 | <nobr>`/gemini-review`</nobr> | Gemini-only review with confidence filtering |
 | <nobr>`/codex-review`</nobr> | Codex-only review with confidence filtering |
+| <nobr>`/fable-review`</nobr> | Direct review by the native Fable model in an isolated, read-only context |
+| <nobr>`/sol-review`</nobr> | Model-pinned GPT-5.6 Sol review through Codex |
 | <nobr>`/ollama-review`</nobr> | Local review — no data leaves your machine |
 | <nobr>`/antigravity-review`</nobr> | Subscription-backed review via Google Antigravity (`agy`) — experimental |
 | <nobr>`/brainstorm`</nobr> | Multi-LLM brainstorm: Claude Opus researches the topic against real files in parallel with external providers (Gemini/Codex/Ollama), then synthesizes all findings with verified findings weighted higher |

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The **Ask LLM plugin** adds multi-provider code review, brainstorming, and autom
 | <nobr>`/multi-review`</nobr> | Parallel Antigravity + Codex review with 4-phase validation pipeline and consensus highlighting (gemini via `/gemini-review`) |
 | <nobr>`/gemini-review`</nobr> | Gemini-only review with confidence filtering |
 | <nobr>`/codex-review`</nobr> | Codex-only review with confidence filtering |
-| <nobr>`/fable-review`</nobr> | Direct review by the native Fable model in an isolated, read-only context |
+| <nobr>`/fable-review`</nobr> | Isolated, read-only review that requests the native Fable model and discloses runtime verification limits |
 | <nobr>`/sol-review`</nobr> | Model-pinned GPT-5.6 Sol review through Codex |
 | <nobr>`/ollama-review`</nobr> | Local review — no data leaves your machine |
 | <nobr>`/antigravity-review`</nobr> | Subscription-backed review via Google Antigravity (`agy`) — experimental |

--- a/apps/docs/plugin/agents.md
+++ b/apps/docs/plugin/agents.md
@@ -1,5 +1,5 @@
 ---
-description: Isolated sub-agents for AI code review and multi-LLM brainstorming. Confidence-based filtering (80%+ threshold) across Codex, Antigravity, Ollama, and Gemini.
+description: Isolated sub-agents for native Fable review, model-pinned GPT-5.6 Sol review, provider-backed code review, and multi-LLM brainstorming.
 ---
 
 # Agents
@@ -8,7 +8,17 @@ Agents are specialized sub-processes that Claude Code dispatches to handle compl
 
 ## Review Agents
 
-All review agents use a 3-phase workflow with confidence-based filtering:
+### `fable-reviewer`
+
+This native reviewer analyzes the current diff directly in an isolated context pinned to `fable`. It has read-only tools, verifies every candidate against the source, and reports only findings at 80% confidence or higher.
+
+Invoke it with `/fable-review`.
+
+### `sol-reviewer`
+
+This reviewer uses an isolated Opus coordinator to request `gpt-5.6-sol` explicitly from `ask-codex` at high reasoning, then validates Sol's findings against the source. Invoke it with `/sol-review`. A quota fallback to Terra is disclosed instead of being presented as a Sol result.
+
+Provider-backed review agents use a 3-phase workflow with confidence-based filtering:
 
 **Phase 1: Context Gathering**
 - Read the project's `CLAUDE.md` for conventions

--- a/apps/docs/plugin/overview.md
+++ b/apps/docs/plugin/overview.md
@@ -47,7 +47,7 @@ This gives you `gemini:ask-gemini` rather than `plugin:ask-llm:gemini:ask-gemini
 | `/multi-review` | Antigravity + Codex | Parallel review with 4-phase validation pipeline and consensus highlighting |
 | `/gemini-review` | Gemini | Get a second opinion on your current changes |
 | `/codex-review` | Codex | Get a second opinion from GPT-5.5 |
-| `/fable-review` | Fable | Native isolated review, pinned to Fable |
+| `/fable-review` | Fable | Native isolated review that requests Fable and discloses runtime verification limits |
 | `/sol-review` | GPT-5.6 Sol | Model-pinned review through Codex |
 | `/ollama-review` | Ollama | Local review — no data leaves your machine |
 | `/antigravity-review` | Antigravity | Subscription-backed second opinion via Google `agy` (experimental) |
@@ -65,7 +65,7 @@ This gives you `gemini:ask-gemini` rather than `plugin:ask-llm:gemini:ask-gemini
 |-------|-------------|
 | `gemini-reviewer` | Isolated Gemini code review with confidence-based filtering |
 | `codex-reviewer` | Isolated Codex code review with confidence-based filtering |
-| `fable-reviewer` | Native read-only Fable review with source validation |
+| `fable-reviewer` | Native read-only review configured to request Fable, with source validation |
 | `sol-reviewer` | GPT-5.6 Sol review through Codex with source validation |
 | `ollama-reviewer` | Local Ollama code review — no data leaves your machine |
 | `antigravity-reviewer` | Subscription-backed Antigravity (`agy`) code review — experimental |

--- a/apps/docs/plugin/overview.md
+++ b/apps/docs/plugin/overview.md
@@ -47,6 +47,8 @@ This gives you `gemini:ask-gemini` rather than `plugin:ask-llm:gemini:ask-gemini
 | `/multi-review` | Antigravity + Codex | Parallel review with 4-phase validation pipeline and consensus highlighting |
 | `/gemini-review` | Gemini | Get a second opinion on your current changes |
 | `/codex-review` | Codex | Get a second opinion from GPT-5.5 |
+| `/fable-review` | Fable | Native isolated review, pinned to Fable |
+| `/sol-review` | GPT-5.6 Sol | Model-pinned review through Codex |
 | `/ollama-review` | Ollama | Local review — no data leaves your machine |
 | `/antigravity-review` | Antigravity | Subscription-backed second opinion via Google `agy` (experimental) |
 | `/brainstorm` | Multi + Claude Opus | Claude Opus researches the topic against real files in parallel with external providers, then synthesizes findings |
@@ -63,6 +65,8 @@ This gives you `gemini:ask-gemini` rather than `plugin:ask-llm:gemini:ask-gemini
 |-------|-------------|
 | `gemini-reviewer` | Isolated Gemini code review with confidence-based filtering |
 | `codex-reviewer` | Isolated Codex code review with confidence-based filtering |
+| `fable-reviewer` | Native read-only Fable review with source validation |
+| `sol-reviewer` | GPT-5.6 Sol review through Codex with source validation |
 | `ollama-reviewer` | Local Ollama code review — no data leaves your machine |
 | `antigravity-reviewer` | Subscription-backed Antigravity (`agy`) code review — experimental |
 | `brainstorm-coordinator` | First-class research participant: runs its own Claude Opus research (reads real files, traces code, fetches docs) in parallel with external providers, then synthesizes consensus. Verified findings weighted higher than inferred ones. |

--- a/apps/docs/plugin/skills.md
+++ b/apps/docs/plugin/skills.md
@@ -12,7 +12,7 @@ Skills are slash commands you can invoke directly in Claude Code. Each skill tri
 
 ### `/fable-review`
 
-Review the current diff directly with a read-only agent pinned to Fable. Findings are checked against the source and filtered at 80% confidence.
+Review the current diff with a read-only agent configured to request Fable. Findings are checked against the source and filtered at 80% confidence.
 
 ```text
 /fable-review
@@ -26,7 +26,7 @@ Run the same independent review contract with an isolated coordinator that expli
 /sol-review
 ```
 
-`/fable-review` requires a Claude Code runtime/account that exposes Fable. `/sol-review` requires an installed, authenticated Codex CLI and registered Codex MCP server. If Sol falls back to Terra on quota, the result says so explicitly.
+`/fable-review` requires a Claude Code runtime/account that exposes Fable. It rejects an explicit non-Fable `CLAUDE_CODE_SUBAGENT_MODEL` override, but Claude Code does not expose the resolved subagent model to skills, so the result discloses that organization-policy fallback could not be independently verified. `/sol-review` requires an installed, authenticated Codex CLI and registered Codex MCP server. If Sol falls back to Terra on quota, the result says so explicitly.
 
 ## Provider Review Skills
 

--- a/apps/docs/plugin/skills.md
+++ b/apps/docs/plugin/skills.md
@@ -1,16 +1,36 @@
 ---
-description: Slash commands for AI code review, brainstorming, and side-by-side multi-provider comparison — /gemini-review, /codex-review, /ollama-review, /antigravity-review, /multi-review (with verification), /brainstorm, /brainstorm-all, and /compare.
+description: Slash commands for AI code review, brainstorming, and side-by-side comparison — including native /fable-review, model-pinned /sol-review, provider reviews, /multi-review, /brainstorm, and /compare.
 ---
 
 # Skills
 
-Skills are slash commands you can invoke directly in Claude Code. Each skill triggers a structured workflow that gathers context, calls a provider, and returns prioritized findings.
+Skills are slash commands you can invoke directly in Claude Code. Each skill triggers a structured workflow that gathers context, runs a native agent or provider, and returns prioritized findings.
 
-> `/gemini-review` works out of the box with the plugin. `/codex-review`, `/ollama-review`, and `/antigravity-review` require their MCP servers to be added separately — see [Plugin Overview](/plugin/overview#installation).
+> `/fable-review` runs as a native isolated agent and needs no MCP server. `/sol-review` and `/codex-review` require the Codex MCP server; `/ollama-review` and `/antigravity-review` require their respective MCP servers — see [Plugin Overview](/plugin/overview#installation).
 
-## Review Skills
+## Native Model Review Skills
 
-All four review skills follow the same pattern:
+### `/fable-review`
+
+Review the current diff directly with a read-only agent pinned to Fable. Findings are checked against the source and filtered at 80% confidence.
+
+```text
+/fable-review
+```
+
+### `/sol-review`
+
+Run the same independent review contract with an isolated coordinator that explicitly requests `gpt-5.6-sol` at high reasoning from the Codex provider. `/codex-review` instead follows the configured Codex default.
+
+```text
+/sol-review
+```
+
+`/fable-review` requires a Claude Code runtime/account that exposes Fable. `/sol-review` requires an installed, authenticated Codex CLI and registered Codex MCP server. If Sol falls back to Terra on quota, the result says so explicitly.
+
+## Provider Review Skills
+
+Provider review skills follow the same pattern:
 
 1. Gather staged and unstaged git changes
 2. Read project conventions from `CLAUDE.md`

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -367,6 +367,8 @@ Launches Antigravity and Codex reviews in parallel with a validation pipeline an
 | /multi-review | Parallel Antigravity + Codex code review with validation pipeline and consensus highlighting |
 | /gemini-review | Gemini-only code review with confidence filtering |
 | /codex-review | Codex-only code review with confidence filtering |
+| /fable-review | Direct, isolated code review pinned to the Fable model |
+| /sol-review | Codex code review explicitly pinned to GPT-5.6 Sol at high reasoning effort |
 | /ollama-review | Local Ollama code review — no data leaves machine |
 | /antigravity-review | Antigravity-only code review (subscription-backed) |
 | /brainstorm [providers] topic | Multi-LLM brainstorm; Claude researches in parallel (default external providers: antigravity,codex) |
@@ -382,6 +384,8 @@ Launches Antigravity and Codex reviews in parallel with a validation pipeline an
 |-------|-------------|
 | gemini-reviewer | Isolated Gemini review, confidence-filtered findings |
 | codex-reviewer | Isolated Codex review, confidence-filtered findings |
+| fable-reviewer | Isolated, read-only review performed directly by Fable |
+| sol-reviewer | Isolated, read-only Codex review pinned to GPT-5.6 Sol |
 | ollama-reviewer | Isolated local Ollama review, confidence-filtered findings |
 | antigravity-reviewer | Isolated Antigravity review, confidence-filtered findings |
 | codex-verifier | Verifies the assistant's claims against actual state (STATUS + CONFIDENCE) |

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -367,7 +367,7 @@ Launches Antigravity and Codex reviews in parallel with a validation pipeline an
 | /multi-review | Parallel Antigravity + Codex code review with validation pipeline and consensus highlighting |
 | /gemini-review | Gemini-only code review with confidence filtering |
 | /codex-review | Codex-only code review with confidence filtering |
-| /fable-review | Direct, isolated code review pinned to the Fable model |
+| /fable-review | Isolated code review that requests Fable and discloses runtime verification limits |
 | /sol-review | Codex code review explicitly pinned to GPT-5.6 Sol at high reasoning effort |
 | /ollama-review | Local Ollama code review — no data leaves machine |
 | /antigravity-review | Antigravity-only code review (subscription-backed) |
@@ -384,7 +384,7 @@ Launches Antigravity and Codex reviews in parallel with a validation pipeline an
 |-------|-------------|
 | gemini-reviewer | Isolated Gemini review, confidence-filtered findings |
 | codex-reviewer | Isolated Codex review, confidence-filtered findings |
-| fable-reviewer | Isolated, read-only review performed directly by Fable |
+| fable-reviewer | Isolated, read-only review configured to request Fable |
 | sol-reviewer | Isolated, read-only Codex review pinned to GPT-5.6 Sol |
 | ollama-reviewer | Isolated local Ollama review, confidence-filtered findings |
 | antigravity-reviewer | Isolated Antigravity review, confidence-filtered findings |

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -57,7 +57,7 @@ Install the plugin for review skills, brainstorm agents, and automated hooks:
 /plugin install ask-llm@ask-llm-plugins
 ```
 
-Skills: /multi-review, /gemini-review, /codex-review, /ollama-review, /antigravity-review, /brainstorm, /brainstorm-all, /compare, /codex-verify, /codex-image, /codex-pair (+ -ack, -pause, -resume)
+Skills: /multi-review, /gemini-review, /codex-review, /fable-review, /sol-review, /ollama-review, /antigravity-review, /brainstorm, /brainstorm-all, /compare, /codex-verify, /codex-image, /codex-pair (+ -ack, -pause, -resume)
 
 ## Links
 

--- a/packages/claude-plugin/README.md
+++ b/packages/claude-plugin/README.md
@@ -36,7 +36,7 @@ claude mcp add --scope user ollama -- npx -y ask-ollama-mcp
 | `/multi-review` | Parallel Gemini + Codex review with 4-phase validation pipeline and consensus highlighting |
 | `/gemini-review` | Gemini-only code review with confidence filtering |
 | `/codex-review` | Codex-only code review (precision-first, ≥80 confidence — default for routine PR review) |
-| `/fable-review` | Native Fable review in an isolated, read-only context |
+| `/fable-review` | Isolated, read-only review requesting native Fable, with runtime verification limits disclosed |
 | `/sol-review` | Model-pinned GPT-5.6 Sol review through Codex |
 | `/ollama-review` | Local review — no data leaves your machine |
 | `/brainstorm` | Multi-LLM brainstorm with Claude Opus as a first-class research participant (default external: gemini,codex) |
@@ -49,7 +49,7 @@ claude mcp add --scope user ollama -- npx -y ask-ollama-mcp
 |-------|-------|-------------|
 | gemini-reviewer | cyan | 4-phase: context, prompt, synthesis, validation |
 | codex-reviewer | green | 4-phase: context, prompt, synthesis, validation |
-| fable-reviewer | purple | Direct Fable review with source-verified findings |
+| fable-reviewer | purple | Fable-requested review with source-verified findings |
 | sol-reviewer | blue | GPT-5.6 Sol review through Codex with source validation |
 | ollama-reviewer | yellow | 4-phase: context, prompt, synthesis, validation (local) |
 | brainstorm-coordinator | magenta | Claude Opus research + parallel multi-LLM consultation with synthesis; verified findings weighted higher than inferred |

--- a/packages/claude-plugin/README.md
+++ b/packages/claude-plugin/README.md
@@ -36,6 +36,8 @@ claude mcp add --scope user ollama -- npx -y ask-ollama-mcp
 | `/multi-review` | Parallel Gemini + Codex review with 4-phase validation pipeline and consensus highlighting |
 | `/gemini-review` | Gemini-only code review with confidence filtering |
 | `/codex-review` | Codex-only code review (precision-first, ≥80 confidence — default for routine PR review) |
+| `/fable-review` | Native Fable review in an isolated, read-only context |
+| `/sol-review` | Model-pinned GPT-5.6 Sol review through Codex |
 | `/ollama-review` | Local review — no data leaves your machine |
 | `/brainstorm` | Multi-LLM brainstorm with Claude Opus as a first-class research participant (default external: gemini,codex) |
 | `/brainstorm-all` | Brainstorm with all four external providers (Gemini, Codex, Ollama, Antigravity) + Claude Opus research |
@@ -47,6 +49,8 @@ claude mcp add --scope user ollama -- npx -y ask-ollama-mcp
 |-------|-------|-------------|
 | gemini-reviewer | cyan | 4-phase: context, prompt, synthesis, validation |
 | codex-reviewer | green | 4-phase: context, prompt, synthesis, validation |
+| fable-reviewer | purple | Direct Fable review with source-verified findings |
+| sol-reviewer | blue | GPT-5.6 Sol review through Codex with source validation |
 | ollama-reviewer | yellow | 4-phase: context, prompt, synthesis, validation (local) |
 | brainstorm-coordinator | magenta | Claude Opus research + parallel multi-LLM consultation with synthesis; verified findings weighted higher than inferred |
 

--- a/packages/claude-plugin/agents/fable-reviewer.md
+++ b/packages/claude-plugin/agents/fable-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: fable-reviewer
-description: Reviews code changes directly with the Fable model in an isolated, read-only context and reports only source-verified, high-confidence correctness findings.
+description: Reviews code changes in an isolated, read-only context configured to request Fable and reports only source-verified, high-confidence correctness findings.
 model: fable
 effort: high
 color: purple

--- a/packages/claude-plugin/agents/fable-reviewer.md
+++ b/packages/claude-plugin/agents/fable-reviewer.md
@@ -1,0 +1,29 @@
+---
+name: fable-reviewer
+description: Reviews code changes directly with the Fable model in an isolated, read-only context and reports only source-verified, high-confidence correctness findings.
+model: fable
+effort: high
+color: purple
+tools:
+  - Bash
+  - Glob
+  - Grep
+  - Read
+---
+
+You are a senior software engineer performing a precision-first code review. Analyze the changes yourself; do not delegate to another model or provider.
+
+## Review contract
+
+1. Inspect `git diff` and `git diff --cached`. Review changed code only.
+2. Read each affected file around the changed lines. Apply the nearest `CLAUDE.md` instructions and inspect any ADR explicitly cited by the code.
+3. Look for concrete correctness, security, data-loss, concurrency, resource-lifecycle, and compatibility failures.
+4. Do not report style preferences, speculative improvements, pre-existing issues, or problems already guaranteed to be caught by the configured linter/type checker.
+5. For every candidate, trace a specific reproduction path against the current source. Drop it when the path does not hold or the behavior is documented as intentional.
+6. Report only findings with confidence of at least 80/100. Never invent findings to fill a report.
+
+## Output
+
+Lead with the highest-severity finding. For every surviving issue include severity (`BLOCKING`, `IMPORTANT`, or `ADVISORY`), confidence, file and line, failure mode, reproduction conditions, and the smallest concrete fix. State clearly when no high-confidence findings survive validation.
+
+You have no edit tools. Remain read-only.

--- a/packages/claude-plugin/agents/sol-reviewer.md
+++ b/packages/claude-plugin/agents/sol-reviewer.md
@@ -1,0 +1,36 @@
+---
+name: sol-reviewer
+description: Coordinates an isolated, read-only code review explicitly pinned to OpenAI GPT-5.6 Sol and reports only source-verified, high-confidence correctness findings.
+model: opus
+effort: high
+color: blue
+tools:
+  - Bash
+  - Glob
+  - Grep
+  - Read
+  - mcp__codex__ask-codex
+---
+
+You are a code review coordinator for a model-pinned OpenAI GPT-5.6 Sol review. Send the changes to Codex, then independently validate every candidate against the current source.
+
+## Workflow
+
+1. Inspect `git diff` and `git diff --cached`. Read each affected file around the changed lines.
+2. Apply the nearest `CLAUDE.md` instructions and inspect any ADR explicitly cited by changed code.
+3. Call `mcp__codex__ask-codex` with:
+   - `model: "gpt-5.6-sol"`
+   - `reasoningEffort: "high"`
+   - `preferred` unset
+   - a prompt containing the scoped conventions, relevant ADR summaries, and the diff
+4. Ask Sol for concrete correctness, security, data-loss, concurrency, resource-lifecycle, and compatibility failures with confidence scores and reproduction conditions.
+5. Read the reported source locations and trace each reproduction path. Drop style preferences, speculative improvements, pre-existing issues, linter/type-checker findings, and behavior documented as intentional.
+6. Report only validated findings with confidence of at least 80/100. Never invent findings to fill a report.
+
+## Output
+
+Lead with the highest-severity finding. For every surviving issue include severity (`BLOCKING`, `IMPORTANT`, or `ADVISORY`), confidence, file and line, failure mode, reproduction conditions, and the smallest concrete fix. State clearly when no high-confidence findings survive validation.
+
+The explicit `model` argument is load-bearing: do not omit it or replace it with an environment-selected default. If the response reports a Terra quota fallback, disclose that the Sol review could not complete as pinned.
+
+You have no edit tools. Remain read-only.

--- a/packages/claude-plugin/skills/fable-review/SKILL.md
+++ b/packages/claude-plugin/skills/fable-review/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: fable-review
+description: Review the current code changes directly with the Fable model. Use when the user asks for a Fable review, says "review with Fable", wants Fable's independent perspective on a diff, or invokes /fable-review.
+user_invocable: true
+---
+
+# Fable Code Review
+
+Run a read-only, precision-first review in an isolated Fable context.
+
+## Workflow
+
+1. Run `git status --short`, `git diff`, and `git diff --cached`.
+2. Include untracked files the user wants reviewed with `git add -N <path>` so their contents appear in the diff without staging them.
+3. If the combined diff is empty, report that there are no changes to review.
+4. Read the root and file-scoped `CLAUDE.md` files plus any ADRs cited by changed code.
+5. Launch the `fable-reviewer` agent with the diff and a compact context brief containing the changed files, applicable conventions, referenced ADRs, and the user's requested review focus.
+6. Return the agent's validated findings without adding unverified issues.
+
+The `fable-reviewer` agent's `model: fable` frontmatter is the model pin. Do not substitute another reviewer or route this skill through an external MCP provider. If Fable is unavailable, surface that failure explicitly.

--- a/packages/claude-plugin/skills/fable-review/SKILL.md
+++ b/packages/claude-plugin/skills/fable-review/SKILL.md
@@ -1,21 +1,22 @@
 ---
 name: fable-review
-description: Review the current code changes directly with the Fable model. Use when the user asks for a Fable review, says "review with Fable", wants Fable's independent perspective on a diff, or invokes /fable-review.
+description: Request a review of the current code changes from the Fable model. Use when the user asks for a Fable review, says "review with Fable", wants Fable's independent perspective on a diff, or invokes /fable-review.
 user_invocable: true
 ---
 
 # Fable Code Review
 
-Run a read-only, precision-first review in an isolated Fable context.
+Request a read-only, precision-first review in an isolated Fable context.
 
 ## Workflow
 
-1. Run `git status --short`, `git diff`, and `git diff --cached`.
-2. Include untracked files the user wants reviewed with `git add -N <path>` so their contents appear in the diff without staging them.
-3. If the combined diff is empty, report that there are no changes to review.
-4. Read the root and file-scoped `CLAUDE.md` files plus any ADRs cited by changed code.
-5. Launch the `fable-reviewer` agent with the per-invocation model set to `fable`, plus the diff and a compact context brief containing the changed files, applicable conventions, referenced ADRs, and the user's requested review focus.
-6. Inspect the Agent tool result metadata before accepting the review. Its `resolvedModel` must start with `claude-fable-`. If the field is absent or names any other model, abort and report that Fable is unavailable or overridden; do not return that agent's findings as a Fable review.
-7. Return the agent's validated findings without adding unverified issues.
+1. Use Bash to read `CLAUDE_CODE_SUBAGENT_MODEL`. If it is set to anything other than `inherit`, `fable`, or a `claude-fable-*` model ID, abort before launching: this environment variable has higher precedence than the skill's model request.
+2. Run `git status --short`, `git diff`, and `git diff --cached`.
+3. Include untracked files the user wants reviewed with `git add -N <path>` so their contents appear in the diff without staging them.
+4. If the combined diff is empty, report that there are no changes to review.
+5. Read the root and file-scoped `CLAUDE.md` files plus any ADRs cited by changed code.
+6. Launch the `fable-reviewer` agent with the per-invocation model set to `fable`, plus the diff and a compact context brief containing the changed files, applicable conventions, referenced ADRs, and the user's requested review focus.
+7. If the Agent tool reports a fallback or model-availability error, abort instead of returning its findings as a Fable review.
+8. Return the agent's validated findings without adding unverified issues. State that Fable was requested but the resolved model was not independently verified, because Claude Code does not expose the resolved subagent model to skills and an organization `availableModels` policy can silently fall back to the inherited model.
 
-The `fable-reviewer` agent's `model: fable` frontmatter and the launch-time `model: "fable"` argument request Fable, while the `resolvedModel` check verifies the model Claude Code actually selected. Do not substitute another reviewer or route this skill through an external MCP provider. If Fable is unavailable, surface that failure explicitly.
+The `fable-reviewer` agent's `model: fable` frontmatter and the launch-time `model: "fable"` argument both request Fable. Do not substitute another reviewer or route this skill through an external MCP provider. Never claim the runtime-selected model was verified when Claude Code did not expose it.

--- a/packages/claude-plugin/skills/fable-review/SKILL.md
+++ b/packages/claude-plugin/skills/fable-review/SKILL.md
@@ -14,7 +14,8 @@ Run a read-only, precision-first review in an isolated Fable context.
 2. Include untracked files the user wants reviewed with `git add -N <path>` so their contents appear in the diff without staging them.
 3. If the combined diff is empty, report that there are no changes to review.
 4. Read the root and file-scoped `CLAUDE.md` files plus any ADRs cited by changed code.
-5. Launch the `fable-reviewer` agent with the diff and a compact context brief containing the changed files, applicable conventions, referenced ADRs, and the user's requested review focus.
-6. Return the agent's validated findings without adding unverified issues.
+5. Launch the `fable-reviewer` agent with the per-invocation model set to `fable`, plus the diff and a compact context brief containing the changed files, applicable conventions, referenced ADRs, and the user's requested review focus.
+6. Inspect the Agent tool result metadata before accepting the review. Its `resolvedModel` must start with `claude-fable-`. If the field is absent or names any other model, abort and report that Fable is unavailable or overridden; do not return that agent's findings as a Fable review.
+7. Return the agent's validated findings without adding unverified issues.
 
-The `fable-reviewer` agent's `model: fable` frontmatter is the model pin. Do not substitute another reviewer or route this skill through an external MCP provider. If Fable is unavailable, surface that failure explicitly.
+The `fable-reviewer` agent's `model: fable` frontmatter and the launch-time `model: "fable"` argument request Fable, while the `resolvedModel` check verifies the model Claude Code actually selected. Do not substitute another reviewer or route this skill through an external MCP provider. If Fable is unavailable, surface that failure explicitly.

--- a/packages/claude-plugin/skills/sol-review/SKILL.md
+++ b/packages/claude-plugin/skills/sol-review/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: sol-review
+description: Review the current code changes specifically with OpenAI GPT-5.6 Sol. Use when the user asks for a Sol review, says "review with Sol", wants a model-pinned Codex review, or invokes /sol-review.
+user_invocable: true
+---
+
+# Sol Code Review
+
+Run a read-only, precision-first review explicitly pinned to GPT-5.6 Sol at high reasoning effort.
+
+## Workflow
+
+1. Run `git status --short`, `git diff`, and `git diff --cached`.
+2. Include untracked files the user wants reviewed with `git add -N <path>` so their contents appear in the diff without staging them.
+3. If the combined diff is empty, report that there are no changes to review.
+4. Read the root and file-scoped `CLAUDE.md` files plus any ADRs cited by changed code.
+5. Launch the `sol-reviewer` agent with the diff and a compact context brief containing the changed files, applicable conventions, referenced ADRs, and the user's requested review focus.
+6. Return the agent's validated findings without adding unverified issues.
+
+The reviewer must call `ask-codex` with `model: "gpt-5.6-sol"` and `reasoningEffort: "high"`. This explicit pin distinguishes `/sol-review` from `/codex-review`, which follows the configured Codex default. If Codex falls back to Terra on quota, disclose that the requested Sol review did not complete on Sol.

--- a/packages/claude-plugin/src/__tests__/skills-and-agents.test.ts
+++ b/packages/claude-plugin/src/__tests__/skills-and-agents.test.ts
@@ -13,17 +13,21 @@ const expectedSkills = [
   "codex-review",
   "codex-verify",
   "compare",
+  "fable-review",
   "gemini-review",
   "multi-review",
   "ollama-review",
+  "sol-review",
 ];
 const expectedAgents = [
   "antigravity-reviewer.md",
   "brainstorm-coordinator.md",
   "codex-reviewer.md",
   "codex-verifier.md",
+  "fable-reviewer.md",
   "gemini-reviewer.md",
   "ollama-reviewer.md",
+  "sol-reviewer.md",
 ];
 
 describe("skills/", () => {
@@ -88,6 +92,7 @@ describe("agents/", () => {
       { file: "codex-reviewer.md", tool: "mcp__codex__ask-codex" },
       { file: "ollama-reviewer.md", tool: "mcp__ollama__ask-ollama" },
       { file: "antigravity-reviewer.md", tool: "mcp__antigravity__ask-antigravity" },
+      { file: "sol-reviewer.md", tool: "mcp__codex__ask-codex" },
     ];
     for (const { file, tool } of cases) {
       const { frontmatter } = parseMarkdownFrontmatter(readFile(`agents/${file}`));
@@ -98,7 +103,14 @@ describe("agents/", () => {
   });
 
   it("review agents are restricted from edit/write tools", () => {
-    const reviewerAgents = ["gemini-reviewer.md", "codex-reviewer.md", "ollama-reviewer.md", "antigravity-reviewer.md"];
+    const reviewerAgents = [
+      "gemini-reviewer.md",
+      "codex-reviewer.md",
+      "ollama-reviewer.md",
+      "antigravity-reviewer.md",
+      "fable-reviewer.md",
+      "sol-reviewer.md",
+    ];
     for (const file of reviewerAgents) {
       const { frontmatter } = parseMarkdownFrontmatter(readFile(`agents/${file}`));
       const tools = frontmatter.tools as string[] | undefined;
@@ -107,6 +119,30 @@ describe("agents/", () => {
       expect(tools).not.toContain("Write");
       expect(tools).not.toContain("NotebookEdit");
     }
+  });
+
+  it("pins the native Fable reviewer and the Sol provider request", () => {
+    const fable = parseMarkdownFrontmatter(readFile("agents/fable-reviewer.md")).frontmatter;
+    const solContent = readFile("agents/sol-reviewer.md");
+    const sol = parseMarkdownFrontmatter(solContent).frontmatter;
+    expect(fable.model).toBe("fable");
+    expect(fable.effort).toBe("high");
+    expect(sol.model).toBe("opus");
+    expect(sol.effort).toBe("high");
+    expect(solContent).toContain('model: "gpt-5.6-sol"');
+    expect(solContent).toContain('reasoningEffort: "high"');
+  });
+});
+
+describe("native model review skills", () => {
+  it.each([
+    ["fable-review", "fable-reviewer", "model: fable"],
+    ["sol-review", "sol-reviewer", 'model: "gpt-5.6-sol"'],
+  ])("%s delegates to its model-pinned reviewer path", (skill, reviewer, modelPin) => {
+    const content = readFile(`skills/${skill}/SKILL.md`);
+    expect(content).toContain(reviewer);
+    expect(content).toContain(modelPin);
+    expect(content).toMatch(/distinguishes|Do not substitute|Do not route/i);
   });
 });
 

--- a/packages/claude-plugin/src/__tests__/skills-and-agents.test.ts
+++ b/packages/claude-plugin/src/__tests__/skills-and-agents.test.ts
@@ -144,6 +144,15 @@ describe("native model review skills", () => {
     expect(content).toContain(modelPin);
     expect(content).toMatch(/distinguishes|Do not substitute|Do not route/i);
   });
+
+  it("rejects a Fable review when Claude Code resolves the agent to another model", () => {
+    const content = readFile("skills/fable-review/SKILL.md");
+    expect(content).toContain('model: "fable"');
+    expect(content).toContain("resolvedModel");
+    expect(content).toContain("claude-fable-");
+    expect(content).toMatch(/absent or names any other model, abort/i);
+    expect(content).toMatch(/do not return.+findings as a Fable review/i);
+  });
 });
 
 describe("multi-review skill — load-bearing polish (ADR-064)", () => {

--- a/packages/claude-plugin/src/__tests__/skills-and-agents.test.ts
+++ b/packages/claude-plugin/src/__tests__/skills-and-agents.test.ts
@@ -145,13 +145,16 @@ describe("native model review skills", () => {
     expect(content).toMatch(/distinguishes|Do not substitute|Do not route/i);
   });
 
-  it("rejects a Fable review when Claude Code resolves the agent to another model", () => {
+  it("guards explicit Fable overrides without claiming inaccessible runtime verification", () => {
     const content = readFile("skills/fable-review/SKILL.md");
     expect(content).toContain('model: "fable"');
-    expect(content).toContain("resolvedModel");
+    expect(content).toContain("CLAUDE_CODE_SUBAGENT_MODEL");
+    expect(content).toContain("inherit");
     expect(content).toContain("claude-fable-");
-    expect(content).toMatch(/absent or names any other model, abort/i);
-    expect(content).toMatch(/do not return.+findings as a Fable review/i);
+    expect(content).toMatch(/higher precedence.+model request/i);
+    expect(content).toMatch(/resolved model was not independently verified/i);
+    expect(content).toMatch(/does not expose the resolved subagent model/i);
+    expect(content).not.toContain("resolvedModel");
   });
 });
 


### PR DESCRIPTION
## Summary

- add `/fable-review` with an isolated read-only reviewer pinned to native Fable
- add `/sol-review` with an isolated coordinator that explicitly requests `gpt-5.6-sol` at high reasoning through Codex
- add model-pin, inventory, read-only-tool, documentation, and changeset coverage

## Why

The existing review commands route by provider defaults. These skills provide explicit model-specific review lanes: Fable runs directly as the reviewer, while Sol remains distinct from `/codex-review` by pinning the Codex model instead of inheriting environment configuration.

## Validation

- `yarn workspace @ask-llm/plugin test` — 487 tests passed on current `main`
- `yarn build`
- `yarn workspace @ask-llm/plugin lint`
- `yarn docs:build`
- `claude plugin validate packages/claude-plugin`
- live `/fable-review` smoke confirmed reviewer usage on `claude-fable-5`

## Review note

The live Fable pass identified a non-blocking test-hardening opportunity: the generic read-only assertion skips agents whose `tools` array is absent. The shipped Fable agent does declare a read-only allowlist; a follow-up can make array presence structurally mandatory.