### PR TITLE
chore(plugin): enforce manifest version synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [`@ask-llm/ollama-mcp`](https://www.npmjs.com/package/@ask-llm/ollama-mcp) | MCP Server | [![npm](https://img.shields.io/npm/v/@ask-llm/ollama-mcp)](https://www.npmjs.com/package/@ask-llm/ollama-mcp) | [![downloads](https://img.shields.io/npm/dt/@ask-llm/ollama-mcp)](https://www.npmjs.com/package/@ask-llm/ollama-mcp) |
 | [`@ask-llm/antigravity-mcp`](https://www.npmjs.com/package/@ask-llm/antigravity-mcp) | MCP Server | [![npm](https://img.shields.io/npm/v/@ask-llm/antigravity-mcp)](https://www.npmjs.com/package/@ask-llm/antigravity-mcp) | [![downloads](https://img.shields.io/npm/dt/@ask-llm/antigravity-mcp)](https://www.npmjs.com/package/@ask-llm/antigravity-mcp) |
 | [`@ask-llm/mcp`](https://www.npmjs.com/package/@ask-llm/mcp) | MCP Server | [![npm](https://img.shields.io/npm/v/@ask-llm/mcp)](https://www.npmjs.com/package/@ask-llm/mcp) | [![downloads](https://img.shields.io/npm/dt/@ask-llm/mcp)](https://www.npmjs.com/package/@ask-llm/mcp) |
-| [`@ask-llm/plugin`](https://github.com/Lykhoyda/ask-llm/tree/main/packages/claude-plugin) | Claude Code Plugin | [![GitHub](https://img.shields.io/github/v/release/Lykhoyda/ask-llm?label=latest)](https://github.com/Lykhoyda/ask-llm/releases) | `/plugin install` |
+| [`@ask-llm/plugin`](https://github.com/Lykhoyda/ask-llm/tree/main/packages/claude-plugin) | Claude Code Plugin | [![package.json](https://img.shields.io/github/package-json/v/Lykhoyda/ask-llm/main?filename=packages%2Fclaude-plugin%2Fpackage.json&label=marketplace)](https://github.com/Lykhoyda/ask-llm/blob/main/packages/claude-plugin/package.json) | `/plugin install` |
 
 **MCP servers + Claude Code plugin for AI-to-AI collaboration**
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -83,7 +83,7 @@ Interactive prompt asks (a) which packages your change affects, (b) the bump typ
 
 You can pick "patch" for any package even if your change doesn't directly touch it. IMPORTANT (ADR-119): `@ask-llm/shared` is private and INLINED into each MCP's `dist/` at build time by tsdown — and because shared is only a devDependency of the MCPs, the changesets internal-dependents cascade does NOT fire for it (verified empirically 2026-06-10). Any change to `packages/shared/src/**` MUST ship with a changeset that explicitly lists all six publishable packages (`@ask-llm/gemini-mcp`, `@ask-llm/codex-mcp`, `@ask-llm/claude-mcp`, `@ask-llm/ollama-mcp`, `@ask-llm/antigravity-mcp`, `@ask-llm/mcp`) — otherwise the fix never reaches npm. CI enforces this via `scripts/check-shared-changeset.mjs`.
 
-`@ask-llm/plugin` is excluded from changesets (it's distributed via the Claude Code plugin marketplace, not npm; tracked in `.claude-plugin/marketplace.json`).
+`@ask-llm/plugin` is private and distributed through the Claude Code plugin marketplace rather than npm, but changesets still versions it. `packages/claude-plugin/package.json` is authoritative; `yarn changeset:version` mirrors its version to the plugin and marketplace manifests, and lint verifies all three stay synchronized.
 
 If your PR is infrastructure-only (no published behavior change), skip the changeset.
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "yarn workspaces foreach -A --topological-dev run build",
     "test": "yarn workspaces foreach -A run test",
-    "lint": "node scripts/check-workflow-security.mjs && node scripts/check-docs-drift.mjs && biome lint scripts/ apps/docs/.vitepress/ && tsc --noEmit -p scripts/tsconfig.json && yarn workspaces foreach -A run lint",
+    "lint": "node scripts/check-workflow-security.mjs && node scripts/check-docs-drift.mjs && node scripts/sync-plugin-manifests.mjs --check && biome lint scripts/ apps/docs/.vitepress/ && tsc --noEmit -p scripts/tsconfig.json && yarn workspaces foreach -A run lint",
     "smoke": "bash scripts/smoke-test.sh",
     "docs:dev": "yarn workspace docs run dev",
     "docs:build": "yarn workspace docs run build",

--- a/scripts/sync-plugin-manifests.mjs
+++ b/scripts/sync-plugin-manifests.mjs
@@ -1,12 +1,6 @@
 #!/usr/bin/env node
-// Mirror packages/claude-plugin/package.json `version` into the two other
-// manifests that carry the same version field:
-//   - packages/claude-plugin/.claude-plugin/plugin.json (read by Claude Code)
-//   - .claude-plugin/marketplace.json (the marketplace listing)
-//
-// Run automatically after `yarn changeset version` via the `changeset:version`
-// composed script. `--check` is used by lint/CI to fail without modifying files
-// if a release-preparation change bypasses that command.
+// Mirror the plugin package version to plugin.json and marketplace.json after changesets versioning.
+// Lint uses `--check` to reject stale release metadata without modifying it.
 
 import { readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
@@ -61,10 +55,9 @@ async function main() {
   const pluginChanged = await syncPluginJson(version);
   const marketplaceChanged = await syncMarketplaceJson(version);
 
-  const changed = [
-    pluginChanged ? "plugin.json" : null,
-    marketplaceChanged ? "marketplace.json" : null,
-  ].filter(Boolean);
+  const changed = [pluginChanged ? "plugin.json" : null, marketplaceChanged ? "marketplace.json" : null].filter(
+    Boolean,
+  );
 
   if (CHECK_ONLY && changed.length > 0) {
     throw new Error(`${changed.join(", ")} must match package.json version ${version}; run yarn changeset:version`);

--- a/scripts/sync-plugin-manifests.mjs
+++ b/scripts/sync-plugin-manifests.mjs
@@ -5,8 +5,8 @@
 //   - .claude-plugin/marketplace.json (the marketplace listing)
 //
 // Run automatically after `yarn changeset version` via the `changeset:version`
-// composed script. Keeps the three manifests in lockstep so a contributor can
-// never accidentally ship a version mismatch.
+// composed script. `--check` is used by lint/CI to fail without modifying files
+// if a release-preparation change bypasses that command.
 
 import { readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
@@ -17,6 +17,7 @@ const SOURCE = resolve(ROOT, "packages/claude-plugin/package.json");
 const PLUGIN_JSON = resolve(ROOT, "packages/claude-plugin/.claude-plugin/plugin.json");
 const MARKETPLACE_JSON = resolve(ROOT, ".claude-plugin/marketplace.json");
 const PLUGIN_NAME = "ask-llm";
+const CHECK_ONLY = process.argv.includes("--check");
 
 async function readJson(path) {
   return JSON.parse(await readFile(path, "utf8"));
@@ -29,8 +30,10 @@ async function writeJson(path, data) {
 async function syncPluginJson(version) {
   const pluginJson = await readJson(PLUGIN_JSON);
   if (pluginJson.version === version) return false;
-  pluginJson.version = version;
-  await writeJson(PLUGIN_JSON, pluginJson);
+  if (!CHECK_ONLY) {
+    pluginJson.version = version;
+    await writeJson(PLUGIN_JSON, pluginJson);
+  }
   return true;
 }
 
@@ -41,8 +44,10 @@ async function syncMarketplaceJson(version) {
     throw new Error(`marketplace.json: no plugin entry named "${PLUGIN_NAME}"`);
   }
   if (entry.version === version) return false;
-  entry.version = version;
-  await writeJson(MARKETPLACE_JSON, marketplace);
+  if (!CHECK_ONLY) {
+    entry.version = version;
+    await writeJson(MARKETPLACE_JSON, marketplace);
+  }
   return true;
 }
 
@@ -56,14 +61,18 @@ async function main() {
   const pluginChanged = await syncPluginJson(version);
   const marketplaceChanged = await syncMarketplaceJson(version);
 
-  if (pluginChanged || marketplaceChanged) {
-    const changed = [
-      pluginChanged ? "plugin.json" : null,
-      marketplaceChanged ? "marketplace.json" : null,
-    ].filter(Boolean);
+  const changed = [
+    pluginChanged ? "plugin.json" : null,
+    marketplaceChanged ? "marketplace.json" : null,
+  ].filter(Boolean);
+
+  if (CHECK_ONLY && changed.length > 0) {
+    throw new Error(`${changed.join(", ")} must match package.json version ${version}; run yarn changeset:version`);
+  }
+  if (changed.length > 0) {
     console.log(`sync-plugin-manifests: synced ${version} to ${changed.join(", ")}`);
   } else {
-    console.log(`sync-plugin-manifests: already at ${version}, no changes`);
+    console.log(`sync-plugin-manifests: all manifests match ${version}`);
   }
 }
 


### PR DESCRIPTION
## Intent

Implement issue #253 on exact current main by first verifying repository tags, current Claude plugin metadata and distribution state, changesets/release automation, mirrors, history, and cache/install semantics. Correct stale plugin version metadata using the repository current release authority rather than blindly applying the issue old 1.6.2 suggestion; keep every authoritative Claude plugin version mirror synchronized and add a focused automated hygiene check at the existing release-validation seam so release preparation cannot silently drift. Current main already has an independent changesets-managed plugin release line at 0.12.7 across package.json, plugin.json, and marketplace.json, while unified v1.x tags deliberately track the Gemini package; therefore do not conflate or bump the plugin to the repository tag line. Keep the correction minimal, update only necessary versioning docs, avoid unrelated package versions/release policy/cache paths/artifact layout and never touch user-level Claude installs, caches, publishing, tags, releases, or merges. Validate stale mismatch detection, full build/test/lint, and clean packaged/generated metadata, then push and open a PR without merging or tagging.

## What Changed

- Add a non-mutating `--check` mode that rejects stale plugin and marketplace manifest versions, and run it as part of lint.
- Preserve automatic manifest synchronization while treating the Claude plugin’s `package.json` version as authoritative.
- Update contributor guidance and the README badge to reflect the plugin’s independent marketplace release line.

## Risk Assessment

✅ Low: The change is narrowly scoped and durably prevents plugin-version drift by synchronizing manifests during versioning and rejecting mismatches through the existing lint/CI release seam.

## Testing

No baseline commands were supplied; after immutable dependency setup, the topological build, focused manifest test, clean validator, stale-drift rejection, non-mutation check, and archived end-user distribution metadata all succeeded. Linters and the full test suite were intentionally not run because this phase requires targeted testing and explicitly forbids lint execution; those broader gates remain owned by the outer pipeline.

<details>
<summary>Evidence: Plugin version hygiene transcript</summary>

```text
Claude plugin version hygiene — target 1686e17773cb0d5177237edac0cc5299c38276a1

1. Clean checkout validation
sync-plugin-manifests: all manifests match 0.12.7
package.json authority: 0.12.7
plugin.json mirror:      0.12.7
marketplace.json mirror: 0.12.7

2. Deliberately stale mirror validation
exit code: 1
sync-plugin-manifests: plugin.json, marketplace.json must match package.json version 0.12.7; run yarn changeset:version
plugin.json unchanged by --check: yes
marketplace.json unchanged by --check: yes

3. Git-subdir distribution metadata at target commit
archived package.json: 0.12.7
archived plugin.json:  0.12.7
published marketplace: 0.12.7
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `yarn install --immutable`
- `yarn build`
- `yarn workspace @ask-llm/plugin test src/__tests__/manifest.test.ts`
- `node scripts/sync-plugin-manifests.mjs --check`
- <code>Isolated stale-replica check with both mirrors changed to `9.9.9`; verified exit code 1 and unchanged SHA-256 hashes</code>
- <code>`git archive 1686e17773cb0d5177237edac0cc5299c38276a1 packages/claude-plugin/package.json packages/claude-plugin/.claude-plugin/plugin.json` plus target marketplace read-back</code>
- <code>Removed generated dependency/build outputs and verified `git status --short` remained empty</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
