### PR TITLE
docs(routines): add per-run new-model sweep to upstream drift tracker

### DIFF
--- a/docs/ROUTINES.md
+++ b/docs/ROUTINES.md
@@ -8,9 +8,11 @@ Each routine is read-only investigation unless stated otherwise; wire via `/sche
 ## Upstream-CLI drift tracker
 
 **Purpose:** Track new releases of the CLIs this monorepo wraps (gemini-cli, codex,
-agy, ollama) and report anything that breaks us or could improve us. Files a GitHub
-issue **only on actionable findings** — otherwise records an audit note on the rolling
-tracker (#139) so runs are auditable without recreating backlog noise (ADR-109 lesson).
+agy, ollama) and report anything that breaks us or could improve us — **including new
+models we should adopt so our skills default to the latest, strongest/cheapest appropriate
+model**. Files a GitHub issue **only on actionable findings** — otherwise records an audit
+note on the rolling tracker (#139) so runs are auditable without recreating backlog noise
+(ADR-109 lesson).
 
 **Scope:** read-only investigation + issue/comment creation only. Do NOT modify code or open PRs.
 
@@ -23,6 +25,8 @@ Dependency & upstream-CLI drift tracker (read-only investigation → issue ONLY 
    - antigravity (agy): GitHub releases (google-antigravity/antigravity-cli) — we now ship @ask-llm/antigravity-mcp
    - (optional) ollama: GitHub releases (ollama/ollama)
    Persist last-checked versions in rolling tracker issue #139 so each run is incremental.
+   Track BOTH the CLI version AND each provider's model catalog (see §5a) — a new model can ship
+   independently of a CLI release (e.g. gemini-3.6-flash launched 2026-07-21 with no CLI bump).
 
 2. MAP EACH CHANGE TO OUR CODE, classify BREAKING / IMPROVEMENT / NO-IMPACT.
    Changelogs are SECONDARY sources — verify every claim against the actual files (ADR-109):
@@ -32,17 +36,31 @@ Dependency & upstream-CLI drift tracker (read-only investigation → issue ONLY 
 
 3. BREAKING = any of: a flag we pass is removed/renamed (e.g. -p, --output-format, --json, --add-dir,
    --resume, --sandbox, --dangerously-skip-permissions); output shape change (JSON keys, JSONL/stream
-   event types, new terminal events); default/fallback model renamed or removed (would 404); auth/quota
-   error strings changed (breaks detection/fallback); min Node bump; for agy, transcript path/schema
-   change (.jsonl → .db).
+   event types, new terminal events); default/fallback model renamed, removed, OR announced-deprecated
+   (would 404 — cf. codex gpt-5.5-mini #194); auth/quota error strings changed (breaks detection/fallback);
+   min Node bump; for agy, transcript path/schema change (.jsonl → .db).
 
 4. WATCH-LIST (flag immediately if RESOLVED — they un-gate work):
    - gemini-cli #27466 (agy -p empty stdout) + antigravity-cli #7 (headless session id): if fixed,
      @ask-llm/antigravity-mcp self-heals onto stdout and can drop transcript-scraping → high value.
    - gemini-cli 2026-06-18 consumer cutoff: any change to API-key / enterprise behavior or error strings.
 
-5. IMPROVEMENT = a new flag/capability we should adopt (e.g. agy gains real --output-format json, a new
-   model, a faster mode). List separately from breaking.
+5. IMPROVEMENT = a new flag/capability/model we should adopt (e.g. agy gains real --output-format json, a
+   new/faster/cheaper model). List separately from breaking.
+
+   5a. NEW-MODEL SWEEP — do this EVERY run. A new model is an improvement even when our current pin still
+       resolves (this is the check whose absence let gemini-3.6-flash slip past — #244). Enumerate each
+       provider's CURRENT model catalog from an authoritative source and diff it against our pinned MODELS
+       constants; our skills should default to the latest, strongest/cheapest appropriate model:
+         - gemini → https://ai.google.dev/gemini-api/docs/models          vs  gemini-mcp constants.ts MODELS.PRO / MODELS.FLASH (+ FACTORY_DEFAULT_MODEL, QUOTA_EXCEEDED_SHORT hint)
+         - codex  → OpenAI model list / GPT-5.x release notes / `codex --help`  vs  codex-mcp constants.ts MODELS.DEFAULT / PREFERRED / FALLBACK
+         - agy    → `agy models` (live, preferred) or antigravity release notes  vs  antigravity-mcp constants.ts MODELS.DEFAULT / FALLBACK
+         - ollama → https://ollama.com/library (informational — we don't pin an ollama model)
+       When a newer sibling ships (new Flash/Pro/GPT generation, a cheaper tier): (a) file/adopt it as an
+       IMPROVEMENT with the concrete constant to change, AND (b) flag the now-older pin as a future-breaking
+       WATCH (it may be deprecated → 404). Verify the new id is actually accepted by the CLI we invoke
+       (e.g. `gemini -m <id> -p ping`) before recommending the bump — a model can exist in the API but lag
+       in the CLI's accepted set.
 
 6. DEDUP before filing: search open issues + rolling tracker #139. If a matching open issue/thread
    exists, COMMENT the new delta — do NOT open a duplicate. Open a NEW issue only for an actionable
@@ -65,3 +83,7 @@ SCOPE: read-only investigation + issue/comment creation only. Do NOT modify code
   closes, the transcript-scraping fallback can be dropped and the `experimental` framing removed.
 - Verification discipline (§2) follows ADR-109 — treat release notes as claims to confirm against
   our executor/constants, not as ground truth.
+- The new-model sweep (§5a) was added after the 2026-07-23 run classified gemini as "no impact" while
+  Gemini 3.6 Flash had shipped two days earlier (#244): the old model check was breaking-only ("is our
+  pin renamed/removed?") and never looked for *new* siblings to adopt. Run §5a as a first-class step, not
+  a side effect of the version diff — new models often ship without a CLI release.


### PR DESCRIPTION
## Description
Improves the **Upstream-CLI drift tracker** routine in `docs/ROUTINES.md` so it catches new models to adopt, not just breaking changes to models we already pin.

**Why:** The 2026-07-23 drift run classified gemini as "no impact" while **Gemini 3.6 Flash** (`gemini-3.6-flash`) had launched two days earlier (2026-07-21) with no CLI bump. Root cause: the routine's model check was breaking-only ("is our pinned model renamed/removed?") and never enumerated each provider's current model catalog to find newer/cheaper siblings worth adopting. Follow-up finding filed as #244.

**Changes to `docs/ROUTINES.md`:**
- **New §5a — NEW-MODEL SWEEP** (run every time): enumerate each provider's live model catalog from an authoritative source (gemini API docs / OpenAI model list / `agy models` / ollama library) and diff against our pinned `MODELS` constants; adopt newer/cheaper models as an IMPROVEMENT and flag the now-older pin as a future-breaking WATCH. Requires verifying the new id is actually CLI-accepted before recommending a bump.
- **§1**: track each provider's model catalog alongside the CLI version (models can ship independently of a CLI release).
- **§3**: treat an announced deprecation of a pinned model as breaking-imminent (cf. codex `gpt-5.5-mini` #194).
- **Purpose + Notes**: record the rationale and the #244 miss.

Docs-only; no code or behavior change. The scheduler runs from its own stored copy of the prompt, so the next scheduled run picks this up only after the schedule is re-synced from `docs/ROUTINES.md`.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing
- [x] I have tested these changes locally — docs-only; reviewed the rendered diff, no code paths touched
- [x] My code follows the project's style — matches the existing routine prompt format/section numbering
- [x] I have updated the documentation if needed — this PR *is* the documentation change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDYKRzV8vfrCSDc5hisx68

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDYKRzV8vfrCSDc5hisx68)_