### PR TITLE
docs: add scoped package migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,25 @@ Replace `@ask-llm/mcp` with `@ask-llm/codex-mcp`, `@ask-llm/claude-mcp`, `@ask-l
 
 </details>
 
+### Migrating from the old package names
+
+All public MCP packages now live in the `@ask-llm` npm organization. The old
+package names are deprecated, but their executable names are unchanged. Update
+the package argument in your MCP config; commands such as `ask-codex-mcp` and
+`ask-llm-mcp doctor` keep working after a global install.
+
+| Old package | Use instead |
+|-------------|-------------|
+| `ask-gemini-mcp` | `@ask-llm/gemini-mcp` |
+| `ask-codex-mcp` | `@ask-llm/codex-mcp` |
+| `@anton-lykhoyda/ask-claude-mcp` | `@ask-llm/claude-mcp` |
+| `ask-ollama-mcp` | `@ask-llm/ollama-mcp` |
+| `ask-antigravity-mcp` | `@ask-llm/antigravity-mcp` |
+| `ask-llm-mcp` | `@ask-llm/mcp` |
+
+See the [installation guide](https://lykhoyda.github.io/ask-llm/installation) for
+the complete package-to-executable mapping.
+
 ## Choose your reviewer
 
 | Provider | Best for | Model (default → fallback) | Notes |

--- a/apps/docs/installation.md
+++ b/apps/docs/installation.md
@@ -30,6 +30,25 @@ Multiple ways to install Ask LLM, depending on whether you want the unified orch
 
 The unified orchestrator uses a single `ask-llm` tool with a `provider` parameter for token efficiency ([ADR-029](https://github.com/Lykhoyda/ask-llm/blob/main/docs/DECISIONS.md)) — you pick the provider per call. Per-provider packages expose the richer per-provider tool surface (`ask-gemini-edit` for structured edits, `fetch-chunk` for large response pagination, etc.).
 
+## Migrating from the legacy names
+
+The six public MCP packages moved to the `@ask-llm` npm organization. Their old
+package names are deprecated and point to these replacements:
+
+| Deprecated package | Replacement |
+|--------------------|-------------|
+| `ask-gemini-mcp` | `@ask-llm/gemini-mcp` |
+| `ask-codex-mcp` | `@ask-llm/codex-mcp` |
+| `@anton-lykhoyda/ask-claude-mcp` | `@ask-llm/claude-mcp` |
+| `ask-ollama-mcp` | `@ask-llm/ollama-mcp` |
+| `ask-antigravity-mcp` | `@ask-llm/antigravity-mcp` |
+| `ask-llm-mcp` | `@ask-llm/mcp` |
+
+Existing installations are not forcibly removed, but npm warns when a deprecated
+name is installed. Replace only the package name in `npx`/`npm install` commands
+and MCP configuration. The executable names remain unchanged, so globally
+installed commands and scripts do not need to be renamed.
+
 ## Method 1: NPX (recommended)
 
 No install needed — `npx` downloads on first invocation and caches:


### PR DESCRIPTION
## Summary

- document all six legacy-to-`@ask-llm` package mappings in the root README
- add the migration procedure to the installation guide
- clarify that package names changed while executable names remain compatible

## Validation

- `corepack yarn install --immutable`
- `corepack yarn docs:build`
- `git diff --check`

No changeset: documentation-only change outside published package contents.