### PR TITLE
fix(release): make registry publishing retryable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,8 @@ on:
   push:
     branches: ["main"]
   # Manual dispatch for dry-runs against feature branches and for re-running
-  # publishes after a workflow-side hotfix. Manual runs may also retry npm
-  # visibility and MCP Registry publication without republishing npm versions.
+  # publishes after a workflow-side hotfix. Manual runs on main may also retry
+  # npm visibility and MCP Registry publication without republishing npm versions.
   workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
@@ -70,7 +70,7 @@ jobs:
       # though every manifest requests public access; a publish can otherwise be
       # accepted by npm but remain invisible to unauthenticated installs.
       - name: Ensure Ask LLM packages are public on npm
-        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.changesets.outputs.published == 'true' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         run: |
@@ -88,14 +88,14 @@ jobs:
       # Registry steps run after a real npm publish or an explicit manual retry.
       # Ordinary main pushes with no published versions still skip them.
       - name: Install mcp-publisher
-        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.changesets.outputs.published == 'true' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
         run: curl -sL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
 
       # server.json + marketplace.json track the same versions as package.json but live in
       # separate files for the MCP Registry's input schema. Sync them after changesets'
       # version bump so the Registry publish picks up the freshly-bumped numbers.
       - name: Sync versions from package.json to server.json and marketplace.json
-        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.changesets.outputs.published == 'true' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
         run: |
           for entry in "gemini-mcp:server.json" "codex-mcp:packages/codex-mcp/server.json" "claude-mcp:packages/claude-mcp/server.json" "ollama-mcp:packages/ollama-mcp/server.json" "antigravity-mcp:packages/antigravity-mcp/server.json" "llm-mcp:packages/llm-mcp/server.json"; do
             pkg="${entry%%:*}"
@@ -106,36 +106,36 @@ jobs:
           PLUGIN_VERSION=$(node -p "require('./packages/claude-plugin/package.json').version")
           jq --arg v "$PLUGIN_VERSION" '(.plugins[0].version = $v)' .claude-plugin/marketplace.json > .claude-plugin/marketplace.json.tmp && mv .claude-plugin/marketplace.json.tmp .claude-plugin/marketplace.json
 
-      - if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
+      - if: steps.changesets.outputs.published == 'true' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
         run: ./mcp-publisher login github-oidc
 
       - name: Publish ask-gemini to MCP Registry
-        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.changesets.outputs.published == 'true' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
         run: ./mcp-publisher publish server.json
         continue-on-error: true
 
       - name: Publish ask-codex to MCP Registry
-        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.changesets.outputs.published == 'true' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
         run: ./mcp-publisher publish packages/codex-mcp/server.json
         continue-on-error: true
 
       - name: Publish ask-claude to MCP Registry
-        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.changesets.outputs.published == 'true' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
         run: ./mcp-publisher publish packages/claude-mcp/server.json
         continue-on-error: true
 
       - name: Publish ask-ollama to MCP Registry
-        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.changesets.outputs.published == 'true' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
         run: ./mcp-publisher publish packages/ollama-mcp/server.json
         continue-on-error: true
 
       - name: Publish ask-antigravity to MCP Registry
-        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.changesets.outputs.published == 'true' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
         run: ./mcp-publisher publish packages/antigravity-mcp/server.json
         continue-on-error: true
 
       - name: Publish ask-llm to MCP Registry
-        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.changesets.outputs.published == 'true' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
         run: ./mcp-publisher publish packages/llm-mcp/server.json
         continue-on-error: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,8 @@ on:
   push:
     branches: ["main"]
   # Manual dispatch for dry-runs against feature branches and for re-running
-  # publishes after a workflow-side hotfix. On a non-main branch with no pending
-  # changesets, changesets/action is a no-op and the downstream MCP Registry +
-  # release steps skip via `if: steps.changesets.outputs.published == 'true'`.
+  # publishes after a workflow-side hotfix. Manual runs may also retry npm
+  # visibility and MCP Registry publication without republishing npm versions.
   workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
@@ -86,18 +85,17 @@ jobs:
             test "$(npm access get status "$pkg" --json | jq -r --arg pkg "$pkg" '.[$pkg]')" = "public"
           done
 
-      # Everything below this line runs ONLY when changesets actually published to npm
-      # (i.e., the Version Packages PR just merged). On every other push to main —
-      # including "pending changesets but no version commit yet" — these steps skip.
+      # Registry steps run after a real npm publish or an explicit manual retry.
+      # Ordinary main pushes with no published versions still skip them.
       - name: Install mcp-publisher
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
         run: curl -sL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
 
       # server.json + marketplace.json track the same versions as package.json but live in
       # separate files for the MCP Registry's input schema. Sync them after changesets'
       # version bump so the Registry publish picks up the freshly-bumped numbers.
       - name: Sync versions from package.json to server.json and marketplace.json
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           for entry in "gemini-mcp:server.json" "codex-mcp:packages/codex-mcp/server.json" "claude-mcp:packages/claude-mcp/server.json" "ollama-mcp:packages/ollama-mcp/server.json" "antigravity-mcp:packages/antigravity-mcp/server.json" "llm-mcp:packages/llm-mcp/server.json"; do
             pkg="${entry%%:*}"
@@ -108,36 +106,36 @@ jobs:
           PLUGIN_VERSION=$(node -p "require('./packages/claude-plugin/package.json').version")
           jq --arg v "$PLUGIN_VERSION" '(.plugins[0].version = $v)' .claude-plugin/marketplace.json > .claude-plugin/marketplace.json.tmp && mv .claude-plugin/marketplace.json.tmp .claude-plugin/marketplace.json
 
-      - if: steps.changesets.outputs.published == 'true'
+      - if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
         run: ./mcp-publisher login github-oidc
 
       - name: Publish ask-gemini to MCP Registry
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
         run: ./mcp-publisher publish server.json
         continue-on-error: true
 
       - name: Publish ask-codex to MCP Registry
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
         run: ./mcp-publisher publish packages/codex-mcp/server.json
         continue-on-error: true
 
       - name: Publish ask-claude to MCP Registry
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
         run: ./mcp-publisher publish packages/claude-mcp/server.json
         continue-on-error: true
 
       - name: Publish ask-ollama to MCP Registry
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
         run: ./mcp-publisher publish packages/ollama-mcp/server.json
         continue-on-error: true
 
       - name: Publish ask-antigravity to MCP Registry
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
         run: ./mcp-publisher publish packages/antigravity-mcp/server.json
         continue-on-error: true
 
       - name: Publish ask-llm to MCP Registry
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
         run: ./mcp-publisher publish packages/llm-mcp/server.json
         continue-on-error: true
 

--- a/packages/llm-mcp/server.json
+++ b/packages/llm-mcp/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.Lykhoyda/ask-llm",
-  "description": "Unified MCP server — auto-detects Gemini, Codex, Claude, Ollama, Antigravity; registers available tools",
+  "description": "Unified MCP server — auto-detects Gemini, Codex, Claude, Ollama, and Antigravity providers",
   "repository": {
     "url": "https://github.com/Lykhoyda/ask-llm",
     "source": "github"

--- a/scripts/preflight-no-workspace-protocol.mjs
+++ b/scripts/preflight-no-workspace-protocol.mjs
@@ -28,6 +28,14 @@ const CANONICAL_PACKAGES = {
   "llm-mcp": { name: "@ask-llm/mcp", bin: "ask-llm-mcp" },
   "ollama-mcp": { name: "@ask-llm/ollama-mcp", bin: "ask-ollama-mcp" },
 };
+const MCP_REGISTRY_MANIFESTS = [
+  "server.json",
+  "packages/antigravity-mcp/server.json",
+  "packages/claude-mcp/server.json",
+  "packages/codex-mcp/server.json",
+  "packages/llm-mcp/server.json",
+  "packages/ollama-mcp/server.json",
+];
 
 function findPublishablePackages() {
   const packagesDir = path.join(REPO_ROOT, "packages");
@@ -95,6 +103,16 @@ if (publishable.length !== Object.keys(CANONICAL_PACKAGES).length) {
   console.error(
     `[preflight] ERROR: expected ${Object.keys(CANONICAL_PACKAGES).length} canonical publishable packages, found ${publishable.length}`,
   );
+}
+
+for (const relativePath of MCP_REGISTRY_MANIFESTS) {
+  const manifest = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf8"));
+  if (typeof manifest.description !== "string" || manifest.description.length > 100) {
+    failed = true;
+    console.error(
+      `[preflight] ERROR: ${relativePath} description must be a string of at most 100 characters (found ${manifest.description?.length ?? "missing"})`,
+    );
+  }
 }
 
 if (failed) {


### PR DESCRIPTION
## Summary

- shorten the unified MCP Registry description to satisfy the 100-character schema limit
- allow an explicit `workflow_dispatch` to retry npm visibility and MCP Registry publication without republishing npm versions
- add a release preflight check for the description-length constraint across all six Registry manifests

## Root cause

The scoped npm packages published successfully, but the unified MCP Registry publish returned HTTP 422 because its 103-character description exceeded the Registry's 100-character limit. The existing workflow could not retry Registry-only steps once Changesets had already published npm.

## Verification

- `node scripts/preflight-no-workspace-protocol.mjs`
- `git diff --check`
